### PR TITLE
audit: codebase v0.5.2 — all phases combined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Performance
+
+- **Render loop allocations eliminated** — playlist version gate skips redundant O(n) visible queue rebuild when queue is idle; borrowed string keys in display line builder remove 2 allocations per entry per call; spectrum data changed from heap Vec to stack arrays ([f32; 48]) eliminating allocation on every frame clone at 60fps
+
 ### Fixed
 
 - **Security hardening** — credentials removed from stored remote URLs (template-based at playback time), config and DB files restricted to 0o600 on Unix, FTS5 and LIKE query inputs sanitized, HTTPS warning for non-localhost remotes, secure random salt via `getrandom`, PID-namespaced cover art temp files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+### Fixed
+
+- **Security hardening** — credentials removed from stored remote URLs (template-based at playback time), config and DB files restricted to 0o600 on Unix, FTS5 and LIKE query inputs sanitized, HTTPS warning for non-localhost remotes, secure random salt via `getrandom`, PID-namespaced cover art temp files
+
+### Changed
+
+- **Symphonia codec features scoped** — replaced blanket `features = ["all"]` with only the codecs koan actually uses (FLAC, MP3, AAC, Vorbis, Opus, ALAC, WavPack, WAV, AIFF), reducing compile time
+
+### Removed
+
+- **Dead code cleanup** — removed 6 unused functions/fields: `LyricsState::clear`, `CoverArt::centered`, `scrollbar_hover` theme field, `event.rs` module, `VisualizerState::num_bars`, 3 unused `HoverZone` variants
+
+### Tests
+
+- **Test coverage expanded** — 332 → 371 tests. Added coverage for PlaybackTimeline (6), SharedPlayerState (12), favourites (8), Subsonic client (5), metadata probe (5). Removed 4 AI-generated duplicate streaming tests
+
 ## 0.5.2
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@
 - **`row_to_track_row` helper** — deduplicated 4 identical 22-line row-mapping closures in tracks.rs into a single shared function
 - **`plan_single_move` helper** — extracted shared move-planning logic (path formatting, sanitization, extension preservation, ancillary file handling) from two `plan_moves` variants in organize.rs
 
+### Dependencies
+
+- **rusqlite removed from koan-music** — 3 raw SQL calls replaced with koan-core query functions (`album_date`, `clear_cached_paths`). Binary crate no longer links rusqlite directly
+- **rusqlite features scoped** — `bundled-full` → `bundled`, removing unused extensions (load_extension, backup, blob, hooks, session)
+- **Workspace dependencies** — added `[workspace.dependencies]` for rusqlite and walkdir, centralizing version management
+
 ### Fixed
 
 - **Security hardening** — credentials removed from stored remote URLs (template-based at playback time), config and DB files restricted to 0o600 on Unix, FTS5 and LIKE query inputs sanitized, HTTPS warning for non-localhost remotes, secure random salt via `getrandom`, PID-namespaced cover art temp files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 - **Render loop allocations eliminated** — playlist version gate skips redundant O(n) visible queue rebuild when queue is idle; borrowed string keys in display line builder remove 2 allocations per entry per call; spectrum data changed from heap Vec to stack arrays ([f32; 48]) eliminating allocation on every frame clone at 60fps
 
+### Refactored
+
+- **`row_to_track_row` helper** — deduplicated 4 identical 22-line row-mapping closures in tracks.rs into a single shared function
+- **`plan_single_move` helper** — extracted shared move-planning logic (path formatting, sanitization, extension preservation, ancillary file handling) from two `plan_moves` variants in organize.rs
+
 ### Fixed
 
 - **Security hardening** — credentials removed from stored remote URLs (template-based at playback time), config and DB files restricted to 0o600 on Unix, FTS5 and LIKE query inputs sanitized, HTTPS warning for non-localhost remotes, secure random salt via `getrandom`, PID-namespaced cover art temp files

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,27 +521,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "csv"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
-dependencies = [
- "csv-core",
- "itoa",
- "ryu",
- "serde_core",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -614,15 +593,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64bff0bd181fba667660276c6b7ebdc50cff37ce593e7adf9e734f89c8f444e8"
 dependencies = [
  "dbus",
-]
-
-[[package]]
-name = "deranged"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
-dependencies = [
- "powerfmt",
 ]
 
 [[package]]
@@ -1246,32 +1216,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
-name = "jiff"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89a5b5e10d5a9ad6e5d1f4bd58225f655d6fe9767575a5e8ac5a6fe64e04495"
-dependencies = [
- "jiff-static",
- "js-sys",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde_core",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff7a39c8862fc1369215ccf0a8f12dd4598c7f6484704359f0351bd617034dbf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "jni"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1360,7 +1304,6 @@ dependencies = [
  "owo-colors",
  "ratatui",
  "rpassword",
- "rusqlite",
  "souvlaki",
  "toml",
  "walkdir",
@@ -1592,12 +1535,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-conv"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
-
-[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1730,21 +1667,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "portable-atomic"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
-dependencies = [
- "portable-atomic",
-]
-
-[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1752,12 +1674,6 @@ checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
-
-[[package]]
-name = "powerfmt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -2092,19 +2008,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1c93dd1c9683b438c392c492109cb702b8090b2bfc8fed6f6e4eb4523f17af3"
 dependencies = [
  "bitflags 2.10.0",
- "chrono",
- "csv",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
- "jiff",
  "libsqlite3-sys",
- "serde_json",
  "smallvec",
  "sqlite-wasm-rs",
- "time",
- "url",
- "uuid",
 ]
 
 [[package]]
@@ -2739,38 +2648,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "time"
-version = "0.3.47"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
-dependencies = [
- "deranged",
- "itoa",
- "js-sys",
- "num-conv",
- "powerfmt",
- "serde_core",
- "time-core",
- "time-macros",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
-
-[[package]]
-name = "time-macros"
-version = "0.2.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
-dependencies = [
- "num-conv",
- "time-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,7 @@ edition = "2024"
 homepage = "https://github.com/radiosilence/koan"
 repository = "https://github.com/radiosilence/koan"
 license = "MIT"
+
+[workspace.dependencies]
+rusqlite = { version = "0.38", features = ["bundled"] }
+walkdir = "2.5"

--- a/crates/koan-core/Cargo.toml
+++ b/crates/koan-core/Cargo.toml
@@ -33,7 +33,7 @@ reqwest = { version = "0.13", default-features = false, features = [
 realfft = "3"
 rtrb = "0.3"
 # Database
-rusqlite = { version = "0.38", features = ["bundled-full"] }
+rusqlite = { workspace = true }
 # Credentials
 security-framework = "3.5"
 # Serialization
@@ -46,7 +46,7 @@ symphonia = { version = "0.5", default-features = false, features = [
 thiserror = "2"
 uuid = { version = "1", features = ["v7"] }
 toml = "0.9"
-walkdir = "2.5"
+walkdir = { workspace = true }
 
 [dev-dependencies]
 serde_json = "1"

--- a/crates/koan-core/src/audio/analyzer.rs
+++ b/crates/koan-core/src/audio/analyzer.rs
@@ -225,13 +225,13 @@ struct AnalysisState {
     /// Last seen sample rate — detects changes.
     last_sample_rate: f32,
     /// Reusable counts per bar (how many bins mapped to each bar).
-    bar_counts: Vec<u32>,
+    bar_counts: [u32; NUM_BARS],
     /// Smoothed spectrum from previous frame (for decay).
-    prev_spectrum: Vec<f32>,
+    prev_spectrum: [f32; NUM_BARS],
     /// Current spectrum (written each pass, then moved to output).
-    spectrum: Vec<f32>,
+    spectrum: [f32; NUM_BARS],
     /// Peak hold values.
-    peaks: Vec<f32>,
+    peaks: [f32; NUM_BARS],
     /// VU levels [left, right].
     vu_levels: [f32; 2],
     /// Timestamp of the previous analysis pass (for decay timing).
@@ -266,10 +266,10 @@ impl AnalysisState {
             fft,
             bin_to_bar: Vec::new(),
             last_sample_rate: 0.0,
-            bar_counts: vec![0u32; NUM_BARS],
-            prev_spectrum: vec![0.0; NUM_BARS],
-            spectrum: vec![0.0; NUM_BARS],
-            peaks: vec![0.0; NUM_BARS],
+            bar_counts: [0u32; NUM_BARS],
+            prev_spectrum: [0.0; NUM_BARS],
+            spectrum: [0.0; NUM_BARS],
+            peaks: [0.0; NUM_BARS],
             vu_levels: [0.0; 2],
             last_update: Instant::now(),
             scale,
@@ -602,7 +602,7 @@ fn analysis_loop(
         // ── Phase 3b: publish to VizSnapshot (RwLock write, <1us) ────────────
         if let Some(ref snap_out) = snapshot {
             snap_out.write(VizFrame {
-                spectrum: state.spectrum.clone(),
+                spectrum: state.spectrum,
                 vu_levels: state.vu_levels,
                 timestamp: Instant::now(),
             });

--- a/crates/koan-core/src/audio/buffer.rs
+++ b/crates/koan-core/src/audio/buffer.rs
@@ -654,6 +654,24 @@ fn decode_single(
     }
 }
 
+pub fn codec_name(codec: CodecType) -> String {
+    match codec {
+        CODEC_TYPE_FLAC => "FLAC",
+        CODEC_TYPE_MP3 => "MP3",
+        CODEC_TYPE_AAC => "AAC",
+        CODEC_TYPE_VORBIS => "Vorbis",
+        CODEC_TYPE_OPUS => "Opus",
+        CODEC_TYPE_ALAC => "ALAC",
+        CODEC_TYPE_WAVPACK => "WavPack",
+        CODEC_TYPE_PCM_S16LE => "PCM/16",
+        CODEC_TYPE_PCM_S24LE => "PCM/24",
+        CODEC_TYPE_PCM_S32LE => "PCM/32",
+        CODEC_TYPE_PCM_F32LE => "PCM/f32",
+        other => return format!("Unknown({:?})", other),
+    }
+    .to_string()
+}
+
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
@@ -848,22 +866,4 @@ mod tests {
             "samples_written should be 0 after reset"
         );
     }
-}
-
-pub fn codec_name(codec: CodecType) -> String {
-    match codec {
-        CODEC_TYPE_FLAC => "FLAC",
-        CODEC_TYPE_MP3 => "MP3",
-        CODEC_TYPE_AAC => "AAC",
-        CODEC_TYPE_VORBIS => "Vorbis",
-        CODEC_TYPE_OPUS => "Opus",
-        CODEC_TYPE_ALAC => "ALAC",
-        CODEC_TYPE_WAVPACK => "WavPack",
-        CODEC_TYPE_PCM_S16LE => "PCM/16",
-        CODEC_TYPE_PCM_S24LE => "PCM/24",
-        CODEC_TYPE_PCM_S32LE => "PCM/32",
-        CODEC_TYPE_PCM_F32LE => "PCM/f32",
-        other => return format!("Unknown({:?})", other),
-    }
-    .to_string()
 }

--- a/crates/koan-core/src/audio/buffer.rs
+++ b/crates/koan-core/src/audio/buffer.rs
@@ -654,6 +654,202 @@ fn decode_single(
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+    use std::sync::atomic::Ordering;
+
+    use super::*;
+    use crate::player::state::QueueItemId;
+
+    fn make_info(sample_rate: u32, channels: u16) -> StreamInfo {
+        StreamInfo {
+            codec: "FLAC".to_string(),
+            sample_rate,
+            channels,
+            bit_depth: 16,
+            duration_ms: 10_000,
+        }
+    }
+
+    fn make_boundary(
+        id: QueueItemId,
+        sample_offset: u64,
+        seek_samples: u64,
+        channels: u16,
+        sample_rate: u32,
+    ) -> TrackBoundary {
+        TrackBoundary {
+            id,
+            path: PathBuf::from("/music/track.flac"),
+            info: make_info(sample_rate, channels),
+            sample_offset,
+            samples_written: 0,
+            seek_samples,
+        }
+    }
+
+    // --- PlaybackTimeline tests ---
+
+    #[test]
+    fn test_timeline_single_track() {
+        // Push one boundary at offset 0 with stereo 44100 Hz audio.
+        // After simulating 44100 frames (88200 interleaved samples) played,
+        // current_playback() should report track index 0 at position 1000 ms.
+        let timeline = PlaybackTimeline::new();
+        let id = QueueItemId::new();
+        // sample_offset=0, seek_samples=0, channels=2, sample_rate=44100
+        timeline.push_boundary(make_boundary(id, 0, 0, 2, 44100));
+        timeline.add_written(88200); // 1 second of audio
+
+        // Simulate 1 second played: 44100 frames * 2 channels = 88200 interleaved samples
+        timeline.samples_played.store(88200, Ordering::Relaxed);
+
+        let result = timeline.current_playback();
+        assert!(
+            result.is_some(),
+            "expected Some for single track with samples played"
+        );
+        let (result_id, _path, _info, position_ms) = result.unwrap();
+        assert_eq!(result_id, id);
+        assert_eq!(
+            position_ms, 1000,
+            "1 second of 44100 Hz stereo should be 1000 ms"
+        );
+    }
+
+    #[test]
+    fn test_timeline_gapless_transition() {
+        // Two tracks in gapless sequence. Track 1 ends at sample 88200 (1 sec stereo 44100 Hz).
+        // Track 2 begins at sample_offset 88200. When playback head is at 100000 (past the boundary),
+        // current_playback() should report track 2.
+        let timeline = PlaybackTimeline::new();
+        let id1 = QueueItemId::new();
+        let id2 = QueueItemId::new();
+
+        // Track 1: starts at offset 0
+        timeline.push_boundary(make_boundary(id1, 0, 0, 2, 44100));
+        timeline.add_written(88200);
+
+        // Track 2: starts at offset 88200 (immediately after track 1's samples)
+        timeline.push_boundary(make_boundary(id2, 88200, 0, 2, 44100));
+        timeline.add_written(44100); // half a second of track 2
+
+        // Set playback head past the track 1/2 boundary
+        timeline.samples_played.store(90000, Ordering::Relaxed);
+
+        let result = timeline.current_playback();
+        assert!(result.is_some());
+        let (result_id, _path, _info, position_ms) = result.unwrap();
+        assert_eq!(
+            result_id, id2,
+            "playback head past boundary should report second track"
+        );
+        // (90000 - 88200) / 2 channels * 1000 / 44100 = 900 / 44100 ≈ 20 ms
+        assert_eq!(position_ms, 20, "position within track 2 should be ~20 ms");
+    }
+
+    #[test]
+    fn test_timeline_zero_samples() {
+        // With 0 samples played and a boundary at offset 0, current_playback() should
+        // still return the first track at position 0 ms.
+        let timeline = PlaybackTimeline::new();
+        let id = QueueItemId::new();
+        timeline.push_boundary(make_boundary(id, 0, 0, 2, 44100));
+        timeline.add_written(1000);
+        timeline.samples_played.store(0, Ordering::Relaxed);
+
+        let result = timeline.current_playback();
+        assert!(
+            result.is_some(),
+            "expected Some at 0 samples played with a boundary at offset 0"
+        );
+        let (result_id, _path, _info, position_ms) = result.unwrap();
+        assert_eq!(result_id, id);
+        assert_eq!(position_ms, 0);
+    }
+
+    #[test]
+    fn test_timeline_past_all_boundaries() {
+        // When samples_played exceeds all boundaries, the last track should be reported.
+        // The binary search finds the last boundary whose sample_offset <= played.
+        let timeline = PlaybackTimeline::new();
+        let id1 = QueueItemId::new();
+        let id2 = QueueItemId::new();
+
+        timeline.push_boundary(make_boundary(id1, 0, 0, 2, 44100));
+        timeline.add_written(88200);
+        timeline.push_boundary(make_boundary(id2, 88200, 0, 2, 44100));
+        timeline.add_written(88200);
+
+        // Simulate playback far past both tracks
+        timeline
+            .samples_played
+            .store(999_999_999, Ordering::Relaxed);
+
+        let result = timeline.current_playback();
+        assert!(result.is_some());
+        let (result_id, _path, _info, _position_ms) = result.unwrap();
+        assert_eq!(
+            result_id, id2,
+            "samples past all boundaries should report the last track"
+        );
+    }
+
+    #[test]
+    fn test_timeline_seek_offset() {
+        // When a seek offset is set, position_ms should include the seek position.
+        // seek_samples = 88200 means playback started 1 second into the track.
+        // With 0 additional samples played past the boundary, position should be 1000 ms.
+        let timeline = PlaybackTimeline::new();
+        let id = QueueItemId::new();
+        let seek_samples = 88200u64; // 1 second at 44100 Hz stereo
+        timeline.push_boundary(make_boundary(id, 0, seek_samples, 2, 44100));
+        timeline.add_written(44100); // half a second written so far
+        // samples_played at the track boundary (0 frames past the track start)
+        timeline.samples_played.store(0, Ordering::Relaxed);
+
+        let result = timeline.current_playback();
+        assert!(result.is_some());
+        let (_result_id, _path, _info, position_ms) = result.unwrap();
+        // track_samples = 0 - 0 = 0; seek contribution = (88200/2)*1000/44100 = 1000 ms
+        assert_eq!(
+            position_ms, 1000,
+            "position should include seek offset of 1000 ms"
+        );
+    }
+
+    #[test]
+    fn test_timeline_reset() {
+        // After reset(), current_playback() returns None and all counters are cleared.
+        let timeline = PlaybackTimeline::new();
+        let id = QueueItemId::new();
+        timeline.push_boundary(make_boundary(id, 0, 0, 2, 44100));
+        timeline.add_written(88200);
+        timeline.samples_played.store(44100, Ordering::Relaxed);
+
+        // Sanity check: playback is live before reset
+        assert!(timeline.current_playback().is_some());
+
+        timeline.reset();
+
+        assert!(
+            timeline.current_playback().is_none(),
+            "after reset, current_playback should return None"
+        );
+        assert_eq!(
+            timeline.samples_played.load(Ordering::Relaxed),
+            0,
+            "samples_played should be 0 after reset"
+        );
+        assert_eq!(
+            timeline.samples_written.load(Ordering::Relaxed),
+            0,
+            "samples_written should be 0 after reset"
+        );
+    }
+}
+
 pub fn codec_name(codec: CodecType) -> String {
     match codec {
         CODEC_TYPE_FLAC => "FLAC",

--- a/crates/koan-core/src/audio/streaming.rs
+++ b/crates/koan-core/src/audio/streaming.rs
@@ -327,65 +327,6 @@ mod tests {
         assert_eq!(&out2, b"012");
     }
 
-    // --- Tests using the requested names ---
-
-    #[test]
-    fn test_new_and_is_complete() {
-        // "is_complete" == bytes_downloaded() == total_len and done==true (finish() called).
-        let data = vec![0u8; 1000];
-        let buf = StreamBuffer::new(Some(1000));
-        buf.push(&data);
-        buf.finish();
-        assert_eq!(buf.bytes_downloaded(), 1000);
-        assert_eq!(buf.total_len(), Some(1000));
-        // A reader should see EOF immediately (no blocking).
-        let mut src = buf.reader();
-        let mut out = Vec::new();
-        src.read_to_end(&mut out).unwrap();
-        assert_eq!(out.len(), 1000);
-    }
-
-    #[test]
-    fn test_read_all_available() {
-        let data: Vec<u8> = (0u8..=255).cycle().take(1000).collect();
-        let buf = StreamBuffer::new(Some(1000));
-        buf.push(&data);
-        buf.finish();
-        let mut src = buf.reader();
-        let mut out = Vec::new();
-        src.read_to_end(&mut out).unwrap();
-        assert_eq!(out, data);
-    }
-
-    #[test]
-    fn test_seek_start() {
-        let data: Vec<u8> = (0u8..=255).cycle().take(1000).collect();
-        let buf = filled_buffer(&data);
-        let mut src = buf.reader();
-
-        src.seek(SeekFrom::Start(500)).unwrap();
-        let mut out = Vec::new();
-        src.read_to_end(&mut out).unwrap();
-        assert_eq!(out, &data[500..]);
-    }
-
-    #[test]
-    fn test_seek_current() {
-        let data: Vec<u8> = (0u8..=255).cycle().take(1000).collect();
-        let buf = filled_buffer(&data);
-        let mut src = buf.reader();
-
-        // Read 100 bytes then seek forward 400 from current → position 500.
-        let mut tmp = vec![0u8; 100];
-        src.read_exact(&mut tmp).unwrap();
-        let pos = src.seek(SeekFrom::Current(400)).unwrap();
-        assert_eq!(pos, 500);
-
-        let mut out = Vec::new();
-        src.read_to_end(&mut out).unwrap();
-        assert_eq!(out, &data[500..]);
-    }
-
     #[test]
     fn test_partial_availability() {
         // Push only 500 bytes without finish() — simulates in-progress download.

--- a/crates/koan-core/src/audio/viz.rs
+++ b/crates/koan-core/src/audio/viz.rs
@@ -16,9 +16,9 @@ pub const NUM_BARS: usize = 48;
 #[derive(Clone)]
 pub struct AnalysisOutput {
     /// Spectrum bar heights (0.0..1.0), one per bar.
-    pub spectrum: Vec<f32>,
+    pub spectrum: [f32; NUM_BARS],
     /// Peak hold values (slowly decaying maxima), one per bar.
-    pub peaks: Vec<f32>,
+    pub peaks: [f32; NUM_BARS],
     /// RMS VU levels: [left, right], each 0.0..1.0.
     pub vu_levels: [f32; 2],
 }
@@ -26,8 +26,8 @@ pub struct AnalysisOutput {
 impl Default for AnalysisOutput {
     fn default() -> Self {
         Self {
-            spectrum: vec![0.0; NUM_BARS],
-            peaks: vec![0.0; NUM_BARS],
+            spectrum: [0.0; NUM_BARS],
+            peaks: [0.0; NUM_BARS],
             vu_levels: [0.0; 2],
         }
     }
@@ -46,7 +46,7 @@ pub type SharedAnalysisOutput = Arc<Mutex<AnalysisOutput>>;
 #[derive(Clone)]
 pub struct VizFrame {
     /// Spectrum bar heights (0.0..1.0), one per bar.
-    pub spectrum: Vec<f32>,
+    pub spectrum: [f32; NUM_BARS],
     /// RMS VU levels: [left, right], each 0.0..1.0.
     pub vu_levels: [f32; 2],
     /// When this frame was computed.
@@ -56,7 +56,7 @@ pub struct VizFrame {
 impl Default for VizFrame {
     fn default() -> Self {
         Self {
-            spectrum: vec![0.0; NUM_BARS],
+            spectrum: [0.0; NUM_BARS],
             vu_levels: [0.0; 2],
             timestamp: std::time::Instant::now(),
         }
@@ -317,7 +317,7 @@ mod tests {
         assert_eq!(frame.spectrum.len(), NUM_BARS);
         assert_eq!(frame.vu_levels, [0.0, 0.0]);
 
-        let mut new_spectrum = vec![0.0f32; NUM_BARS];
+        let mut new_spectrum = [0.0f32; NUM_BARS];
         new_spectrum[5] = 0.9;
         snap.write(VizFrame {
             spectrum: new_spectrum,

--- a/crates/koan-core/src/db/queries/albums.rs
+++ b/crates/koan-core/src/db/queries/albums.rs
@@ -72,6 +72,18 @@ pub fn albums_for_artist(conn: &Connection, artist_id: i64) -> Result<Vec<AlbumR
     Ok(rows)
 }
 
+/// Get the date string for an album by ID.
+pub fn album_date(conn: &Connection, album_id: i64) -> Result<Option<String>, DbError> {
+    Ok(conn
+        .query_row(
+            "SELECT date FROM albums WHERE id = ?1",
+            params![album_id],
+            |row| row.get(0),
+        )
+        .ok()
+        .flatten())
+}
+
 /// Get all albums with their artist name, sorted.
 pub fn all_albums(conn: &Connection) -> Result<Vec<AlbumRow>, DbError> {
     let mut stmt = conn.prepare(

--- a/crates/koan-core/src/db/queries/favourites.rs
+++ b/crates/koan-core/src/db/queries/favourites.rs
@@ -112,3 +112,186 @@ pub fn import_remote_favourites(
     }
     Ok(count)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_conn() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.pragma_update(None, "foreign_keys", "on").unwrap();
+        crate::db::schema::create_tables(&conn).unwrap();
+        conn
+    }
+
+    /// Insert a minimal track row so `import_remote_favourites` can resolve remote_id → path.
+    fn insert_track_with_remote_id(conn: &Connection, path: &str, remote_id: &str) {
+        conn.execute(
+            "INSERT INTO artists (name) VALUES ('Artist') ON CONFLICT(name) DO NOTHING",
+            [],
+        )
+        .unwrap();
+        let artist_id: i64 = conn
+            .query_row("SELECT id FROM artists WHERE name = 'Artist'", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        conn.execute(
+            "INSERT INTO albums (title, artist_id) VALUES ('Album', ?1) ON CONFLICT(title, artist_id) DO NOTHING",
+            [artist_id],
+        )
+        .unwrap();
+        let album_id: i64 = conn
+            .query_row(
+                "SELECT id FROM albums WHERE title = 'Album' AND artist_id = ?1",
+                [artist_id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        conn.execute(
+            "INSERT INTO tracks (title, artist_id, album_id, source, path, remote_id)
+             VALUES ('Track', ?1, ?2, 'local', ?3, ?4)",
+            rusqlite::params![artist_id, album_id, path, remote_id],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn test_load_favourites_returns_empty_when_none_added() {
+        let conn = test_conn();
+        let favs = load_favourites(&conn).unwrap();
+        assert!(
+            favs.is_empty(),
+            "expected no favourites in a fresh database"
+        );
+    }
+
+    #[test]
+    fn test_add_and_remove_favourite() {
+        let conn = test_conn();
+        let path = Path::new("/music/track.flac");
+
+        add_favourite(&conn, path).unwrap();
+        let favs = load_favourites(&conn).unwrap();
+        assert!(
+            favs.contains(path),
+            "track should be in favourites after add"
+        );
+
+        remove_favourite(&conn, path).unwrap();
+        let favs = load_favourites(&conn).unwrap();
+        assert!(
+            !favs.contains(path),
+            "track should not be in favourites after remove"
+        );
+    }
+
+    #[test]
+    fn test_add_favourite_is_idempotent() {
+        let conn = test_conn();
+        let path = Path::new("/music/idempotent.flac");
+
+        add_favourite(&conn, path).unwrap();
+        add_favourite(&conn, path).unwrap(); // second call must not error
+        let favs = load_favourites(&conn).unwrap();
+        assert_eq!(favs.len(), 1, "duplicate add should not create two rows");
+    }
+
+    #[test]
+    fn test_toggle_favourite_on_then_off() {
+        let conn = test_conn();
+        let path = Path::new("/music/toggle.flac");
+
+        // First toggle: not present → should be added, returns true.
+        let now_fav = toggle_favourite(&conn, path).unwrap();
+        assert!(
+            now_fav,
+            "toggle on empty should add the favourite and return true"
+        );
+
+        let favs = load_favourites(&conn).unwrap();
+        assert!(
+            favs.contains(path),
+            "track should be in favourites after first toggle"
+        );
+
+        // Second toggle: present → should be removed, returns false.
+        let now_fav = toggle_favourite(&conn, path).unwrap();
+        assert!(
+            !now_fav,
+            "second toggle should remove the favourite and return false"
+        );
+
+        let favs = load_favourites(&conn).unwrap();
+        assert!(
+            !favs.contains(path),
+            "track should not be in favourites after second toggle"
+        );
+    }
+
+    #[test]
+    fn test_toggle_favourite_nonexistent_track_path_handled_gracefully() {
+        // The favourites table stores paths directly; there is no FK constraint
+        // to the tracks table. A path that has no corresponding track row should
+        // be toggled in/out without error.
+        let conn = test_conn();
+        let path = Path::new("/music/does-not-exist-in-tracks.flac");
+
+        let result = toggle_favourite(&conn, path);
+        assert!(
+            result.is_ok(),
+            "toggling a path with no track row should not error"
+        );
+        assert!(
+            result.unwrap(),
+            "non-existent path should be added on first toggle"
+        );
+
+        let favs = load_favourites(&conn).unwrap();
+        assert!(
+            favs.contains(path),
+            "path should appear in favourites even without a matching track row"
+        );
+    }
+
+    #[test]
+    fn test_import_remote_favourites_adds_matching_tracks() {
+        let conn = test_conn();
+        insert_track_with_remote_id(&conn, "/music/remote-track.flac", "remote-001");
+
+        let added = import_remote_favourites(&conn, &["remote-001".to_string()]).unwrap();
+        assert_eq!(added, 1, "should have imported one favourite");
+
+        let favs = load_favourites(&conn).unwrap();
+        assert!(
+            favs.contains(Path::new("/music/remote-track.flac")),
+            "imported track path should be in favourites"
+        );
+    }
+
+    #[test]
+    fn test_import_remote_favourites_skips_unknown_remote_ids() {
+        let conn = test_conn();
+
+        let added = import_remote_favourites(&conn, &["unknown-remote-id".to_string()]).unwrap();
+        assert_eq!(added, 0, "unknown remote_id should not add any favourites");
+
+        let favs = load_favourites(&conn).unwrap();
+        assert!(favs.is_empty());
+    }
+
+    #[test]
+    fn test_import_remote_favourites_is_idempotent() {
+        let conn = test_conn();
+        insert_track_with_remote_id(&conn, "/music/idempotent-remote.flac", "remote-002");
+
+        import_remote_favourites(&conn, &["remote-002".to_string()]).unwrap();
+        let added = import_remote_favourites(&conn, &["remote-002".to_string()]).unwrap();
+
+        assert_eq!(
+            added, 0,
+            "re-importing an already-favourited track should add 0 rows"
+        );
+        assert_eq!(load_favourites(&conn).unwrap().len(), 1);
+    }
+}

--- a/crates/koan-core/src/db/queries/tracks.rs
+++ b/crates/koan-core/src/db/queries/tracks.rs
@@ -8,6 +8,37 @@ use super::albums::get_or_create_album;
 use super::artists::get_or_create_artist;
 use super::{PlaybackSource, TrackMeta, TrackRow};
 
+/// Map a rusqlite Row to a TrackRow. Expects the standard column order:
+/// id, album_id, artist_id, artist_name, album_artist_name, album_title,
+/// disc, track_number, title, duration_ms, path,
+/// codec, sample_rate, bit_depth, channels, bitrate,
+/// genre, source, remote_id, cached_path
+fn row_to_track_row(row: &rusqlite::Row) -> rusqlite::Result<TrackRow> {
+    let artist_name: String = row.get::<_, Option<String>>(3)?.unwrap_or_default();
+    Ok(TrackRow {
+        id: row.get(0)?,
+        album_id: row.get(1)?,
+        artist_id: row.get(2)?,
+        artist_name: artist_name.clone(),
+        album_artist_name: row.get::<_, Option<String>>(4)?.unwrap_or(artist_name),
+        album_title: row.get::<_, Option<String>>(5)?.unwrap_or_default(),
+        disc: row.get(6)?,
+        track_number: row.get(7)?,
+        title: row.get(8)?,
+        duration_ms: row.get(9)?,
+        path: row.get(10)?,
+        codec: row.get(11)?,
+        sample_rate: row.get(12)?,
+        bit_depth: row.get(13)?,
+        channels: row.get(14)?,
+        bitrate: row.get(15)?,
+        genre: row.get(16)?,
+        source: row.get(17)?,
+        remote_id: row.get(18)?,
+        cached_path: row.get(19)?,
+    })
+}
+
 /// Insert or update a track. Deduplicates local+remote: one row per logical track.
 ///
 /// Matching priority:
@@ -292,31 +323,7 @@ pub fn tracks_for_artist(conn: &Connection, artist_id: i64) -> Result<Vec<TrackR
          ORDER BY al.date, al.title, t.disc, t.track_number",
     )?;
     let rows = stmt
-        .query_map(params![artist_id], |row| {
-            let artist_name: String = row.get::<_, Option<String>>(3)?.unwrap_or_default();
-            Ok(TrackRow {
-                id: row.get(0)?,
-                album_id: row.get(1)?,
-                artist_id: row.get(2)?,
-                artist_name: artist_name.clone(),
-                album_artist_name: row.get::<_, Option<String>>(4)?.unwrap_or(artist_name),
-                album_title: row.get::<_, Option<String>>(5)?.unwrap_or_default(),
-                disc: row.get(6)?,
-                track_number: row.get(7)?,
-                title: row.get(8)?,
-                duration_ms: row.get(9)?,
-                path: row.get(10)?,
-                codec: row.get(11)?,
-                sample_rate: row.get(12)?,
-                bit_depth: row.get(13)?,
-                channels: row.get(14)?,
-                bitrate: row.get(15)?,
-                genre: row.get(16)?,
-                source: row.get(17)?,
-                remote_id: row.get(18)?,
-                cached_path: row.get(19)?,
-            })
-        })?
+        .query_map(params![artist_id], row_to_track_row)?
         .collect::<Result<Vec<_>, _>>()?;
     Ok(rows)
 }
@@ -336,31 +343,7 @@ pub fn all_tracks(conn: &Connection) -> Result<Vec<TrackRow>, DbError> {
     )?;
 
     let rows = stmt
-        .query_map(params![], |row| {
-            let artist_name: String = row.get::<_, Option<String>>(3)?.unwrap_or_default();
-            Ok(TrackRow {
-                id: row.get(0)?,
-                album_id: row.get(1)?,
-                artist_id: row.get(2)?,
-                artist_name: artist_name.clone(),
-                album_artist_name: row.get::<_, Option<String>>(4)?.unwrap_or(artist_name),
-                album_title: row.get::<_, Option<String>>(5)?.unwrap_or_default(),
-                disc: row.get(6)?,
-                track_number: row.get(7)?,
-                title: row.get(8)?,
-                duration_ms: row.get(9)?,
-                path: row.get(10)?,
-                codec: row.get(11)?,
-                sample_rate: row.get(12)?,
-                bit_depth: row.get(13)?,
-                channels: row.get(14)?,
-                bitrate: row.get(15)?,
-                genre: row.get(16)?,
-                source: row.get(17)?,
-                remote_id: row.get(18)?,
-                cached_path: row.get(19)?,
-            })
-        })?
+        .query_map(params![], row_to_track_row)?
         .collect::<Result<Vec<_>, _>>()?;
 
     Ok(rows)
@@ -379,31 +362,7 @@ pub fn get_track_row(conn: &Connection, track_id: i64) -> Result<Option<TrackRow
          LEFT JOIN artists aa ON al.artist_id = aa.id
          WHERE t.id = ?1",
         params![track_id],
-        |row| {
-            let artist_name: String = row.get::<_, Option<String>>(3)?.unwrap_or_default();
-            Ok(TrackRow {
-                id: row.get(0)?,
-                album_id: row.get(1)?,
-                artist_id: row.get(2)?,
-                artist_name: artist_name.clone(),
-                album_artist_name: row.get::<_, Option<String>>(4)?.unwrap_or(artist_name),
-                album_title: row.get::<_, Option<String>>(5)?.unwrap_or_default(),
-                disc: row.get(6)?,
-                track_number: row.get(7)?,
-                title: row.get(8)?,
-                duration_ms: row.get(9)?,
-                path: row.get(10)?,
-                codec: row.get(11)?,
-                sample_rate: row.get(12)?,
-                bit_depth: row.get(13)?,
-                channels: row.get(14)?,
-                bitrate: row.get(15)?,
-                genre: row.get(16)?,
-                source: row.get(17)?,
-                remote_id: row.get(18)?,
-                cached_path: row.get(19)?,
-            })
-        },
+        row_to_track_row,
     );
 
     match result {
@@ -497,31 +456,7 @@ pub fn tracks_for_album(conn: &Connection, album_id: i64) -> Result<Vec<TrackRow
     )?;
 
     let rows = stmt
-        .query_map(params![album_id], |row| {
-            let artist_name: String = row.get::<_, Option<String>>(3)?.unwrap_or_default();
-            Ok(TrackRow {
-                id: row.get(0)?,
-                album_id: row.get(1)?,
-                artist_id: row.get(2)?,
-                artist_name: artist_name.clone(),
-                album_artist_name: row.get::<_, Option<String>>(4)?.unwrap_or(artist_name),
-                album_title: row.get::<_, Option<String>>(5)?.unwrap_or_default(),
-                disc: row.get(6)?,
-                track_number: row.get(7)?,
-                title: row.get(8)?,
-                duration_ms: row.get(9)?,
-                path: row.get(10)?,
-                codec: row.get(11)?,
-                sample_rate: row.get(12)?,
-                bit_depth: row.get(13)?,
-                channels: row.get(14)?,
-                bitrate: row.get(15)?,
-                genre: row.get(16)?,
-                source: row.get(17)?,
-                remote_id: row.get(18)?,
-                cached_path: row.get(19)?,
-            })
-        })?
+        .query_map(params![album_id], row_to_track_row)?
         .collect::<Result<Vec<_>, _>>()?;
 
     Ok(rows)

--- a/crates/koan-core/src/db/queries/tracks.rs
+++ b/crates/koan-core/src/db/queries/tracks.rs
@@ -386,6 +386,12 @@ pub fn track_id_by_path(conn: &Connection, path: &str) -> Result<Option<i64>, Db
     }
 }
 
+/// Clear all cached_path values (used when purging the download cache).
+pub fn clear_cached_paths(conn: &Connection) -> Result<(), DbError> {
+    conn.execute("UPDATE tracks SET cached_path = NULL", params![])?;
+    Ok(())
+}
+
 /// Update the cached_path for a track after downloading.
 pub fn set_cached_path(conn: &Connection, track_id: i64, path: &str) -> Result<(), DbError> {
     conn.execute(

--- a/crates/koan-core/src/index/metadata.rs
+++ b/crates/koan-core/src/index/metadata.rs
@@ -268,4 +268,114 @@ mod tests {
         assert_eq!(codec_from_file_type(lofty::file::FileType::Opus), "Opus");
         assert_eq!(codec_from_file_type(lofty::file::FileType::Wav), "WAV");
     }
+
+    // --- metadata_from_probe_result tests ---
+    //
+    // MetadataRevision has private fields and can only be constructed via
+    // MetadataBuilder (symphonia::core::meta::MetadataBuilder). Tag::new()
+    // is public, so we can build arbitrary revisions in tests.
+
+    use symphonia::core::meta::{MetadataBuilder, StandardTagKey, Tag, Value};
+
+    fn make_revision(tags: &[(StandardTagKey, &str)]) -> symphonia::core::meta::MetadataRevision {
+        let mut builder = MetadataBuilder::new();
+        for (key, value) in tags {
+            builder.add_tag(Tag::new(Some(*key), "", Value::String(value.to_string())));
+        }
+        builder.metadata()
+    }
+
+    #[test]
+    fn test_probe_track_number_slash_format() {
+        // "3/12" in TrackNumber tag should parse to track_number = Some(3),
+        // ignoring the total-tracks part after the slash.
+        let rev = make_revision(&[
+            (StandardTagKey::TrackTitle, "My Song"),
+            (StandardTagKey::Artist, "Artist"),
+            (StandardTagKey::Album, "Album"),
+            (StandardTagKey::TrackNumber, "3/12"),
+        ]);
+        let meta = metadata_from_probe_result(&rev, "fallback");
+        assert_eq!(
+            meta.track_number,
+            Some(3),
+            "slash-format track number should parse to the first component"
+        );
+    }
+
+    #[test]
+    fn test_probe_original_date_fallback() {
+        // When Date is absent, OriginalDate should be used as the date.
+        let rev = make_revision(&[
+            (StandardTagKey::TrackTitle, "My Song"),
+            (StandardTagKey::OriginalDate, "1991"),
+        ]);
+        let meta = metadata_from_probe_result(&rev, "fallback");
+        assert_eq!(
+            meta.date,
+            Some("1991".to_string()),
+            "OriginalDate should be used when Date is missing"
+        );
+    }
+
+    #[test]
+    fn test_probe_original_date_not_used_when_date_present() {
+        // When both Date and OriginalDate are present, Date wins.
+        let rev = make_revision(&[
+            (StandardTagKey::Date, "2005"),
+            (StandardTagKey::OriginalDate, "1991"),
+        ]);
+        let meta = metadata_from_probe_result(&rev, "fallback");
+        assert_eq!(
+            meta.date,
+            Some("2005".to_string()),
+            "Date should take precedence over OriginalDate"
+        );
+    }
+
+    #[test]
+    fn test_probe_empty_values_skipped() {
+        // Tags with empty string values should be silently skipped,
+        // leaving the corresponding fields as None (or falling back to defaults).
+        let rev = make_revision(&[
+            (StandardTagKey::Artist, ""),
+            (StandardTagKey::Album, ""),
+            (StandardTagKey::Genre, ""),
+        ]);
+        let meta = metadata_from_probe_result(&rev, "Title");
+        // Empty artist/album fall back to defaults, not empty string.
+        assert_eq!(
+            meta.artist, "Unknown Artist",
+            "empty artist tag should fall back to 'Unknown Artist'"
+        );
+        assert_eq!(
+            meta.album, "Unknown Album",
+            "empty album tag should fall back to 'Unknown Album'"
+        );
+        assert_eq!(meta.genre, None, "empty genre tag should produce None");
+    }
+
+    #[test]
+    fn test_probe_defaults() {
+        // When no tags are present, artist and album should use the hardcoded defaults.
+        // Title should fall back to the fallback_title argument.
+        let rev = make_revision(&[]);
+        let meta = metadata_from_probe_result(&rev, "Fallback Title");
+        assert_eq!(
+            meta.title, "Fallback Title",
+            "missing title should use fallback_title argument"
+        );
+        assert_eq!(
+            meta.artist, "Unknown Artist",
+            "missing artist should default to 'Unknown Artist'"
+        );
+        assert_eq!(
+            meta.album, "Unknown Album",
+            "missing album should default to 'Unknown Album'"
+        );
+        assert_eq!(meta.track_number, None);
+        assert_eq!(meta.date, None);
+        assert_eq!(meta.genre, None);
+        assert_eq!(meta.source, "streaming");
+    }
 }

--- a/crates/koan-core/src/organize.rs
+++ b/crates/koan-core/src/organize.rs
@@ -206,6 +206,68 @@ fn find_ancillary_files(track_dir: &Path) -> Vec<PathBuf> {
     files
 }
 
+/// Plan a single file move: format pattern, sanitize path, build dest, find ancillary files.
+///
+/// Returns `Ok(None)` when source == dest (skipped), `Ok(Some(FileMove))` for a planned move,
+/// or `Err(String)` for errors that should be collected by the caller.
+fn plan_single_move(
+    source: &Path,
+    track_id: i64,
+    metadata: &TrackMetadata,
+    pattern: &str,
+    base_dir: &Path,
+    planned_ancillary: &mut std::collections::HashSet<PathBuf>,
+) -> Result<Option<FileMove>, String> {
+    let relative = format::format(pattern, metadata).map_err(|e| format!("format error: {e}"))?;
+
+    if relative.is_empty() {
+        return Err("format string produced empty path".into());
+    }
+
+    let sanitized = sanitize_relative_path(&relative);
+
+    // Preserve the original file extension.
+    // Don't use with_extension() — it replaces after the LAST dot, which
+    // destroys titles containing dots (e.g. "0111. Bicep - TANGZ II" → "0111.flac").
+    let ext = source
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("flac");
+    let mut dest = base_dir.join(sanitized);
+    let stem = dest.as_os_str().to_os_string();
+    dest = PathBuf::from(format!("{}.{}", stem.to_string_lossy(), ext));
+
+    if paths_equal(source, &dest) {
+        return Ok(None);
+    }
+
+    // Plan ancillary moves — move files in source dir to dest dir.
+    let source_dir = source.parent().unwrap_or(Path::new("."));
+    let dest_dir = dest.parent().unwrap_or(Path::new("."));
+    let mut ancillary = Vec::new();
+
+    if source_dir != dest_dir {
+        for anc_path in find_ancillary_files(source_dir) {
+            if planned_ancillary.contains(&anc_path) {
+                continue;
+            }
+            let Some(anc_name) = anc_path.file_name() else {
+                continue;
+            };
+            let anc_dest = dest_dir.join(anc_name);
+            planned_ancillary.insert(anc_path.clone());
+            ancillary.push((anc_path, anc_dest));
+        }
+    }
+
+    Ok(Some(FileMove {
+        track_id,
+        from: source.to_path_buf(),
+        to: dest,
+        ancillary,
+    }))
+}
+
 /// Build the list of moves for all local tracks (or a filtered subset).
 fn plan_moves(
     db: &Database,
@@ -252,62 +314,19 @@ fn plan_moves(
         };
 
         let metadata = TrackMetadata::from_track_row(track, album_date.as_deref());
-        let relative = match format::format(pattern, &metadata) {
-            Ok(r) => r,
-            Err(e) => {
-                errors.push((source, format!("format error: {e}")));
-                continue;
-            }
-        };
 
-        if relative.is_empty() {
-            errors.push((source, "format string produced empty path".into()));
-            continue;
+        match plan_single_move(
+            &source,
+            track.id,
+            &metadata,
+            pattern,
+            base_dir,
+            &mut planned_ancillary,
+        ) {
+            Ok(Some(file_move)) => moves.push(file_move),
+            Ok(None) => skipped += 1,
+            Err(msg) => errors.push((source, msg)),
         }
-
-        let sanitized = sanitize_relative_path(&relative);
-
-        // Preserve the original file extension.
-        // Don't use with_extension() — it replaces after the LAST dot, which
-        // destroys titles containing dots (e.g. "0111. Bicep - TANGZ II" → "0111.flac").
-        let ext = source
-            .extension()
-            .and_then(|e| e.to_str())
-            .unwrap_or("flac");
-        let mut dest = base_dir.join(sanitized);
-        let stem = dest.as_os_str().to_os_string();
-        dest = PathBuf::from(format!("{}.{}", stem.to_string_lossy(), ext));
-
-        if paths_equal(&source, &dest) {
-            skipped += 1;
-            continue;
-        }
-
-        // Plan ancillary moves — move files in source dir to dest dir.
-        let source_dir = source.parent().unwrap_or(Path::new("."));
-        let dest_dir = dest.parent().unwrap_or(Path::new("."));
-        let mut ancillary = Vec::new();
-
-        if source_dir != dest_dir {
-            for anc_path in find_ancillary_files(source_dir) {
-                if planned_ancillary.contains(&anc_path) {
-                    continue;
-                }
-                let Some(anc_name) = anc_path.file_name() else {
-                    continue;
-                };
-                let anc_dest = dest_dir.join(anc_name);
-                planned_ancillary.insert(anc_path.clone());
-                ancillary.push((anc_path, anc_dest));
-            }
-        }
-
-        moves.push(FileMove {
-            track_id: track.id,
-            from: source,
-            to: dest,
-            ancillary,
-        });
     }
 
     Ok(OrganizeResult {
@@ -346,57 +365,19 @@ fn plan_moves_from_paths(
         };
 
         let metadata = TrackMetadata::from_file_meta(&meta);
-        let relative = match format::format(pattern, &metadata) {
-            Ok(r) => r,
-            Err(e) => {
-                errors.push((source.clone(), format!("format error: {e}")));
-                continue;
-            }
-        };
 
-        if relative.is_empty() {
-            errors.push((source.clone(), "format string produced empty path".into()));
-            continue;
+        match plan_single_move(
+            source,
+            0,
+            &metadata,
+            pattern,
+            base_dir,
+            &mut planned_ancillary,
+        ) {
+            Ok(Some(file_move)) => moves.push(file_move),
+            Ok(None) => skipped += 1,
+            Err(msg) => errors.push((source.clone(), msg)),
         }
-
-        let sanitized = sanitize_relative_path(&relative);
-        let ext = source
-            .extension()
-            .and_then(|e| e.to_str())
-            .unwrap_or("flac");
-        let mut dest = base_dir.join(sanitized);
-        let stem = dest.as_os_str().to_os_string();
-        dest = PathBuf::from(format!("{}.{}", stem.to_string_lossy(), ext));
-
-        if paths_equal(source, &dest) {
-            skipped += 1;
-            continue;
-        }
-
-        let source_dir = source.parent().unwrap_or(Path::new("."));
-        let dest_dir = dest.parent().unwrap_or(Path::new("."));
-        let mut ancillary = Vec::new();
-
-        if source_dir != dest_dir {
-            for anc_path in find_ancillary_files(source_dir) {
-                if planned_ancillary.contains(&anc_path) {
-                    continue;
-                }
-                let Some(anc_name) = anc_path.file_name() else {
-                    continue;
-                };
-                let anc_dest = dest_dir.join(anc_name);
-                planned_ancillary.insert(anc_path.clone());
-                ancillary.push((anc_path, anc_dest));
-            }
-        }
-
-        moves.push(FileMove {
-            track_id: 0, // no DB identity
-            from: source.clone(),
-            to: dest,
-            ancillary,
-        });
     }
 
     Ok(OrganizeResult {

--- a/crates/koan-core/src/player/state.rs
+++ b/crates/koan-core/src/player/state.rs
@@ -784,3 +784,292 @@ impl SharedPlayerState {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- helpers ---
+
+    fn make_item(title: &str, load_state: LoadState) -> PlaylistItem {
+        PlaylistItem {
+            id: QueueItemId::new(),
+            path: PathBuf::from(format!("/music/{title}.flac")),
+            title: title.to_string(),
+            artist: "Artist".to_string(),
+            album_artist: "Artist".to_string(),
+            album: "Album".to_string(),
+            year: None,
+            codec: Some("FLAC".to_string()),
+            track_number: None,
+            disc: None,
+            duration_ms: Some(200_000),
+            load_state,
+        }
+    }
+
+    fn ready_item(title: &str) -> PlaylistItem {
+        make_item(title, LoadState::Ready)
+    }
+
+    fn pending_item(title: &str) -> PlaylistItem {
+        make_item(title, LoadState::Pending)
+    }
+
+    // --- advance_cursor ---
+
+    #[test]
+    fn test_advance_cursor_skips_non_ready() {
+        // playlist: Ready, Pending, Ready
+        // advance from None should land on index 0 (first Ready).
+        // advance again should skip Pending at index 1 and land on index 2.
+        let state = SharedPlayerState::new();
+        let item0 = ready_item("track-0");
+        let item1 = pending_item("track-1");
+        let item2 = ready_item("track-2");
+        let id0 = item0.id;
+        let id2 = item2.id;
+
+        state.add_items(vec![item0, item1, item2]);
+
+        // First advance — no cursor set yet, starts from beginning.
+        let result = state.advance_cursor();
+        assert!(result.is_some(), "expected to find first Ready item");
+        assert_eq!(result.unwrap().0, id0, "should land on first Ready item");
+
+        // Second advance — cursor is at index 0; Pending at index 1 must be skipped.
+        let result = state.advance_cursor();
+        assert!(
+            result.is_some(),
+            "expected to find next Ready item after skipping Pending"
+        );
+        assert_eq!(
+            result.unwrap().0,
+            id2,
+            "should skip Pending and land on third item"
+        );
+    }
+
+    #[test]
+    fn test_advance_cursor_stops_at_end_of_playlist() {
+        // With cursor already on the last Ready item, advance should return None.
+        let state = SharedPlayerState::new();
+        let item0 = ready_item("track-0");
+        let item1 = ready_item("track-1");
+        let id1 = item1.id;
+
+        state.add_items(vec![item0, item1]);
+
+        // Move cursor to last item.
+        state.set_cursor(Some(id1));
+
+        let result = state.advance_cursor();
+        assert!(
+            result.is_none(),
+            "advance past last item should return None"
+        );
+
+        // Cursor should remain unchanged after a failed advance.
+        assert_eq!(state.cursor(), Some(id1));
+    }
+
+    #[test]
+    fn test_advance_cursor_with_no_ready_items_returns_none() {
+        let state = SharedPlayerState::new();
+        state.add_items(vec![pending_item("pending-0"), pending_item("pending-1")]);
+
+        let result = state.advance_cursor();
+        assert!(
+            result.is_none(),
+            "should return None when no Ready items exist"
+        );
+    }
+
+    // --- retreat_cursor ---
+
+    #[test]
+    fn test_retreat_cursor_goes_to_previous_item() {
+        let state = SharedPlayerState::new();
+        let item0 = ready_item("track-0");
+        let item1 = ready_item("track-1");
+        let id0 = item0.id;
+        let id1 = item1.id;
+
+        state.add_items(vec![item0, item1]);
+        state.set_cursor(Some(id1));
+
+        let result = state.retreat_cursor();
+        assert!(result.is_some(), "expected to retreat to previous item");
+        assert_eq!(result.unwrap().0, id0, "should retreat to first item");
+        assert_eq!(state.cursor(), Some(id0));
+    }
+
+    #[test]
+    fn test_retreat_cursor_returns_none_when_at_first_item() {
+        let state = SharedPlayerState::new();
+        let item0 = ready_item("only-track");
+        let id0 = item0.id;
+
+        state.add_items(vec![item0]);
+        state.set_cursor(Some(id0));
+
+        let result = state.retreat_cursor();
+        assert!(result.is_none(), "cannot retreat before the first item");
+        // Cursor stays on the first item.
+        assert_eq!(state.cursor(), Some(id0));
+    }
+
+    #[test]
+    fn test_retreat_cursor_returns_none_when_cursor_is_unset() {
+        let state = SharedPlayerState::new();
+        state.add_items(vec![ready_item("track-0")]);
+
+        let result = state.retreat_cursor();
+        assert!(
+            result.is_none(),
+            "retreat with no cursor should return None"
+        );
+    }
+
+    // --- derive_visible_queue ---
+
+    #[test]
+    fn test_derive_visible_queue_statuses() {
+        // playlist: [played, playing, queued]
+        let state = SharedPlayerState::new();
+        let item0 = ready_item("played-track");
+        let item1 = ready_item("playing-track");
+        let item2 = ready_item("queued-track");
+        let id1 = item1.id;
+
+        state.add_items(vec![item0, item1, item2]);
+        state.set_cursor(Some(id1));
+
+        let snap = state.derive_visible_queue();
+
+        assert_eq!(snap.entries.len(), 3);
+        assert_eq!(snap.entries[0].status, QueueEntryStatus::Played);
+        assert_eq!(snap.entries[1].status, QueueEntryStatus::Playing);
+        assert_eq!(snap.entries[2].status, QueueEntryStatus::Queued);
+        assert!(snap.has_playing);
+        assert_eq!(snap.finished_count, 1);
+        assert_eq!(snap.queue_count, 1);
+    }
+
+    #[test]
+    fn test_derive_visible_queue_downloading_statuses() {
+        // A Downloading item at cursor → PriorityPending; after cursor → Downloading.
+        let state = SharedPlayerState::new();
+        let bytes_cursor = Arc::new(AtomicU64::new(0));
+        let bytes_queued = Arc::new(AtomicU64::new(0));
+        let dl_cursor = make_item(
+            "downloading-at-cursor",
+            LoadState::Downloading {
+                downloaded: 0,
+                total: 1_000_000,
+                bytes_written: bytes_cursor.clone(),
+            },
+        );
+        let dl_queued = make_item(
+            "downloading-queued",
+            LoadState::Downloading {
+                downloaded: 0,
+                total: 500_000,
+                bytes_written: bytes_queued.clone(),
+            },
+        );
+        let id_cursor = dl_cursor.id;
+
+        state.add_items(vec![dl_cursor, dl_queued]);
+        state.set_cursor(Some(id_cursor));
+
+        let snap = state.derive_visible_queue();
+
+        assert_eq!(snap.entries[0].status, QueueEntryStatus::PriorityPending);
+        assert_eq!(snap.entries[1].status, QueueEntryStatus::Downloading);
+    }
+
+    #[test]
+    fn test_derive_visible_queue_no_cursor_all_queued() {
+        let state = SharedPlayerState::new();
+        state.add_items(vec![ready_item("a"), ready_item("b"), ready_item("c")]);
+
+        let snap = state.derive_visible_queue();
+
+        assert_eq!(snap.entries.len(), 3);
+        for entry in &snap.entries {
+            assert_eq!(entry.status, QueueEntryStatus::Queued);
+        }
+        assert!(!snap.has_playing);
+        assert_eq!(snap.finished_count, 0);
+        assert_eq!(snap.queue_count, 3);
+    }
+
+    // --- move_item_to ---
+
+    #[test]
+    fn test_move_item_to_reorders_playlist() {
+        // Start: [A, B, C]. Move C to after A → [A, C, B].
+        let state = SharedPlayerState::new();
+        let item_a = ready_item("A");
+        let item_b = ready_item("B");
+        let item_c = ready_item("C");
+        let id_a = item_a.id;
+        let id_b = item_b.id;
+        let id_c = item_c.id;
+
+        state.add_items(vec![item_a, item_b, item_c]);
+        state.move_item_to(id_c, Some(id_a));
+
+        let (items, _) = state.snapshot_playlist();
+        let titles: Vec<&str> = items.iter().map(|i| i.title.as_str()).collect();
+        assert_eq!(titles, vec!["A", "C", "B"]);
+        assert_eq!(items[0].id, id_a);
+        assert_eq!(items[1].id, id_c);
+        assert_eq!(items[2].id, id_b);
+    }
+
+    #[test]
+    fn test_move_item_to_front_when_after_is_none() {
+        // Start: [A, B, C]. Move C to front (after=None) → [C, A, B].
+        let state = SharedPlayerState::new();
+        let item_a = ready_item("A");
+        let item_b = ready_item("B");
+        let item_c = ready_item("C");
+        let id_c = item_c.id;
+
+        state.add_items(vec![item_a, item_b, item_c]);
+        state.move_item_to(id_c, None);
+
+        let (items, _) = state.snapshot_playlist();
+        let titles: Vec<&str> = items.iter().map(|i| i.title.as_str()).collect();
+        assert_eq!(titles, vec!["C", "A", "B"]);
+    }
+
+    // --- move_items (batch) ---
+
+    #[test]
+    fn test_move_items_batch_preserves_relative_order() {
+        // Start: [A, B, C, D]. Move [A, C] after D → [B, D, A, C].
+        let state = SharedPlayerState::new();
+        let item_a = ready_item("A");
+        let item_b = ready_item("B");
+        let item_c = ready_item("C");
+        let item_d = ready_item("D");
+        let id_a = item_a.id;
+        let id_b = item_b.id;
+        let id_c = item_c.id;
+        let id_d = item_d.id;
+
+        state.add_items(vec![item_a, item_b, item_c, item_d]);
+        state.move_items(&[id_a, id_c], id_d, true);
+
+        let (items, _) = state.snapshot_playlist();
+        let titles: Vec<&str> = items.iter().map(|i| i.title.as_str()).collect();
+        assert_eq!(titles, vec!["B", "D", "A", "C"]);
+        assert_eq!(items[0].id, id_b);
+        assert_eq!(items[1].id, id_d);
+        assert_eq!(items[2].id, id_a);
+        assert_eq!(items[3].id, id_c);
+    }
+}

--- a/crates/koan-core/src/remote/client.rs
+++ b/crates/koan-core/src/remote/client.rs
@@ -332,6 +332,285 @@ pub struct SubsonicStarred {
     pub song: Vec<SubsonicSong>,
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- SubsonicSong deserialization ---
+
+    #[test]
+    fn test_deserialize_subsonic_song() {
+        let json = r#"{
+            "id": "42",
+            "title": "Space Oddity",
+            "album": "Space Oddity",
+            "artist": "David Bowie",
+            "track": 1,
+            "discNumber": 1,
+            "year": 1969,
+            "genre": "Rock",
+            "duration": 314,
+            "bitRate": 320,
+            "suffix": "mp3",
+            "contentType": "audio/mpeg",
+            "albumId": "7",
+            "artistId": "3"
+        }"#;
+
+        let song: SubsonicSong = serde_json::from_str(json).unwrap();
+
+        assert_eq!(song.id, "42");
+        assert_eq!(song.title, "Space Oddity");
+        assert_eq!(song.album.as_deref(), Some("Space Oddity"));
+        assert_eq!(song.artist.as_deref(), Some("David Bowie"));
+        assert_eq!(song.track, Some(1));
+        assert_eq!(song.disc_number, Some(1));
+        assert_eq!(song.year, Some(1969));
+        assert_eq!(song.genre.as_deref(), Some("Rock"));
+        assert_eq!(song.duration, Some(314));
+        assert_eq!(song.bit_rate, Some(320));
+        assert_eq!(song.suffix.as_deref(), Some("mp3"));
+        assert_eq!(song.content_type.as_deref(), Some("audio/mpeg"));
+        assert_eq!(song.album_id.as_deref(), Some("7"));
+        assert_eq!(song.artist_id.as_deref(), Some("3"));
+    }
+
+    #[test]
+    fn test_deserialize_subsonic_song_optional_fields_absent() {
+        // Only the required fields (id, title) — all Option fields should be None.
+        let json = r#"{"id": "99", "title": "Minimal Track"}"#;
+
+        let song: SubsonicSong = serde_json::from_str(json).unwrap();
+
+        assert_eq!(song.id, "99");
+        assert_eq!(song.title, "Minimal Track");
+        assert!(song.album.is_none());
+        assert!(song.artist.is_none());
+        assert!(song.track.is_none());
+        assert!(song.disc_number.is_none());
+        assert!(song.year.is_none());
+        assert!(song.duration.is_none());
+        assert!(song.bit_rate.is_none());
+    }
+
+    // --- SubsonicAlbum deserialization ---
+
+    #[test]
+    fn test_deserialize_album_list() {
+        let json = r#"{
+            "subsonic-response": {
+                "status": "ok",
+                "version": "1.16.1",
+                "albumList2": {
+                    "album": [
+                        {
+                            "id": "1",
+                            "name": "Abbey Road",
+                            "artist": "The Beatles",
+                            "artistId": "10",
+                            "songCount": 17,
+                            "year": 1969,
+                            "genre": "Rock",
+                            "created": "2020-01-01T00:00:00"
+                        },
+                        {
+                            "id": "2",
+                            "name": "Led Zeppelin IV",
+                            "artist": "Led Zeppelin",
+                            "artistId": "11",
+                            "songCount": 8,
+                            "year": 1971,
+                            "genre": "Hard Rock",
+                            "created": "2020-01-02T00:00:00"
+                        }
+                    ]
+                }
+            }
+        }"#;
+
+        let wrapper: SubsonicResponseWrapper = serde_json::from_str(json).unwrap();
+        let album_list = wrapper
+            .subsonic_response
+            .album_list2
+            .expect("album_list2 should be present");
+
+        assert_eq!(album_list.album.len(), 2);
+
+        let first = &album_list.album[0];
+        assert_eq!(first.id, "1");
+        assert_eq!(first.name, "Abbey Road");
+        assert_eq!(first.artist.as_deref(), Some("The Beatles"));
+        assert_eq!(first.artist_id.as_deref(), Some("10"));
+        assert_eq!(first.song_count, Some(17));
+        assert_eq!(first.year, Some(1969));
+
+        let second = &album_list.album[1];
+        assert_eq!(second.id, "2");
+        assert_eq!(second.name, "Led Zeppelin IV");
+        assert_eq!(second.song_count, Some(8));
+    }
+
+    // --- SubsonicClient auth params ---
+
+    #[test]
+    fn test_auth_params_format() {
+        let client = SubsonicClient::new("http://localhost:4533", "alice", "secret");
+        let params = client.auth_params();
+
+        // Must contain exactly these six keys.
+        assert!(params.contains_key("u"), "missing 'u' param");
+        assert!(params.contains_key("t"), "missing 't' param");
+        assert!(params.contains_key("s"), "missing 's' param");
+        assert!(params.contains_key("v"), "missing 'v' param");
+        assert!(params.contains_key("c"), "missing 'c' param");
+        assert!(params.contains_key("f"), "missing 'f' param");
+        assert_eq!(params.len(), 6);
+
+        assert_eq!(params["u"], "alice");
+        assert_eq!(params["v"], "1.16.1");
+        assert_eq!(params["c"], "koan");
+        assert_eq!(params["f"], "json");
+    }
+
+    #[test]
+    fn test_auth_params_token_is_md5_of_password_plus_salt() {
+        let client = SubsonicClient::new("http://localhost:4533", "bob", "letmein");
+        let params = client.auth_params();
+
+        let salt = &params["s"];
+        let token = &params["t"];
+
+        // The token must equal md5(password + salt).
+        let expected = format!("{:x}", md5::compute(format!("letmein{}", salt)));
+        assert_eq!(token, &expected);
+    }
+
+    #[test]
+    fn test_auth_params_salt_is_different_each_call() {
+        let client = SubsonicClient::new("http://localhost:4533", "user", "pass");
+        let params1 = client.auth_params();
+        let params2 = client.auth_params();
+
+        // Salts should differ across calls (random); tokens will differ too.
+        // There is a negligible probability they collide — acceptable in tests.
+        assert_ne!(params1["s"], params2["s"], "salt should be random per call");
+    }
+
+    // --- stream_url ---
+
+    #[test]
+    fn test_stream_url_has_auth() {
+        let client = SubsonicClient::new("http://myserver:4533", "user", "pass");
+        let url = client.stream_url("track-123");
+
+        assert!(url.contains("track-123"), "url must include the track id");
+        assert!(url.contains("u=user"), "url must include username param");
+        assert!(url.contains("v=1.16.1"), "url must include api version");
+        assert!(url.contains("c=koan"), "url must include client name");
+        assert!(url.contains("f=json"), "url must include format param");
+        assert!(url.contains("/rest/stream"), "url must target /rest/stream");
+        assert!(
+            url.starts_with("http://myserver:4533"),
+            "url must use the configured base_url"
+        );
+    }
+
+    #[test]
+    fn test_stream_url_base_url_trailing_slash_normalised() {
+        // SubsonicClient::new strips trailing slashes from base_url.
+        let client_with_slash = SubsonicClient::new("http://myserver:4533/", "u", "p");
+        let client_no_slash = SubsonicClient::new("http://myserver:4533", "u", "p");
+
+        let url_with = client_with_slash.stream_url("1");
+        let url_without = client_no_slash.stream_url("1");
+
+        // Both should produce the same path prefix (no double slash).
+        assert!(
+            url_with.contains("/rest/stream"),
+            "should not have double slash"
+        );
+        assert!(!url_with.contains("//rest"), "should not have double slash");
+        // Both base URLs normalise to the same path structure.
+        assert_eq!(
+            url_with.split('?').next(),
+            url_without.split('?').next(),
+            "path segment should be identical regardless of trailing slash"
+        );
+    }
+
+    // --- SubsonicAlbumFull deserialization ---
+
+    #[test]
+    fn test_deserialize_album_full_with_songs() {
+        let json = r#"{
+            "id": "5",
+            "name": "Kind of Blue",
+            "artist": "Miles Davis",
+            "artistId": "20",
+            "year": 1959,
+            "genre": "Jazz",
+            "songCount": 5,
+            "created": "2021-06-01T00:00:00",
+            "song": [
+                {"id": "101", "title": "So What"},
+                {"id": "102", "title": "Freddie Freeloader"},
+                {"id": "103", "title": "Blue in Green"}
+            ]
+        }"#;
+
+        let album: SubsonicAlbumFull = serde_json::from_str(json).unwrap();
+
+        assert_eq!(album.id, "5");
+        assert_eq!(album.name, "Kind of Blue");
+        assert_eq!(album.artist.as_deref(), Some("Miles Davis"));
+        assert_eq!(album.year, Some(1959));
+        assert_eq!(album.song.len(), 3);
+        assert_eq!(album.song[0].title, "So What");
+        assert_eq!(album.song[2].id, "103");
+    }
+
+    #[test]
+    fn test_deserialize_album_full_empty_song_list() {
+        // When `song` key is absent, the #[serde(default)] should yield an empty Vec.
+        let json = r#"{"id": "9", "name": "No Tracks Yet"}"#;
+
+        let album: SubsonicAlbumFull = serde_json::from_str(json).unwrap();
+
+        assert_eq!(album.id, "9");
+        assert!(album.song.is_empty(), "song list should default to empty");
+    }
+
+    // --- SubsonicSearchResult deserialization ---
+
+    #[test]
+    fn test_deserialize_search_result_mixed() {
+        let json = r#"{
+            "artist": [{"id": "1", "name": "Artist One"}],
+            "album":  [{"id": "2", "name": "Album One"}],
+            "song":   [{"id": "3", "title": "Song One"}]
+        }"#;
+
+        let result: SubsonicSearchResult = serde_json::from_str(json).unwrap();
+
+        assert_eq!(result.artist.len(), 1);
+        assert_eq!(result.artist[0].name, "Artist One");
+        assert_eq!(result.album.len(), 1);
+        assert_eq!(result.album[0].name, "Album One");
+        assert_eq!(result.song.len(), 1);
+        assert_eq!(result.song[0].title, "Song One");
+    }
+
+    #[test]
+    fn test_deserialize_search_result_defaults_to_empty() {
+        // All three lists are #[serde(default)], so an empty object is valid.
+        let result: SubsonicSearchResult = serde_json::from_str("{}").unwrap();
+
+        assert!(result.artist.is_empty());
+        assert!(result.album.is_empty());
+        assert!(result.song.is_empty());
+    }
+}
+
 /// Generate a random hex salt string for Subsonic auth.
 fn random_salt() -> String {
     let mut buf = [0u8; 12];

--- a/crates/koan-core/src/remote/client.rs
+++ b/crates/koan-core/src/remote/client.rs
@@ -332,6 +332,13 @@ pub struct SubsonicStarred {
     pub song: Vec<SubsonicSong>,
 }
 
+/// Generate a random hex salt string for Subsonic auth.
+fn random_salt() -> String {
+    let mut buf = [0u8; 12];
+    getrandom::getrandom(&mut buf).expect("failed to generate random salt");
+    buf.iter().map(|b| format!("{:02x}", b)).collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -609,11 +616,4 @@ mod tests {
         assert!(result.album.is_empty());
         assert!(result.song.is_empty());
     }
-}
-
-/// Generate a random hex salt string for Subsonic auth.
-fn random_salt() -> String {
-    let mut buf = [0u8; 12];
-    getrandom::getrandom(&mut buf).expect("failed to generate random salt");
-    buf.iter().map(|b| format!("{:02x}", b)).collect()
 }

--- a/crates/koan-music/Cargo.toml
+++ b/crates/koan-music/Cargo.toml
@@ -28,6 +28,5 @@ ratatui = "0.29"
 rpassword = "7.4"
 souvlaki = "0.8"
 core-foundation = "0.9"
-rusqlite = { version = "0.38", features = ["bundled-full"] }
 toml = "0.9"
-walkdir = "2"
+walkdir = { workspace = true }

--- a/crates/koan-music/src/commands/cache.rs
+++ b/crates/koan-music/src/commands/cache.rs
@@ -1,4 +1,5 @@
 use koan_core::config;
+use koan_core::db::queries;
 use owo_colors::OwoColorize;
 
 use super::{confirm, format_bytes, open_db};
@@ -89,9 +90,7 @@ pub fn cmd_cache_clear(skip_confirm: bool) {
 
     // Clear cached_path in DB so tracks get re-downloaded next time.
     let db = open_db();
-    let _ = db
-        .conn
-        .execute("UPDATE tracks SET cached_path = NULL", rusqlite::params![]);
+    let _ = queries::clear_cached_paths(&db.conn);
 
     println!(
         "{} {} {}",

--- a/crates/koan-music/src/commands/enqueue.rs
+++ b/crates/koan-music/src/commands/enqueue.rs
@@ -34,16 +34,9 @@ pub fn enqueue_playlist(
         let Some(track) = queries::get_track_row(&db.conn, id).ok().flatten() else {
             continue;
         };
-        let album_date: Option<String> = track.album_id.and_then(|aid| {
-            db.conn
-                .query_row(
-                    "SELECT date FROM albums WHERE id = ?1",
-                    rusqlite::params![aid],
-                    |row| row.get(0),
-                )
-                .ok()
-                .flatten()
-        });
+        let album_date: Option<String> = track
+            .album_id
+            .and_then(|aid| queries::album_date(&db.conn, aid).ok().flatten());
 
         // Resolve the path — local, cached, or needs download.
         let (dest, load_state) = resolve_item_path(&db, &cfg, id, &track, album_date.as_deref());
@@ -214,16 +207,9 @@ fn download_single_track(
         }
     };
 
-    let album_date: Option<String> = track.album_id.and_then(|aid| {
-        db.conn
-            .query_row(
-                "SELECT date FROM albums WHERE id = ?1",
-                rusqlite::params![aid],
-                |row| row.get(0),
-            )
-            .ok()
-            .flatten()
-    });
+    let album_date: Option<String> = track
+        .album_id
+        .and_then(|aid| queries::album_date(&db.conn, aid).ok().flatten());
 
     let dest = cache_path_for_track(&cfg.cache_dir(), &track, album_date.as_deref());
 

--- a/crates/koan-music/src/tui/app.rs
+++ b/crates/koan-music/src/tui/app.rs
@@ -110,6 +110,7 @@ pub struct QueueState {
     pub drag: Option<DragState>,
     /// Cached visible queue snapshot — refreshed once per frame.
     pub(super) vq_cache: VisibleQueueSnapshot,
+    pub(super) vq_version: u64,
 }
 
 /// Cached layout rects from last render, used for mouse hit-testing.
@@ -2306,7 +2307,11 @@ impl App {
     /// Refresh the cached visible queue snapshot from shared state.
     /// Call once per frame before any queue-related reads.
     pub fn refresh_visible_queue(&mut self) {
-        self.queue.vq_cache = self.state.derive_visible_queue();
+        let v = self.state.playlist_version();
+        if v != self.queue.vq_version {
+            self.queue.vq_cache = self.state.derive_visible_queue();
+            self.queue.vq_version = v;
+        }
     }
 
     pub fn visible_queue(&self) -> Vec<QueueEntry> {

--- a/crates/koan-music/src/tui/queue.rs
+++ b/crates/koan-music/src/tui/queue.rs
@@ -131,14 +131,14 @@ impl<'a> QueueView<'a> {
 /// (so callers can look up album info for rendering).
 fn build_display_lines(entries: &[QueueEntry]) -> Vec<(Option<usize>, bool)> {
     let mut lines = Vec::new();
-    let mut current_album_key: Option<(String, String)> = None;
+    let mut current_album_key: Option<(&str, &str)> = None;
 
     for (i, entry) in entries.iter().enumerate() {
-        let album_key = (entry.album_artist.clone(), entry.album.clone());
+        let album_key = (entry.album_artist.as_str(), entry.album.as_str());
         let show_header = if entry.album.is_empty() {
             false
         } else {
-            current_album_key.as_ref() != Some(&album_key)
+            current_album_key != Some(album_key)
         };
 
         if show_header {

--- a/crates/koan-music/src/tui/ui.rs
+++ b/crates/koan-music/src/tui/ui.rs
@@ -92,8 +92,15 @@ pub fn render(frame: &mut Frame, app: &mut App) {
     app.layout.transport_text_area = text_area;
 
     // Seek bar metrics + transport widget — rendered once.
+    // Prefer the queue entry's DB-sourced duration over the probed duration so
+    // bar_metrics and the rendered time string agree (probing a partial streaming
+    // file returns a truncated duration).
     let pos_ms = app.state.position_ms();
-    let dur_ms = track_info.as_ref().map_or(0, |t| t.duration_ms);
+    let dur_ms = playing_entry
+        .as_ref()
+        .and_then(|e| e.duration_ms)
+        .or_else(|| track_info.as_ref().map(|t| t.duration_ms))
+        .unwrap_or(0);
     let (bs, bw) = TransportBar::bar_metrics(text_area, pos_ms, dur_ms);
     app.layout.seek_bar_start = bs;
     app.layout.seek_bar_width = bw;

--- a/crates/koan-music/src/tui/visualizer.rs
+++ b/crates/koan-music/src/tui/visualizer.rs
@@ -22,11 +22,11 @@ const EIGHTH_BLOCKS: &[char] = &[' ', '▁', '▂', '▃', '▄', '▅', '▆', 
 /// (clone of ~200 bytes), then does all decay/smoothing on local copies with no locks held.
 pub struct VisualizerState {
     /// Current spectrum bar values (0.0..1.0), one per bar.
-    pub spectrum: Vec<f32>,
+    pub spectrum: [f32; NUM_BARS],
     /// Previous frame's spectrum for decay smoothing.
-    prev_spectrum: Vec<f32>,
+    prev_spectrum: [f32; NUM_BARS],
     /// Peak hold values (slowly decaying maxima).
-    pub peaks: Vec<f32>,
+    pub peaks: [f32; NUM_BARS],
     /// RMS levels for VU meters: [left, right].
     pub vu_levels: [f32; 2],
     /// Last update timestamp for time-based decay.
@@ -46,9 +46,9 @@ impl VisualizerState {
 
     pub fn with_config(bar_half_life: f32, peak_half_life: f32) -> Self {
         Self {
-            spectrum: vec![0.0; NUM_BARS],
-            prev_spectrum: vec![0.0; NUM_BARS],
-            peaks: vec![0.0; NUM_BARS],
+            spectrum: [0.0; NUM_BARS],
+            prev_spectrum: [0.0; NUM_BARS],
+            peaks: [0.0; NUM_BARS],
             vu_levels: [0.0; 2],
             last_update: Instant::now(),
             bar_half_life,
@@ -257,7 +257,7 @@ mod tests {
         let snapshot = VizSnapshot::new();
 
         // Write a frame with some energy.
-        let mut spectrum = vec![0.0f32; NUM_BARS];
+        let mut spectrum = [0.0f32; NUM_BARS];
         spectrum[10] = 0.8;
         spectrum[20] = 0.5;
         snapshot.write(VizFrame {
@@ -278,7 +278,7 @@ mod tests {
         let snapshot = VizSnapshot::new();
 
         // Seed some energy.
-        let spectrum = vec![1.0f32; NUM_BARS];
+        let spectrum = [1.0f32; NUM_BARS];
         snapshot.write(VizFrame {
             spectrum,
             vu_levels: [1.0, 1.0],
@@ -309,7 +309,7 @@ mod tests {
         let snapshot = VizSnapshot::new();
 
         // Push a loud frame.
-        let mut spectrum = vec![0.0f32; NUM_BARS];
+        let mut spectrum = [0.0f32; NUM_BARS];
         spectrum[5] = 0.9;
         snapshot.write(VizFrame {
             spectrum,
@@ -322,7 +322,7 @@ mod tests {
 
         // Push silence — peak should hold or slowly decay, not jump to zero.
         snapshot.write(VizFrame {
-            spectrum: vec![0.0; NUM_BARS],
+            spectrum: [0.0; NUM_BARS],
             vu_levels: [0.0; 2],
             timestamp: Instant::now(),
         });


### PR DESCRIPTION
## Codebase Audit v0.5.2 — Combined Changes

This PR combines all audit phases into a single branch for integration testing. Individual phase PRs are available for isolated review.

### Phase 1: Security & Quick Wins (#13 ✅ merged)
- Credentials removed from stored remote URLs
- Config/DB file permissions restricted to 0o600 on Unix
- FTS5 and LIKE query inputs sanitized
- Secure random salt, PID-namespaced temp files, HTTPS warnings
- 6 dead code items removed, 2 panicking unwraps fixed
- Symphonia features scoped to used codecs only

### Phase 5: Test Coverage (#14)
- 332 → 371 tests (+39, -4 AI-generated duplicates)
- New coverage: PlaybackTimeline, SharedPlayerState, favourites, Subsonic client, metadata probe

### Phase 2: Performance (#15)
- playlist_version gate skips redundant O(n) visible queue rebuild
- Borrowed string keys eliminate 2 allocations per entry per call
- Spectrum data changed from heap Vec to stack arrays [f32; 48]

### Phase 3: Architecture (#16)
- row_to_track_row helper deduplicates 4×22-line closures in tracks.rs
- plan_single_move helper consolidates duplicated organize logic

### Phase 4: Dependencies (#17)
- rusqlite removed from koan-music (3 calls → koan-core functions)
- rusqlite features: bundled-full → bundled
- Workspace dependencies added for centralized version management

### Deferred
- app.rs decomposition (2,319 lines) — dedicated PR recommended
- player/mod.rs cleanup — undo already modularized, limited further payoff

## Test plan
- [x] 371 tests pass
- [x] clippy clean
- [x] fmt clean

Full audit plan: #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)