### PR TITLE
refactor: unsafe code audit — eliminate manual CFString, add SAFETY docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1336,6 +1336,7 @@ dependencies = [
 name = "koan-core"
 version = "0.9.2"
 dependencies = [
+ "core-foundation 0.9.4",
  "coreaudio-sys",
  "crossbeam-channel",
  "dirs",

--- a/crates/koan-core/Cargo.toml
+++ b/crates/koan-core/Cargo.toml
@@ -10,6 +10,7 @@ categories = ["multimedia::audio"]
 
 [dependencies]
 # CoreAudio
+core-foundation = "0.9"
 coreaudio-sys = "0.2"
 crossbeam-channel = "0.5"
 # Config

--- a/crates/koan-core/src/audio/buffer.rs
+++ b/crates/koan-core/src/audio/buffer.rs
@@ -671,6 +671,9 @@ fn decode_single(
                         slot.write(val);
                     }
                 }
+                // SAFETY: All slots in the chunk have been initialized by the
+                // two loops above — first.len() + second.len() == chunk_size,
+                // and every slot is written via MaybeUninit::write().
                 unsafe { chunk.commit_all() };
                 offset += chunk_size;
             }

--- a/crates/koan-core/src/audio/device.rs
+++ b/crates/koan-core/src/audio/device.rs
@@ -169,8 +169,9 @@ fn device_name(device_id: AudioDeviceID) -> Result<String> {
     // CFRelease on drop, so no manual release is needed. The pointer cast bridges
     // coreaudio-sys's CFStringRef and core-foundation's CFStringRef which are
     // identical C types from different bindgen runs.
-    let cf_string: CFString =
-        unsafe { CFString::wrap_under_create_rule(name_ref as core_foundation::string::CFStringRef) };
+    let cf_string: CFString = unsafe {
+        CFString::wrap_under_create_rule(name_ref as core_foundation::string::CFStringRef)
+    };
     Ok(cf_string.to_string())
 }
 

--- a/crates/koan-core/src/audio/device.rs
+++ b/crates/koan-core/src/audio/device.rs
@@ -1,6 +1,8 @@
 use std::mem;
 use std::ptr;
 
+use core_foundation::base::TCFType;
+use core_foundation::string::CFString;
 use coreaudio_sys::*;
 use thiserror::Error;
 
@@ -44,6 +46,8 @@ pub fn default_output_device() -> Result<AudioDeviceID> {
     let mut device_id: AudioDeviceID = 0;
     let mut size = mem::size_of::<AudioDeviceID>() as u32;
 
+    // SAFETY: `device_id` is a stack-allocated AudioDeviceID with correct size.
+    // CoreAudio writes a single u32 device ID into the provided buffer.
     check(unsafe {
         AudioObjectGetPropertyData(
             kAudioObjectSystemObject,
@@ -71,6 +75,7 @@ pub fn list_output_devices() -> Result<Vec<AudioDevice>> {
     };
 
     let mut size: u32 = 0;
+    // SAFETY: Querying data size only — no output buffer, just writes to `size`.
     check(unsafe {
         AudioObjectGetPropertyDataSize(
             kAudioObjectSystemObject,
@@ -84,6 +89,8 @@ pub fn list_output_devices() -> Result<Vec<AudioDevice>> {
     let device_count = size as usize / mem::size_of::<AudioDeviceID>();
     let mut device_ids = vec![0u32; device_count];
 
+    // SAFETY: `device_ids` is pre-allocated to exactly the size returned by
+    // GetPropertyDataSize. CoreAudio fills it with `device_count` AudioDeviceIDs.
     check(unsafe {
         AudioObjectGetPropertyData(
             kAudioObjectSystemObject,
@@ -121,6 +128,7 @@ fn has_output_streams(device_id: AudioDeviceID) -> bool {
     };
 
     let mut size: u32 = 0;
+    // SAFETY: Querying data size only — no output buffer, just writes to `size`.
     let status =
         unsafe { AudioObjectGetPropertyDataSize(device_id, &property, 0, ptr::null(), &mut size) };
 
@@ -138,6 +146,9 @@ fn device_name(device_id: AudioDeviceID) -> Result<String> {
     let mut name_ref: CFStringRef = ptr::null();
     let mut size = mem::size_of::<CFStringRef>() as u32;
 
+    // SAFETY: Standard CoreAudio property query. `name_ref` is a correctly-sized
+    // output buffer for a single CFStringRef. CoreAudio writes the pointer and
+    // transfers ownership to the caller (Create Rule).
     check(unsafe {
         AudioObjectGetPropertyData(
             device_id,
@@ -149,41 +160,18 @@ fn device_name(device_id: AudioDeviceID) -> Result<String> {
         )
     })?;
 
-    let name = unsafe { cfstring_to_string(name_ref) };
-    if !name_ref.is_null() {
-        unsafe { CFRelease(name_ref as *const _) };
-    }
-    Ok(name)
-}
-
-/// Convert a CFStringRef to a Rust String.
-unsafe fn cfstring_to_string(cf_str: CFStringRef) -> String {
-    if cf_str.is_null() {
-        return String::new();
+    if name_ref.is_null() {
+        return Ok(String::new());
     }
 
-    let len = unsafe { CFStringGetLength(cf_str) };
-    let mut buf = vec![0u8; (len as usize) * 4];
-    let mut used: CFIndex = 0;
-
-    unsafe {
-        CFStringGetBytes(
-            cf_str,
-            CFRange {
-                location: 0,
-                length: len,
-            },
-            kCFStringEncodingUTF8,
-            0,
-            false as Boolean,
-            buf.as_mut_ptr(),
-            buf.len() as CFIndex,
-            &mut used,
-        );
-    }
-
-    buf.truncate(used as usize);
-    String::from_utf8_lossy(&buf).into_owned()
+    // SAFETY: `name_ref` was returned by a CoreAudio Create Rule API — the caller
+    // owns the reference. `wrap_under_create_rule` takes ownership and will
+    // CFRelease on drop, so no manual release is needed. The pointer cast bridges
+    // coreaudio-sys's CFStringRef and core-foundation's CFStringRef which are
+    // identical C types from different bindgen runs.
+    let cf_string: CFString =
+        unsafe { CFString::wrap_under_create_rule(name_ref as core_foundation::string::CFStringRef) };
+    Ok(cf_string.to_string())
 }
 
 /// Get available sample rates for a device.
@@ -195,6 +183,7 @@ pub fn available_sample_rates(device_id: AudioDeviceID) -> Result<Vec<f64>> {
     };
 
     let mut size: u32 = 0;
+    // SAFETY: Querying data size only — no output buffer, just writes to `size`.
     check(unsafe {
         AudioObjectGetPropertyDataSize(device_id, &property, 0, ptr::null(), &mut size)
     })?;
@@ -208,6 +197,8 @@ pub fn available_sample_rates(device_id: AudioDeviceID) -> Result<Vec<f64>> {
         count
     ];
 
+    // SAFETY: `ranges` is pre-allocated to exactly the size returned by
+    // GetPropertyDataSize. CoreAudio fills it with `count` AudioValueRange structs.
     check(unsafe {
         AudioObjectGetPropertyData(
             device_id,
@@ -237,6 +228,7 @@ pub fn get_device_sample_rate(device_id: AudioDeviceID) -> Result<f64> {
     let mut rate: f64 = 0.0;
     let mut size = mem::size_of::<f64>() as u32;
 
+    // SAFETY: `rate` is a stack-allocated f64 with correct size for the property.
     check(unsafe {
         AudioObjectGetPropertyData(
             device_id,
@@ -269,6 +261,7 @@ pub fn set_device_sample_rate(device_id: AudioDeviceID, rate: f64) -> Result<()>
         mElement: kAudioObjectPropertyElementMain,
     };
 
+    // SAFETY: `rate` is a stack-allocated f64 with correct size for the property.
     check(unsafe {
         AudioObjectSetPropertyData(
             device_id,

--- a/crates/koan-core/src/audio/engine.rs
+++ b/crates/koan-core/src/audio/engine.rs
@@ -38,8 +38,11 @@ struct CallbackData {
     samples_played: Arc<AtomicU64>,
 }
 
-// SAFETY: Consumer is only ever accessed from the CoreAudio render callback thread
-// (single-consumer). The raw pointer prevents auto-Send but the access pattern is safe.
+// SAFETY: `rtrb::Consumer` is `!Send` due to internal raw pointers, but our usage is
+// sound: the Consumer is moved into CallbackData on the creating thread, then only
+// ever accessed from the single CoreAudio render callback thread. It is never shared
+// or accessed from multiple threads simultaneously. If this invariant changes (e.g.
+// Consumer accessed outside the callback), this impl must be revisited.
 unsafe impl Send for CallbackData {}
 
 /// CoreAudio AUHAL output engine.
@@ -52,10 +55,12 @@ pub struct AudioEngine {
     running: Arc<AtomicBool>,
 }
 
-// SAFETY: AudioEngine is created on one thread and may be moved to the player thread
-// before start() is called. After start(), the AudioUnit and callback_data pointer are
-// only accessed from the CoreAudio render thread via the installed callback. The engine
-// itself is only used for start/stop/drop which are safe across threads.
+// SAFETY: AudioEngine contains an AudioUnit (opaque C pointer) and a *mut CallbackData.
+// The engine is created on one thread, moved to the player thread, then only used for
+// start/stop/drop — all of which are sequentially called from one thread at a time.
+// The AudioUnit and callback_data are accessed by the CoreAudio RT thread only through
+// the installed render callback, which is removed before drop. AudioEngine is not Clone
+// and not shared — it has a single owner at all times.
 unsafe impl Send for AudioEngine {}
 
 impl AudioEngine {
@@ -76,6 +81,11 @@ impl AudioEngine {
             componentFlags: 0,
             componentFlagsMask: 0,
         };
+
+        // SAFETY: All CoreAudio FFI calls below pass stack-allocated structs with
+        // correct sizes via mem::size_of. Pointers are valid for the duration of each
+        // call. Return values are checked via check(). The AudioUnit is created, configured,
+        // and initialized in sequence — no concurrent access is possible during setup.
 
         let component = unsafe { AudioComponentFindNext(ptr::null_mut(), &desc) };
         if component.is_null() {
@@ -182,6 +192,8 @@ impl Drop for AudioEngine {
             inputProc: None,
             inputProcRefCon: ptr::null_mut(),
         };
+        // SAFETY: Removing the callback from a valid AudioUnit. Even if the unit
+        // is in a degraded state, setting a null callback is a no-op at worst.
         unsafe {
             AudioUnitSetProperty(
                 self.audio_unit,
@@ -199,6 +211,10 @@ impl Drop for AudioEngine {
         // above is belt-and-suspenders for the (extremely rare) case where
         // stop() returns an error and the unit is in a degraded state.
 
+        // SAFETY: AudioUnit was successfully created in new(). Uninitialize and
+        // Dispose are the documented teardown sequence. callback_data was created
+        // via Box::into_raw in new() and is not aliased — the render callback
+        // has been removed and AudioOutputUnitStop guarantees it's not in flight.
         unsafe {
             AudioUnitUninitialize(self.audio_unit);
             AudioComponentInstanceDispose(self.audio_unit);
@@ -219,7 +235,12 @@ unsafe extern "C" fn render_callback(
     in_number_frames: UInt32,
     io_data: *mut AudioBufferList,
 ) -> OSStatus {
+    // SAFETY: `in_ref_con` points to a heap-allocated CallbackData created via
+    // Box::into_raw in AudioEngine::new. It remains valid for the lifetime of the
+    // engine — the callback is removed and the pointer freed only in Drop, after
+    // AudioOutputUnitStop guarantees no callbacks are in flight.
     let data = unsafe { &mut *(in_ref_con as *mut CallbackData) };
+    // SAFETY: `io_data` is provided by CoreAudio and is valid for the callback's duration.
     let buffer_list = unsafe { &mut *io_data };
 
     if !data.running.load(Ordering::Relaxed) {
@@ -234,9 +255,15 @@ unsafe extern "C" fn render_callback(
         return 0;
     }
 
+    // SAFETY: Accessing the first buffer in the CoreAudio-provided AudioBufferList.
+    // We configured a non-interleaved float format, so mNumberBuffers >= 1.
     let buf = unsafe { &mut *buffer_list.mBuffers.as_mut_ptr() };
     let channels = buf.mNumberChannels;
     let total_samples = (in_number_frames * channels) as usize;
+    debug_assert!(
+        (buf.mData as usize).is_multiple_of(mem::align_of::<f32>()),
+        "CoreAudio buffer not aligned for f32"
+    );
     let out_ptr = buf.mData as *mut f32;
 
     let available = data.consumer.slots();

--- a/crates/koan-music/src/media_keys.rs
+++ b/crates/koan-music/src/media_keys.rs
@@ -17,6 +17,9 @@ use souvlaki::{
 #[cfg(target_os = "macos")]
 pub fn pump_run_loop() {
     use core_foundation::runloop::{CFRunLoopRunInMode, kCFRunLoopDefaultMode};
+    // SAFETY: CFRunLoopRunInMode is inherently safe — it pumps the current thread's
+    // run loop with a tiny timeout. The unsafe is only required because it's a C FFI
+    // call. No preconditions can be violated.
     unsafe {
         CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.001, 1);
     }


### PR DESCRIPTION
## Summary

- **Eliminate manual CFString handling** — replace hand-rolled `cfstring_to_string` + `CFRelease` in `device.rs` with `core-foundation`'s safe `CFString::wrap_under_create_rule` API, deleting 28 lines of unsafe CoreFoundation string code
- **Add `core-foundation` dep to `koan-core`** (already a transitive dependency)
- **Add `// SAFETY:` comments to every unsafe block** across `engine.rs`, `device.rs`, `buffer.rs`, and `media_keys.rs` documenting invariants
- **Upgrade `unsafe impl Send` comments** to formal safety contracts explaining exactly when soundness would be violated
- **Add `debug_assert` for f32 alignment** in the render callback — zero cost in release, catches hypothetical CoreAudio format mismatch in debug

Remaining unsafe is all necessary CoreAudio FFI — no safe wrapper exists for AUHAL render callbacks with raw `AudioBufferList` manipulation. `coreaudio-rs` doesn't support this pattern.

## Test plan

- [ ] `cargo clippy --workspace -- -D warnings` passes
- [ ] All 412 tests pass
- [ ] Playback works (local + streaming)
- [ ] Device switching still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)