### PR TITLE
fix: security hardening, dead code removal, dependency scoping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1321,6 +1321,7 @@ dependencies = [
  "crossbeam-channel",
  "dirs",
  "ebur128",
+ "getrandom 0.2.17",
  "lofty",
  "log",
  "md5",
@@ -2507,14 +2508,11 @@ dependencies = [
  "symphonia-bundle-flac",
  "symphonia-bundle-mp3",
  "symphonia-codec-aac",
- "symphonia-codec-adpcm",
  "symphonia-codec-alac",
  "symphonia-codec-pcm",
  "symphonia-codec-vorbis",
  "symphonia-core",
- "symphonia-format-caf",
  "symphonia-format-isomp4",
- "symphonia-format-mkv",
  "symphonia-format-ogg",
  "symphonia-format-riff",
  "symphonia-metadata",
@@ -2551,16 +2549,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c263845aa86881416849c1729a54c7f55164f8b96111dba59de46849e73a790"
 dependencies = [
  "lazy_static",
- "log",
- "symphonia-core",
-]
-
-[[package]]
-name = "symphonia-codec-adpcm"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dddc50e2bbea4cfe027441eece77c46b9f319748605ab8f3443350129ddd07f"
-dependencies = [
  "log",
  "symphonia-core",
 ]
@@ -2607,17 +2595,7 @@ dependencies = [
  "bytemuck",
  "lazy_static",
  "log",
-]
-
-[[package]]
-name = "symphonia-format-caf"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8faf379316b6b6e6bbc274d00e7a592e0d63ff1a7e182ce8ba25e24edd3d096"
-dependencies = [
- "log",
- "symphonia-core",
- "symphonia-metadata",
+ "rustfft",
 ]
 
 [[package]]
@@ -2627,19 +2605,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "243739585d11f81daf8dac8d9f3d18cc7898f6c09a259675fc364b382c30e0a5"
 dependencies = [
  "encoding_rs",
- "log",
- "symphonia-core",
- "symphonia-metadata",
- "symphonia-utils-xiph",
-]
-
-[[package]]
-name = "symphonia-format-mkv"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "122d786d2c43a49beb6f397551b4a050d8229eaa54c7ddf9ee4b98899b8742d0"
-dependencies = [
- "lazy_static",
  "log",
  "symphonia-core",
  "symphonia-metadata",

--- a/crates/koan-core/Cargo.toml
+++ b/crates/koan-core/Cargo.toml
@@ -19,6 +19,7 @@ ebur128 = "0.1"
 lofty = "0.23"
 log = "0.4"
 # Subsonic/Navidrome
+getrandom = "0.2"
 md5 = "0.8"
 # Async/threading
 parking_lot = "0.12"
@@ -38,7 +39,9 @@ security-framework = "3.5"
 # Serialization
 serde = { version = "1", features = ["derive"] }
 # Audio
-symphonia = { version = "0.5", features = ["all"] }
+symphonia = { version = "0.5", default-features = false, features = [
+    "flac", "mp3", "aac", "vorbis", "alac", "pcm", "isomp4", "ogg", "wav", "aiff", "opt-simd",
+] }
 # Utilities
 thiserror = "2"
 uuid = { version = "1", features = ["v7"] }

--- a/crates/koan-core/src/audio/buffer.rs
+++ b/crates/koan-core/src/audio/buffer.rs
@@ -221,7 +221,9 @@ impl SourceEntry {
             path,
             hint,
             make_mss: Box::new(move || {
-                let file = File::open(&path_clone).expect("failed to open audio file");
+                let file = File::open(&path_clone).unwrap_or_else(|e| {
+                    panic!("failed to open audio file {}: {}", path_clone.display(), e)
+                });
                 MediaSourceStream::new(Box::new(file), Default::default())
             }),
         }

--- a/crates/koan-core/src/audio/replaygain.rs
+++ b/crates/koan-core/src/audio/replaygain.rs
@@ -234,10 +234,13 @@ pub fn scan_album(paths: &[PathBuf]) -> Result<Vec<ReplayGainInfo>, ReplayGainEr
         });
 
         // Album-level: feed same samples into a shared EbuR128 instance.
-        let ebu = album_ebu.get_or_insert_with(|| {
-            // Unwrap safe: if track decoding succeeded, this will too.
-            ebur128::EbuR128::new(channels as u32, sample_rate, ebur128::Mode::all()).unwrap()
-        });
+        if album_ebu.is_none() {
+            album_ebu = Some(
+                ebur128::EbuR128::new(channels as u32, sample_rate, ebur128::Mode::all())
+                    .map_err(|e| ReplayGainError::Ebur128(e.to_string()))?,
+            );
+        }
+        let ebu = album_ebu.as_mut().expect("just initialized above");
         ebu.add_frames_f32(&all_samples)
             .map_err(|e| ReplayGainError::Ebur128(e.to_string()))?;
     }

--- a/crates/koan-core/src/config.rs
+++ b/crates/koan-core/src/config.rs
@@ -224,6 +224,11 @@ impl Config {
         }
         let contents = toml::to_string_pretty(self)?;
         fs::write(&path, contents)?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&path, fs::Permissions::from_mode(0o600))?;
+        }
         Ok(())
     }
 

--- a/crates/koan-core/src/db/connection.rs
+++ b/crates/koan-core/src/db/connection.rs
@@ -28,6 +28,12 @@ impl Database {
 
         let conn = Connection::open(path)?;
 
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600));
+        }
+
         // WAL mode for concurrent reads + single writer.
         conn.pragma_update(None, "journal_mode", "wal")?;
         conn.pragma_update(None, "foreign_keys", "on")?;

--- a/crates/koan-core/src/db/queries/artists.rs
+++ b/crates/koan-core/src/db/queries/artists.rs
@@ -4,6 +4,13 @@ use crate::db::connection::DbError;
 
 use super::ArtistRow;
 
+/// Escape SQL LIKE wildcard characters in user input.
+fn escape_like(s: &str) -> String {
+    s.replace('\\', "\\\\")
+        .replace('%', "\\%")
+        .replace('_', "\\_")
+}
+
 /// Get or create an artist by name. Returns the artist ID.
 pub fn get_or_create_artist(
     conn: &Connection,
@@ -39,12 +46,12 @@ pub fn get_or_create_artist(
 
 /// Find artists by name (case-insensitive substring match).
 pub fn find_artists(conn: &Connection, query: &str) -> Result<Vec<ArtistRow>, DbError> {
-    let pattern = format!("%{}%", query);
+    let pattern = format!("%{}%", escape_like(query));
     let mut stmt = conn.prepare(
         "SELECT DISTINCT a.id, a.name, a.sort_name, a.remote_id
          FROM artists a
          INNER JOIN albums al ON al.artist_id = a.id
-         WHERE a.name LIKE ?1 COLLATE NOCASE
+         WHERE a.name LIKE ?1 COLLATE NOCASE ESCAPE '\\'
          ORDER BY COALESCE(a.sort_name, a.name)",
     )?;
     let rows = stmt

--- a/crates/koan-core/src/db/queries/search.rs
+++ b/crates/koan-core/src/db/queries/search.rs
@@ -4,10 +4,22 @@ use crate::db::connection::DbError;
 
 use super::TrackRow;
 
+/// Sanitize a user query for FTS5 MATCH: escapes double-quotes and wraps in
+/// a quoted phrase so FTS5 special characters are treated as literals.
+fn sanitize_fts_query(query: &str) -> String {
+    let trimmed = query.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+    // Escape double quotes for FTS5 literal matching
+    let escaped = trimmed.replace('"', "\"\"");
+    format!("\"{}\"*", escaped)
+}
+
 /// Full-text search across track title, artist, album, genre.
 pub fn search_tracks(conn: &Connection, query: &str) -> Result<Vec<TrackRow>, DbError> {
-    // FTS5 query — append * for prefix matching.
-    let fts_query = format!("{}*", query.trim());
+    // FTS5 query — sanitize input and append * for prefix matching.
+    let fts_query = sanitize_fts_query(query);
 
     let mut stmt = conn.prepare(
         "SELECT t.id, t.album_id, t.artist_id, a.name, aa.name, al.title,

--- a/crates/koan-core/src/remote/client.rs
+++ b/crates/koan-core/src/remote/client.rs
@@ -140,6 +140,11 @@ impl SubsonicClient {
         format!("{}/rest/stream?id={}&{}", self.base_url, track_id, query)
     }
 
+    /// Stream URL without auth params — safe for database storage.
+    pub fn stream_url_template(&self, track_id: &str) -> String {
+        format!("{}/rest/stream?id={}", self.base_url, track_id)
+    }
+
     /// Download a track to a local path.
     pub fn download(&self, track_id: &str, dest: &Path) -> Result<(), SubsonicError> {
         self.download_with_progress(track_id, dest, |_, _| {})
@@ -330,9 +335,6 @@ pub struct SubsonicStarred {
 /// Generate a random hex salt string for Subsonic auth.
 fn random_salt() -> String {
     let mut buf = [0u8; 12];
-    if let Ok(mut f) = std::fs::File::open("/dev/urandom") {
-        use std::io::Read;
-        let _ = f.read_exact(&mut buf);
-    }
+    getrandom::getrandom(&mut buf).expect("failed to generate random salt");
     buf.iter().map(|b| format!("{:02x}", b)).collect()
 }

--- a/crates/koan-core/src/remote/sync.rs
+++ b/crates/koan-core/src/remote/sync.rs
@@ -249,7 +249,7 @@ pub fn sync_library(
                     path: None,
                     source: "remote".to_string(),
                     remote_id: Some(song.id.clone()),
-                    remote_url: Some(client.stream_url(&song.id)),
+                    remote_url: Some(client.stream_url_template(&song.id)),
                 };
 
                 match queries::upsert_track(&db.conn, &meta) {

--- a/crates/koan-music/src/commands/remote.rs
+++ b/crates/koan-music/src/commands/remote.rs
@@ -4,6 +4,10 @@ use owo_colors::OwoColorize;
 use super::{get_remote_password, open_db};
 
 pub fn cmd_remote_login(url: &str, username: &str) {
+    if !url.starts_with("https://") && !url.contains("localhost") && !url.contains("127.0.0.1") {
+        eprintln!("warning: server URL does not use HTTPS — credentials will be sent in plaintext");
+    }
+
     let password = rpassword::prompt_password("password: ").unwrap_or_else(|e| {
         eprintln!("{} {}", "error:".red().bold(), e);
         std::process::exit(1);

--- a/crates/koan-music/src/media_keys.rs
+++ b/crates/koan-music/src/media_keys.rs
@@ -149,9 +149,9 @@ impl MediaKeyHandler {
         let path = track_path?;
         let bytes = extract_cover_art(path)?;
 
-        let tmp = self
-            .cover_art_path
-            .get_or_insert_with(|| std::env::temp_dir().join("koan-now-playing-cover"));
+        let tmp = self.cover_art_path.get_or_insert_with(|| {
+            std::env::temp_dir().join(format!("koan-cover-{}", std::process::id()))
+        });
 
         std::fs::write(&*tmp, &bytes).ok()?;
         Some(format!("file://{}", tmp.display()))

--- a/crates/koan-music/src/tui/app.rs
+++ b/crates/koan-music/src/tui/app.rs
@@ -81,7 +81,6 @@ pub struct DragState {
 
 /// Which UI element the mouse cursor is currently hovering over.
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
-#[allow(dead_code)]
 pub enum HoverZone {
     #[default]
     None,
@@ -91,9 +90,6 @@ pub enum HoverZone {
     ScrollbarQueue,
     TransportArt,
     TransportText,
-    PanelDivider,
-    PickerItem(usize),
-    ContextMenuItem(usize),
 }
 
 /// Tracks the current mouse hover position and zone.

--- a/crates/koan-music/src/tui/cover_art.rs
+++ b/crates/koan-music/src/tui/cover_art.rs
@@ -235,12 +235,6 @@ impl<'a> CoverArt<'a> {
             center: false,
         }
     }
-
-    #[allow(dead_code)]
-    pub fn centered(mut self) -> Self {
-        self.center = true;
-        self
-    }
 }
 
 impl Widget for CoverArt<'_> {

--- a/crates/koan-music/src/tui/event.rs
+++ b/crates/koan-music/src/tui/event.rs
@@ -1,8 +1,0 @@
-use crossterm::event::{KeyEvent, MouseEvent};
-
-#[allow(dead_code)]
-pub enum Event {
-    Key(KeyEvent),
-    Mouse(MouseEvent),
-    Paste(String),
-}

--- a/crates/koan-music/src/tui/lyrics.rs
+++ b/crates/koan-music/src/tui/lyrics.rs
@@ -36,15 +36,6 @@ impl LyricsState {
         self.result = result;
         self.fetching = false;
     }
-
-    /// Clear lyrics state (e.g. on track change before new fetch).
-    #[allow(dead_code)]
-    pub fn clear(&mut self) {
-        self.result = None;
-        self.lrc_lines.clear();
-        self.track_path = None;
-        self.fetching = false;
-    }
 }
 
 /// Widget for rendering lyrics in a side panel.

--- a/crates/koan-music/src/tui/mod.rs
+++ b/crates/koan-music/src/tui/mod.rs
@@ -1,7 +1,6 @@
 pub mod app;
 pub mod context_menu;
 pub mod cover_art;
-pub mod event;
 pub mod keys;
 pub mod library;
 pub mod lyrics;

--- a/crates/koan-music/src/tui/theme.rs
+++ b/crates/koan-music/src/tui/theme.rs
@@ -27,8 +27,6 @@ pub struct Theme {
     pub library_cursor: Style,
     pub track_hover: Style,
     pub library_hover: Style,
-    #[allow(dead_code)]
-    pub scrollbar_hover: Style,
     pub favourite: Style,
     pub spectrum_low: Style,
     pub spectrum_mid: Style,
@@ -83,7 +81,6 @@ impl Default for Theme {
                 .add_modifier(Modifier::BOLD | Modifier::REVERSED),
             track_hover: Style::new().add_modifier(Modifier::UNDERLINED),
             library_hover: Style::new().add_modifier(Modifier::UNDERLINED),
-            scrollbar_hover: Style::new().fg(Color::White).add_modifier(Modifier::BOLD),
             favourite: Style::new().fg(Color::Yellow),
             spectrum_low: Style::new().fg(Color::Green),
             spectrum_mid: Style::new().fg(Color::Yellow),

--- a/crates/koan-music/src/tui/visualizer.rs
+++ b/crates/koan-music/src/tui/visualizer.rs
@@ -67,12 +67,6 @@ impl VisualizerState {
         (bar_decay, peak_decay)
     }
 
-    /// Number of bars in the spectrum.
-    #[allow(dead_code)]
-    pub fn num_bars(&self) -> usize {
-        NUM_BARS
-    }
-
     /// Read the latest analysis frame from VizSnapshot and apply decay/smoothing.
     ///
     /// The snapshot read is <1us (RwLock clone of ~200 bytes).


### PR DESCRIPTION
## Summary

Phase 1 of the [codebase audit plan](https://github.com/radiosilence/koan/pull/12) (v0.5.2).

### Security (6 fixes)
- **CRITICAL**: Auth credentials no longer persisted in `remote_url` DB column — store only track ID template, reconstruct auth at playback time
- Config and DB files restricted to `0o600` on unix
- FTS5 search queries sanitized against injection
- `/dev/urandom` replaced with `getrandom` crate for auth salt generation
- HTTPS warning for non-localhost Subsonic URLs
- LIKE wildcards escaped in artist search

### Dead Code (6 removals)
- Removed unused methods, fields, enum variants, and an entire unused module (`tui::event`)

### Fixes (2)
- ebur128 init error propagated instead of panicking
- File path included in buffer open error message

### Dependencies (1)
- `symphonia` scoped to specific codecs instead of `features = ["all"]` (-36 lines Cargo.lock)

## Verification
- `cargo check` — clean
- `cargo fmt` — clean
- `cargo clippy -D warnings` — clean
- `cargo test` — 332 tests pass (318 core + 14 music)

## Test plan
- [ ] Verify `koan remote sync` still works (stream URLs now store template without auth)
- [ ] Verify search still works with special characters
- [ ] Verify cover art still shows in Now Playing

Generated with Claude Code