### PR TITLE
chore: clean up dependencies and centralize workspace versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@
 - **`row_to_track_row` helper** — deduplicated 4 identical 22-line row-mapping closures in tracks.rs into a single shared function
 - **`plan_single_move` helper** — extracted shared move-planning logic (path formatting, sanitization, extension preservation, ancillary file handling) from two `plan_moves` variants in organize.rs
 
+### Dependencies
+
+- **rusqlite removed from koan-music** — 3 raw SQL calls replaced with koan-core query functions (`album_date`, `clear_cached_paths`). Binary crate no longer links rusqlite directly
+- **rusqlite features scoped** — `bundled-full` → `bundled`, removing unused extensions (load_extension, backup, blob, hooks, session)
+- **Workspace dependencies** — added `[workspace.dependencies]` for rusqlite and walkdir, centralizing version management
+
 ### Fixed
 
 - **Security hardening** — credentials removed from stored remote URLs (template-based at playback time), config and DB files restricted to 0o600 on Unix, FTS5 and LIKE query inputs sanitized, HTTPS warning for non-localhost remotes, secure random salt via `getrandom`, PID-namespaced cover art temp files

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,27 +521,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "csv"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
-dependencies = [
- "csv-core",
- "itoa",
- "ryu",
- "serde_core",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -614,15 +593,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64bff0bd181fba667660276c6b7ebdc50cff37ce593e7adf9e734f89c8f444e8"
 dependencies = [
  "dbus",
-]
-
-[[package]]
-name = "deranged"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
-dependencies = [
- "powerfmt",
 ]
 
 [[package]]
@@ -1246,32 +1216,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
-name = "jiff"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89a5b5e10d5a9ad6e5d1f4bd58225f655d6fe9767575a5e8ac5a6fe64e04495"
-dependencies = [
- "jiff-static",
- "js-sys",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde_core",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff7a39c8862fc1369215ccf0a8f12dd4598c7f6484704359f0351bd617034dbf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "jni"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1360,7 +1304,6 @@ dependencies = [
  "owo-colors",
  "ratatui",
  "rpassword",
- "rusqlite",
  "souvlaki",
  "toml",
  "walkdir",
@@ -1592,12 +1535,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-conv"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
-
-[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1730,21 +1667,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "portable-atomic"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
-dependencies = [
- "portable-atomic",
-]
-
-[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1752,12 +1674,6 @@ checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
-
-[[package]]
-name = "powerfmt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -2092,19 +2008,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1c93dd1c9683b438c392c492109cb702b8090b2bfc8fed6f6e4eb4523f17af3"
 dependencies = [
  "bitflags 2.10.0",
- "chrono",
- "csv",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
- "jiff",
  "libsqlite3-sys",
- "serde_json",
  "smallvec",
  "sqlite-wasm-rs",
- "time",
- "url",
- "uuid",
 ]
 
 [[package]]
@@ -2739,38 +2648,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "time"
-version = "0.3.47"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
-dependencies = [
- "deranged",
- "itoa",
- "js-sys",
- "num-conv",
- "powerfmt",
- "serde_core",
- "time-core",
- "time-macros",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
-
-[[package]]
-name = "time-macros"
-version = "0.2.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
-dependencies = [
- "num-conv",
- "time-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,7 @@ edition = "2024"
 homepage = "https://github.com/radiosilence/koan"
 repository = "https://github.com/radiosilence/koan"
 license = "MIT"
+
+[workspace.dependencies]
+rusqlite = { version = "0.38", features = ["bundled"] }
+walkdir = "2.5"

--- a/crates/koan-core/Cargo.toml
+++ b/crates/koan-core/Cargo.toml
@@ -33,7 +33,7 @@ reqwest = { version = "0.13", default-features = false, features = [
 realfft = "3"
 rtrb = "0.3"
 # Database
-rusqlite = { version = "0.38", features = ["bundled-full"] }
+rusqlite = { workspace = true }
 # Credentials
 security-framework = "3.5"
 # Serialization
@@ -46,7 +46,7 @@ symphonia = { version = "0.5", default-features = false, features = [
 thiserror = "2"
 uuid = { version = "1", features = ["v7"] }
 toml = "0.9"
-walkdir = "2.5"
+walkdir = { workspace = true }
 
 [dev-dependencies]
 serde_json = "1"

--- a/crates/koan-core/src/db/queries/albums.rs
+++ b/crates/koan-core/src/db/queries/albums.rs
@@ -72,6 +72,18 @@ pub fn albums_for_artist(conn: &Connection, artist_id: i64) -> Result<Vec<AlbumR
     Ok(rows)
 }
 
+/// Get the date string for an album by ID.
+pub fn album_date(conn: &Connection, album_id: i64) -> Result<Option<String>, DbError> {
+    Ok(conn
+        .query_row(
+            "SELECT date FROM albums WHERE id = ?1",
+            params![album_id],
+            |row| row.get(0),
+        )
+        .ok()
+        .flatten())
+}
+
 /// Get all albums with their artist name, sorted.
 pub fn all_albums(conn: &Connection) -> Result<Vec<AlbumRow>, DbError> {
     let mut stmt = conn.prepare(

--- a/crates/koan-core/src/db/queries/tracks.rs
+++ b/crates/koan-core/src/db/queries/tracks.rs
@@ -386,6 +386,12 @@ pub fn track_id_by_path(conn: &Connection, path: &str) -> Result<Option<i64>, Db
     }
 }
 
+/// Clear all cached_path values (used when purging the download cache).
+pub fn clear_cached_paths(conn: &Connection) -> Result<(), DbError> {
+    conn.execute("UPDATE tracks SET cached_path = NULL", params![])?;
+    Ok(())
+}
+
 /// Update the cached_path for a track after downloading.
 pub fn set_cached_path(conn: &Connection, track_id: i64, path: &str) -> Result<(), DbError> {
     conn.execute(

--- a/crates/koan-music/Cargo.toml
+++ b/crates/koan-music/Cargo.toml
@@ -28,6 +28,5 @@ ratatui = "0.29"
 rpassword = "7.4"
 souvlaki = "0.8"
 core-foundation = "0.9"
-rusqlite = { version = "0.38", features = ["bundled-full"] }
 toml = "0.9"
-walkdir = "2"
+walkdir = { workspace = true }

--- a/crates/koan-music/src/commands/cache.rs
+++ b/crates/koan-music/src/commands/cache.rs
@@ -1,4 +1,5 @@
 use koan_core::config;
+use koan_core::db::queries;
 use owo_colors::OwoColorize;
 
 use super::{confirm, format_bytes, open_db};
@@ -89,9 +90,7 @@ pub fn cmd_cache_clear(skip_confirm: bool) {
 
     // Clear cached_path in DB so tracks get re-downloaded next time.
     let db = open_db();
-    let _ = db
-        .conn
-        .execute("UPDATE tracks SET cached_path = NULL", rusqlite::params![]);
+    let _ = queries::clear_cached_paths(&db.conn);
 
     println!(
         "{} {} {}",

--- a/crates/koan-music/src/commands/enqueue.rs
+++ b/crates/koan-music/src/commands/enqueue.rs
@@ -34,16 +34,9 @@ pub fn enqueue_playlist(
         let Some(track) = queries::get_track_row(&db.conn, id).ok().flatten() else {
             continue;
         };
-        let album_date: Option<String> = track.album_id.and_then(|aid| {
-            db.conn
-                .query_row(
-                    "SELECT date FROM albums WHERE id = ?1",
-                    rusqlite::params![aid],
-                    |row| row.get(0),
-                )
-                .ok()
-                .flatten()
-        });
+        let album_date: Option<String> = track
+            .album_id
+            .and_then(|aid| queries::album_date(&db.conn, aid).ok().flatten());
 
         // Resolve the path — local, cached, or needs download.
         let (dest, load_state) = resolve_item_path(&db, &cfg, id, &track, album_date.as_deref());
@@ -214,16 +207,9 @@ fn download_single_track(
         }
     };
 
-    let album_date: Option<String> = track.album_id.and_then(|aid| {
-        db.conn
-            .query_row(
-                "SELECT date FROM albums WHERE id = ?1",
-                rusqlite::params![aid],
-                |row| row.get(0),
-            )
-            .ok()
-            .flatten()
-    });
+    let album_date: Option<String> = track
+        .album_id
+        .and_then(|aid| queries::album_date(&db.conn, aid).ok().flatten());
 
     let dest = cache_path_for_track(&cfg.cache_dir(), &track, album_date.as_deref());
 


### PR DESCRIPTION
## Summary

- **D2: rusqlite removed from koan-music** — 3 raw SQL calls replaced with koan-core query functions (`album_date`, `clear_cached_paths`). Binary crate no longer links rusqlite directly
- **D3: rusqlite features scoped** — `bundled-full` → `bundled`, removing unused SQLite extensions (load_extension, backup, blob, hooks, session)
- **D4-D6: workspace dependencies** — added `[workspace.dependencies]` for rusqlite and walkdir, centralizing version management

## Test plan

- [x] `cargo test --workspace` — 371 tests pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

Part of codebase audit (see #12 for full plan). Stacked on #16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)