### PR TITLE
refactor: deduplicate row mapping and move planning logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 - **Render loop allocations eliminated** — playlist version gate skips redundant O(n) visible queue rebuild when queue is idle; borrowed string keys in display line builder remove 2 allocations per entry per call; spectrum data changed from heap Vec to stack arrays ([f32; 48]) eliminating allocation on every frame clone at 60fps
 
+### Refactored
+
+- **`row_to_track_row` helper** — deduplicated 4 identical 22-line row-mapping closures in tracks.rs into a single shared function
+- **`plan_single_move` helper** — extracted shared move-planning logic (path formatting, sanitization, extension preservation, ancillary file handling) from two `plan_moves` variants in organize.rs
+
 ### Fixed
 
 - **Security hardening** — credentials removed from stored remote URLs (template-based at playback time), config and DB files restricted to 0o600 on Unix, FTS5 and LIKE query inputs sanitized, HTTPS warning for non-localhost remotes, secure random salt via `getrandom`, PID-namespaced cover art temp files

--- a/crates/koan-core/src/db/queries/tracks.rs
+++ b/crates/koan-core/src/db/queries/tracks.rs
@@ -8,6 +8,37 @@ use super::albums::get_or_create_album;
 use super::artists::get_or_create_artist;
 use super::{PlaybackSource, TrackMeta, TrackRow};
 
+/// Map a rusqlite Row to a TrackRow. Expects the standard column order:
+/// id, album_id, artist_id, artist_name, album_artist_name, album_title,
+/// disc, track_number, title, duration_ms, path,
+/// codec, sample_rate, bit_depth, channels, bitrate,
+/// genre, source, remote_id, cached_path
+fn row_to_track_row(row: &rusqlite::Row) -> rusqlite::Result<TrackRow> {
+    let artist_name: String = row.get::<_, Option<String>>(3)?.unwrap_or_default();
+    Ok(TrackRow {
+        id: row.get(0)?,
+        album_id: row.get(1)?,
+        artist_id: row.get(2)?,
+        artist_name: artist_name.clone(),
+        album_artist_name: row.get::<_, Option<String>>(4)?.unwrap_or(artist_name),
+        album_title: row.get::<_, Option<String>>(5)?.unwrap_or_default(),
+        disc: row.get(6)?,
+        track_number: row.get(7)?,
+        title: row.get(8)?,
+        duration_ms: row.get(9)?,
+        path: row.get(10)?,
+        codec: row.get(11)?,
+        sample_rate: row.get(12)?,
+        bit_depth: row.get(13)?,
+        channels: row.get(14)?,
+        bitrate: row.get(15)?,
+        genre: row.get(16)?,
+        source: row.get(17)?,
+        remote_id: row.get(18)?,
+        cached_path: row.get(19)?,
+    })
+}
+
 /// Insert or update a track. Deduplicates local+remote: one row per logical track.
 ///
 /// Matching priority:
@@ -292,31 +323,7 @@ pub fn tracks_for_artist(conn: &Connection, artist_id: i64) -> Result<Vec<TrackR
          ORDER BY al.date, al.title, t.disc, t.track_number",
     )?;
     let rows = stmt
-        .query_map(params![artist_id], |row| {
-            let artist_name: String = row.get::<_, Option<String>>(3)?.unwrap_or_default();
-            Ok(TrackRow {
-                id: row.get(0)?,
-                album_id: row.get(1)?,
-                artist_id: row.get(2)?,
-                artist_name: artist_name.clone(),
-                album_artist_name: row.get::<_, Option<String>>(4)?.unwrap_or(artist_name),
-                album_title: row.get::<_, Option<String>>(5)?.unwrap_or_default(),
-                disc: row.get(6)?,
-                track_number: row.get(7)?,
-                title: row.get(8)?,
-                duration_ms: row.get(9)?,
-                path: row.get(10)?,
-                codec: row.get(11)?,
-                sample_rate: row.get(12)?,
-                bit_depth: row.get(13)?,
-                channels: row.get(14)?,
-                bitrate: row.get(15)?,
-                genre: row.get(16)?,
-                source: row.get(17)?,
-                remote_id: row.get(18)?,
-                cached_path: row.get(19)?,
-            })
-        })?
+        .query_map(params![artist_id], row_to_track_row)?
         .collect::<Result<Vec<_>, _>>()?;
     Ok(rows)
 }
@@ -336,31 +343,7 @@ pub fn all_tracks(conn: &Connection) -> Result<Vec<TrackRow>, DbError> {
     )?;
 
     let rows = stmt
-        .query_map(params![], |row| {
-            let artist_name: String = row.get::<_, Option<String>>(3)?.unwrap_or_default();
-            Ok(TrackRow {
-                id: row.get(0)?,
-                album_id: row.get(1)?,
-                artist_id: row.get(2)?,
-                artist_name: artist_name.clone(),
-                album_artist_name: row.get::<_, Option<String>>(4)?.unwrap_or(artist_name),
-                album_title: row.get::<_, Option<String>>(5)?.unwrap_or_default(),
-                disc: row.get(6)?,
-                track_number: row.get(7)?,
-                title: row.get(8)?,
-                duration_ms: row.get(9)?,
-                path: row.get(10)?,
-                codec: row.get(11)?,
-                sample_rate: row.get(12)?,
-                bit_depth: row.get(13)?,
-                channels: row.get(14)?,
-                bitrate: row.get(15)?,
-                genre: row.get(16)?,
-                source: row.get(17)?,
-                remote_id: row.get(18)?,
-                cached_path: row.get(19)?,
-            })
-        })?
+        .query_map(params![], row_to_track_row)?
         .collect::<Result<Vec<_>, _>>()?;
 
     Ok(rows)
@@ -379,31 +362,7 @@ pub fn get_track_row(conn: &Connection, track_id: i64) -> Result<Option<TrackRow
          LEFT JOIN artists aa ON al.artist_id = aa.id
          WHERE t.id = ?1",
         params![track_id],
-        |row| {
-            let artist_name: String = row.get::<_, Option<String>>(3)?.unwrap_or_default();
-            Ok(TrackRow {
-                id: row.get(0)?,
-                album_id: row.get(1)?,
-                artist_id: row.get(2)?,
-                artist_name: artist_name.clone(),
-                album_artist_name: row.get::<_, Option<String>>(4)?.unwrap_or(artist_name),
-                album_title: row.get::<_, Option<String>>(5)?.unwrap_or_default(),
-                disc: row.get(6)?,
-                track_number: row.get(7)?,
-                title: row.get(8)?,
-                duration_ms: row.get(9)?,
-                path: row.get(10)?,
-                codec: row.get(11)?,
-                sample_rate: row.get(12)?,
-                bit_depth: row.get(13)?,
-                channels: row.get(14)?,
-                bitrate: row.get(15)?,
-                genre: row.get(16)?,
-                source: row.get(17)?,
-                remote_id: row.get(18)?,
-                cached_path: row.get(19)?,
-            })
-        },
+        row_to_track_row,
     );
 
     match result {
@@ -497,31 +456,7 @@ pub fn tracks_for_album(conn: &Connection, album_id: i64) -> Result<Vec<TrackRow
     )?;
 
     let rows = stmt
-        .query_map(params![album_id], |row| {
-            let artist_name: String = row.get::<_, Option<String>>(3)?.unwrap_or_default();
-            Ok(TrackRow {
-                id: row.get(0)?,
-                album_id: row.get(1)?,
-                artist_id: row.get(2)?,
-                artist_name: artist_name.clone(),
-                album_artist_name: row.get::<_, Option<String>>(4)?.unwrap_or(artist_name),
-                album_title: row.get::<_, Option<String>>(5)?.unwrap_or_default(),
-                disc: row.get(6)?,
-                track_number: row.get(7)?,
-                title: row.get(8)?,
-                duration_ms: row.get(9)?,
-                path: row.get(10)?,
-                codec: row.get(11)?,
-                sample_rate: row.get(12)?,
-                bit_depth: row.get(13)?,
-                channels: row.get(14)?,
-                bitrate: row.get(15)?,
-                genre: row.get(16)?,
-                source: row.get(17)?,
-                remote_id: row.get(18)?,
-                cached_path: row.get(19)?,
-            })
-        })?
+        .query_map(params![album_id], row_to_track_row)?
         .collect::<Result<Vec<_>, _>>()?;
 
     Ok(rows)

--- a/crates/koan-core/src/organize.rs
+++ b/crates/koan-core/src/organize.rs
@@ -206,6 +206,68 @@ fn find_ancillary_files(track_dir: &Path) -> Vec<PathBuf> {
     files
 }
 
+/// Plan a single file move: format pattern, sanitize path, build dest, find ancillary files.
+///
+/// Returns `Ok(None)` when source == dest (skipped), `Ok(Some(FileMove))` for a planned move,
+/// or `Err(String)` for errors that should be collected by the caller.
+fn plan_single_move(
+    source: &Path,
+    track_id: i64,
+    metadata: &TrackMetadata,
+    pattern: &str,
+    base_dir: &Path,
+    planned_ancillary: &mut std::collections::HashSet<PathBuf>,
+) -> Result<Option<FileMove>, String> {
+    let relative = format::format(pattern, metadata).map_err(|e| format!("format error: {e}"))?;
+
+    if relative.is_empty() {
+        return Err("format string produced empty path".into());
+    }
+
+    let sanitized = sanitize_relative_path(&relative);
+
+    // Preserve the original file extension.
+    // Don't use with_extension() — it replaces after the LAST dot, which
+    // destroys titles containing dots (e.g. "0111. Bicep - TANGZ II" → "0111.flac").
+    let ext = source
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("flac");
+    let mut dest = base_dir.join(sanitized);
+    let stem = dest.as_os_str().to_os_string();
+    dest = PathBuf::from(format!("{}.{}", stem.to_string_lossy(), ext));
+
+    if paths_equal(source, &dest) {
+        return Ok(None);
+    }
+
+    // Plan ancillary moves — move files in source dir to dest dir.
+    let source_dir = source.parent().unwrap_or(Path::new("."));
+    let dest_dir = dest.parent().unwrap_or(Path::new("."));
+    let mut ancillary = Vec::new();
+
+    if source_dir != dest_dir {
+        for anc_path in find_ancillary_files(source_dir) {
+            if planned_ancillary.contains(&anc_path) {
+                continue;
+            }
+            let Some(anc_name) = anc_path.file_name() else {
+                continue;
+            };
+            let anc_dest = dest_dir.join(anc_name);
+            planned_ancillary.insert(anc_path.clone());
+            ancillary.push((anc_path, anc_dest));
+        }
+    }
+
+    Ok(Some(FileMove {
+        track_id,
+        from: source.to_path_buf(),
+        to: dest,
+        ancillary,
+    }))
+}
+
 /// Build the list of moves for all local tracks (or a filtered subset).
 fn plan_moves(
     db: &Database,
@@ -252,62 +314,19 @@ fn plan_moves(
         };
 
         let metadata = TrackMetadata::from_track_row(track, album_date.as_deref());
-        let relative = match format::format(pattern, &metadata) {
-            Ok(r) => r,
-            Err(e) => {
-                errors.push((source, format!("format error: {e}")));
-                continue;
-            }
-        };
 
-        if relative.is_empty() {
-            errors.push((source, "format string produced empty path".into()));
-            continue;
+        match plan_single_move(
+            &source,
+            track.id,
+            &metadata,
+            pattern,
+            base_dir,
+            &mut planned_ancillary,
+        ) {
+            Ok(Some(file_move)) => moves.push(file_move),
+            Ok(None) => skipped += 1,
+            Err(msg) => errors.push((source, msg)),
         }
-
-        let sanitized = sanitize_relative_path(&relative);
-
-        // Preserve the original file extension.
-        // Don't use with_extension() — it replaces after the LAST dot, which
-        // destroys titles containing dots (e.g. "0111. Bicep - TANGZ II" → "0111.flac").
-        let ext = source
-            .extension()
-            .and_then(|e| e.to_str())
-            .unwrap_or("flac");
-        let mut dest = base_dir.join(sanitized);
-        let stem = dest.as_os_str().to_os_string();
-        dest = PathBuf::from(format!("{}.{}", stem.to_string_lossy(), ext));
-
-        if paths_equal(&source, &dest) {
-            skipped += 1;
-            continue;
-        }
-
-        // Plan ancillary moves — move files in source dir to dest dir.
-        let source_dir = source.parent().unwrap_or(Path::new("."));
-        let dest_dir = dest.parent().unwrap_or(Path::new("."));
-        let mut ancillary = Vec::new();
-
-        if source_dir != dest_dir {
-            for anc_path in find_ancillary_files(source_dir) {
-                if planned_ancillary.contains(&anc_path) {
-                    continue;
-                }
-                let Some(anc_name) = anc_path.file_name() else {
-                    continue;
-                };
-                let anc_dest = dest_dir.join(anc_name);
-                planned_ancillary.insert(anc_path.clone());
-                ancillary.push((anc_path, anc_dest));
-            }
-        }
-
-        moves.push(FileMove {
-            track_id: track.id,
-            from: source,
-            to: dest,
-            ancillary,
-        });
     }
 
     Ok(OrganizeResult {
@@ -346,57 +365,19 @@ fn plan_moves_from_paths(
         };
 
         let metadata = TrackMetadata::from_file_meta(&meta);
-        let relative = match format::format(pattern, &metadata) {
-            Ok(r) => r,
-            Err(e) => {
-                errors.push((source.clone(), format!("format error: {e}")));
-                continue;
-            }
-        };
 
-        if relative.is_empty() {
-            errors.push((source.clone(), "format string produced empty path".into()));
-            continue;
+        match plan_single_move(
+            source,
+            0,
+            &metadata,
+            pattern,
+            base_dir,
+            &mut planned_ancillary,
+        ) {
+            Ok(Some(file_move)) => moves.push(file_move),
+            Ok(None) => skipped += 1,
+            Err(msg) => errors.push((source.clone(), msg)),
         }
-
-        let sanitized = sanitize_relative_path(&relative);
-        let ext = source
-            .extension()
-            .and_then(|e| e.to_str())
-            .unwrap_or("flac");
-        let mut dest = base_dir.join(sanitized);
-        let stem = dest.as_os_str().to_os_string();
-        dest = PathBuf::from(format!("{}.{}", stem.to_string_lossy(), ext));
-
-        if paths_equal(source, &dest) {
-            skipped += 1;
-            continue;
-        }
-
-        let source_dir = source.parent().unwrap_or(Path::new("."));
-        let dest_dir = dest.parent().unwrap_or(Path::new("."));
-        let mut ancillary = Vec::new();
-
-        if source_dir != dest_dir {
-            for anc_path in find_ancillary_files(source_dir) {
-                if planned_ancillary.contains(&anc_path) {
-                    continue;
-                }
-                let Some(anc_name) = anc_path.file_name() else {
-                    continue;
-                };
-                let anc_dest = dest_dir.join(anc_name);
-                planned_ancillary.insert(anc_path.clone());
-                ancillary.push((anc_path, anc_dest));
-            }
-        }
-
-        moves.push(FileMove {
-            track_id: 0, // no DB identity
-            from: source.clone(),
-            to: dest,
-            ancillary,
-        });
     }
 
     Ok(OrganizeResult {


### PR DESCRIPTION
## Summary

- **`row_to_track_row` helper** (tracks.rs) — replaces 4 identical 22-line row-mapping closures with one shared function. Net ~66 lines of duplication removed
- **`plan_single_move` helper** (organize.rs) — extracts shared move-planning logic (path formatting, sanitization, extension preservation, ancillary file handling) from `plan_moves` and `plan_moves_from_paths`
- **Deferred**: app.rs decomposition and player/mod.rs cleanup noted as future work (larger structural changes)

## Test plan

- [x] `cargo test --workspace` — all tests pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

Part of codebase audit (see #12 for full plan). Stacked on #15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)