### PR TITLE
feat: add Shift-V shortcut to toggle visualiser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- **Visualiser toggle** — press `V` (Shift-V) to enable/disable the spectrum visualiser at runtime. Persists to config.toml. Visible in `?` help menu under Toggles
+
 ## 0.10.0
 
 ### Added

--- a/crates/koan-music/src/tui/app.rs
+++ b/crates/koan-music/src/tui/app.rs
@@ -967,6 +967,22 @@ impl App {
                     std::time::Instant::now(),
                 ));
             }
+            KeyCode::Char('V') => {
+                self.viz_config.enabled = !self.viz_config.enabled;
+                self.status_message = Some((
+                    if self.viz_config.enabled {
+                        "visualiser on".into()
+                    } else {
+                        "visualiser off".into()
+                    },
+                    std::time::Instant::now(),
+                ));
+                // Persist to config
+                if let Ok(mut cfg) = koan_core::config::Config::load() {
+                    cfg.visualizer.enabled = self.viz_config.enabled;
+                    let _ = cfg.save();
+                }
+            }
             KeyCode::Up => {
                 let visible = self.visible_queue();
                 if !visible.is_empty() {

--- a/crates/koan-music/src/tui/help_modal.rs
+++ b/crates/koan-music/src/tui/help_modal.rs
@@ -75,6 +75,7 @@ const SECTIONS: &[Section] = &[
         bindings: &[
             ("L", "Lyrics panel"),
             ("R", "Radio mode (auto-queue)"),
+            ("V", "Visualiser"),
             ("f", "Favourite track"),
         ],
     },


### PR DESCRIPTION
## Summary

- Adds `V` (Shift-V) keyboard shortcut to toggle the spectrum visualiser on/off at runtime
- Persists the setting to `config.toml` so it survives restarts
- Listed in `?` help menu under Toggles section

Closes #28

## Test plan

- [ ] Press `V` in normal mode — visualiser toggles off, status message shows "visualiser off"
- [ ] Press `V` again — visualiser toggles back on, status message shows "visualiser on"
- [ ] Check `~/.config/koan/config.toml` — `enabled` under `[visualizer]` reflects the toggle
- [ ] Press `?` — "V" appears under Toggles with description "Visualiser"
- [ ] Restart koan — visualiser state persists from previous toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)