### PR TITLE
chore: sync docs with codebase reality

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -19,13 +19,14 @@ Two crates, one workspace. `koan-core` is the engine, `koan-music` is the interf
 
 ## Threading model
 
-Four threads at steady state during playback:
+Five threads at steady state during playback:
 
 ```
 ┌─────────────────────────────────────────────────┐
 │ Main Thread (TUI)                               │
-│ Event loop: poll keyboard/mouse/tick at 50ms    │
-│ Sends PlayerCommands, reads SharedPlayerState    │
+│ Event loop: configurable fps (default 60,       │
+│ ~16.7ms per frame). Sends PlayerCommands,       │
+│ reads SharedPlayerState.                        │
 └───────────────┬─────────────────────────────────┘
                 │ crossbeam channel (bounded 16)
                 ▼
@@ -45,6 +46,13 @@ Four threads at steady state during playback:
 │ side of ring    │  │ Increments samples_played│
 │ buffer          │  │ MUST NOT allocate/lock   │
 └─────────────────┘  └──────────────────────────┘
+
+┌─────────────────────────────────────────────────┐
+│ Analyzer Thread ("koan-analyzer")               │
+│ Always spawned. Reads VizBuffer, runs FFT,      │
+│ writes VizSnapshot. Configurable fps (default   │
+│ 60). Never blocks audio or UI.                  │
+└─────────────────────────────────────────────────┘
 ```
 
 **Sync primitives by thread:**
@@ -60,6 +68,8 @@ Four threads at steady state during playback:
 | `playlist_version` | Player | TUI | `AtomicU64` (Relaxed) |
 | Track boundaries | Decode | TUI, Player | `parking_lot::RwLock` |
 | `running` flag | Player (start/stop) | CoreAudio RT | `AtomicBool` (Relaxed) |
+| Viz samples | Decode | Analyzer | `VizBuffer` (`parking_lot::Mutex` ring) |
+| Analysis output | Analyzer | TUI | `VizSnapshot` (`parking_lot::Mutex`) |
 
 **The golden rule: nothing on the CoreAudio render thread may allocate or lock.** It only touches atomics and the ring buffer consumer.
 
@@ -78,7 +88,7 @@ SampleBuffer<f32> (interleaved)
 rtrb::Producer::write_chunk_uninit()
     │
     ▼
-Ring Buffer (SPSC, ~192k samples)
+Ring Buffer (SPSC, 384k samples — 192k frames × 2 channels)
     │
     ▼
 rtrb::Consumer::read_chunk() ─── CoreAudio RT Thread
@@ -152,6 +162,9 @@ struct Playlist {
 | `buffer.rs` | `PlaybackTimeline` — track boundaries, `current_playback()` position query (binary search), decode thread entry points (`start_decode`, `decode_single`, `decode_queue_loop`) |
 | `device.rs` | CoreAudio device enumeration, sample rate get/set |
 | `replaygain.rs` | EBU R128 loudness scanning, gain application, tag read/write via lofty |
+| `viz.rs` | `VizBuffer` (lock-protected ring of f32 samples for analyzer), `VizSnapshot` (atomic snapshot for UI thread) |
+| `analyzer.rs` | FFT analysis thread — 48-band spectrum, VU meters, peak hold. Configurable fps. Writes to `VizSnapshot`. |
+| `streaming.rs` | Progressive download with `Condvar`-based ready signaling for streaming playback |
 
 ### `player/`
 
@@ -160,6 +173,7 @@ struct Playlist {
 | `mod.rs` | `Player` struct, command loop (`run()`), `start_playback()`, `update_playback_state()` |
 | `commands.rs` | `PlayerCommand` enum (includes `UpdatePaths`, `InsertInPlaylist`), `CommandChannel` (bounded crossbeam) |
 | `state.rs` | `SharedPlayerState`, `PlaylistItem`, `Playlist`, `QueueItemId`, `LoadState`, `PlaybackState`, `derive_visible_queue()`, `insert_items_after()`, `update_paths()` |
+| `undo.rs` | Undo/redo stack for playlist operations (100-deep). Batching support for multi-step ops (e.g. drag). |
 
 ### `db/`
 
@@ -174,6 +188,9 @@ struct Playlist {
 | `queries/search.rs` | FTS5 full-text search |
 | `queries/scan_cache.rs` | Mtime+size change detection to skip unchanged files |
 | `queries/stats.rs` | Library statistics |
+| `queries/lyrics.rs` | Lyrics caching (synced + plain, per-track) |
+| `queries/favourites.rs` | Favourite/star status (syncs with Navidrome) |
+| `queries/playback_state.rs` | Queue and playback position persistence across sessions |
 
 **Track dedup:** `upsert_track` tries three match strategies in order: (1) exact path match, (2) remote_id match, (3) content match (artist + album + title + track#). First match wins — the row is updated rather than duplicated. This merges local files with remote library entries into single rows.
 
@@ -192,7 +209,7 @@ fb2k-compatible template engine.
 |---|---|
 | `parser.rs` | Recursive descent tokenizer: `%field%`, `[conditional]`, `$function(args)`, `'quoted'` |
 | `eval.rs` | Evaluates token tree against a `MetadataProvider` trait. Conditionals omit block if any field missing. |
-| `functions.rs` | 23 built-in functions: string ops (`left`, `right`, `pad`, `replace`, `trim`, `caps`), logic (`if`, `if2`, `if3`), numeric (`num`, `div`, `mod`), path (`directory`, `ext`, `filename`) |
+| `functions.rs` | 55 built-in functions: string ops (`left`, `right`, `pad`, `replace`, `trim`, `caps`, `abbr`, `substr`, `insert`, `repeat`, `rot13`, etc.), logic (`if`, `if2`, `if3`, `ifequal`, `ifgreater`, `iflonger`, `select`, `not`, `and`, `or`, `xor`), numeric (`num`, `add`, `sub`, `mul`, `div`, `mod`, `max`, `min`, `hex`), path (`directory`, `directory_path`, `ext`, `filename`), info (`len`, `info`), special (`tab`, `crlf`, `char`) |
 
 ### `remote/`
 
@@ -200,6 +217,7 @@ fb2k-compatible template engine.
 |---|---|
 | `client.rs` | Subsonic/Navidrome HTTP client. Token auth (MD5+salt). Endpoints: ping, getArtists, getAlbumList2, getAlbum, search3, scrobble, download |
 | `sync.rs` | Parallel library sync: paginate albums (500/page) → rayon fetch full details → batch DB write per page |
+| `lrclib.rs` | LRCLIB API client for lyrics fetching (synced LRC + plain text) |
 
 ### Other
 
@@ -208,6 +226,7 @@ fb2k-compatible template engine.
 | `config.rs` | Two-layer TOML config: `config.toml` (base) + `config.local.toml` (override). Playback, library, remote settings. |
 | `credentials.rs` | macOS Keychain integration via security-framework |
 | `organize.rs` | File renaming using format strings. Preview/execute/undo. Scoped operations via `preview_for_tracks()`/`execute_for_tracks()` (used by TUI modal). Moves ancillary files (cover art, cue sheets). Logs moves for undo. |
+| `lyrics.rs` | LRCLIB lyrics fetching and parsing (synced LRC + plain text). Cached per-track in SQLite. |
 
 ## koan-music modules
 
@@ -250,7 +269,10 @@ Subcommand handlers split into focused modules:
 | `theme.rs` | Color palette. Cyan for active/cursor, green for albums, DarkGray for hints. |
 | `context_menu.rs` | `ContextMenuOverlay` widget: action list popup (currently: Organize) |
 | `organize.rs` | `OrganizeModalState` + `OrganizeOverlay`: pattern picker, scoped preview table, background execute with path update propagation to player |
-| `event.rs` | Event enum wrapper (includes `Paste` for bracketed paste / drag-drop) |
+| `visualizer.rs` | Spectrum analyzer widget: reads `VizSnapshot`, renders 48-band bars with Unicode block chars, peak markers, amplitude coloring |
+| `lyrics.rs` | Lyrics side panel: synced (LRC) line highlighting with auto-scroll, plain text fallback |
+| `device_selector.rs` | Audio output device selection modal |
+| `help_modal.rs` | Help overlay with key binding reference |
 | `keys.rs` | `HintBar` widget: mode-specific key binding hints |
 
 ### `media_keys.rs`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,179 @@
 # Project Rules
 
+## What is koan
+
+Bit-perfect macOS music player. Pure Rust, Ratatui TUI. Two crates:
+
+- **koan-core** — library crate. Audio engine, player, database, indexer, format strings, file organization, remote (Subsonic/Navidrome) client. No UI code, no terminal deps.
+- **koan-music** — binary crate (`koan`). Ratatui TUI, CLI (clap), media keys. Depends on koan-core.
+
+If you want a different UI, write a new crate against koan-core. The CLI owns zero business logic.
+
+## Architecture overview
+
+Read `ARCHITECTURE.md` for the full technical manual (threading model, data flow, sync primitives, module reference). This section is the quick-ref.
+
+### Threading model (5 threads at steady state)
+
+```
+Main Thread (TUI, 60fps)   ──crossbeam channel──►  Player Thread ("koan-player")
+                                                       │
+                                                       ├──rtrb ring buffer──►  Decode Thread ("koan-decode")
+                                                       │
+                                                       └──controls──►  CoreAudio RT Thread (system-managed)
+
+Analyzer Thread ("koan-analyzer") ◄──VizBuffer──  Decode Thread
+                                  ──VizSnapshot──►  Main Thread (TUI)
+```
+
+**Golden rule: the CoreAudio render callback must NEVER allocate or lock.** It only touches atomics and the rtrb consumer.
+
+### Sync primitives
+
+| Data | Primitive | Why |
+|------|-----------|-----|
+| PCM samples (decode→CoreAudio) | `rtrb` SPSC ring buffer | Lock-free, cache-friendly |
+| Commands (TUI→Player) | `crossbeam-channel` bounded(16) | Backpressure, timeout recv |
+| Atomics (position, state, samples_played) | `AtomicU8/U64/Bool` Relaxed | Hot path, no contention |
+| Complex shared state (playlist, track info) | `parking_lot::RwLock` | Faster than std, no poisoning |
+| Viz samples (decode→analyzer) | `VizBuffer` (`parking_lot::Mutex`) | Ring of f32 for FFT |
+| Analysis output (analyzer→TUI) | `VizSnapshot` (`parking_lot::Mutex`) | Atomic snapshot |
+| Parallel work (scan, remote sync) | `rayon` | Work-stealing thread pool |
+
+### Key data flow
+
+```
+File → Symphonia → f32 → rtrb ring buffer → CoreAudio render callback → DAC
+```
+
+No resampling. Device sample rate switched to match source (bit-perfect). Float32 all the way.
+
+### Key design decisions
+
+- **QueueItemId (UUIDv7)** — all queue ops use IDs, not indices. Survives reordering, handles duplicate tracks.
+- **Status is derived** — `QueueEntryStatus` computed from cursor + load state, never stored.
+- **Decode cursor ≠ UI cursor** — decode thread peeks ahead for gapless without moving the playlist cursor.
+- **One `derive_visible_queue()` per frame** — cached snapshot, all render/mouse ops see consistent state.
+- **Track dedup across sources** — local file + remote entry = one DB row. 3-strategy match: path → remote_id → content.
+- **Two-layer config** — `config.toml` (base, committable) + `config.local.toml` (machine-specific override).
+
 ## Git
 
 - **NEVER push tags.** Tags and releases are handled externally. Only push commits.
+- Work in PRs, never push to main.
+- Don't rebase on merge — we squash PRs.
+
+## Build & check
+
+```bash
+just check    # cargo test + clippy -D warnings
+just fmt      # cargo fmt
+just cli      # cargo run --release -p koan-music -- <args>
+just build    # cargo build --release
+```
+
+Pre-push hook (`.claude/settings.json`) runs `cargo fmt --all` + `cargo clippy --workspace -- -D warnings` before any `git push`. If clippy fails, fix before pushing.
+
+**Zero warnings policy.** Fix all clippy/compiler/lint warnings immediately. Run fmt after every change.
+
+## Where things live
+
+### koan-core (`crates/koan-core/src/`)
+
+| Module | What |
+|--------|------|
+| `audio/engine.rs` | CoreAudio AUHAL setup, render callback (unsafe extern "C") |
+| `audio/buffer.rs` | `PlaybackTimeline`, track boundaries, decode thread entry points (`start_decode`, `decode_queue_loop`, `decode_single`) |
+| `audio/device.rs` | CoreAudio device enumeration, sample rate get/set |
+| `audio/replaygain.rs` | EBU R128 loudness scanning, gain application via lofty |
+| `audio/viz.rs` | `VizBuffer` (ring of f32 samples for analyzer), `VizSnapshot` (atomic snapshot for UI) |
+| `audio/analyzer.rs` | FFT analysis thread — 48-band spectrum, VU meters, peak hold. Runs at configurable FPS |
+| `audio/streaming.rs` | Progressive download with `Condvar`-based ready signaling |
+| `player/mod.rs` | `Player` struct, command loop (`run()`), `start_playback()`, `update_playback_state()` |
+| `player/commands.rs` | `PlayerCommand` enum, `CommandChannel` (bounded crossbeam) |
+| `player/state.rs` | `SharedPlayerState`, `Playlist`, `PlaylistItem`, `QueueItemId`, `LoadState`, `PlaybackState`, `derive_visible_queue()` |
+| `player/undo.rs` | Undo/redo stack for playlist operations (100-deep) |
+| `db/schema.rs` | DDL: artists, albums, tracks, scan_cache, remote_servers, organize_log, tracks_fts (FTS5) |
+| `db/connection.rs` | `Database::open()`, WAL mode, pragmas |
+| `db/queries/` | Row types, upsert (3-strategy dedup), FTS5 search, scan cache, stats |
+| `index/scanner.rs` | Parallel library scan: walkdir → rayon → sequential DB upsert |
+| `index/metadata.rs` | Tag reading via lofty (ID3, Vorbis, MP4, APE), codec detection |
+| `format/` | fb2k-compatible template engine: parser (recursive descent), evaluator, 55 built-in functions |
+| `remote/client.rs` | Subsonic/Navidrome HTTP client (reqwest blocking, MD5+salt auth) |
+| `remote/sync.rs` | Parallel library sync: paginate → rayon fetch → batch DB write |
+| `config.rs` | Two-layer TOML config loader |
+| `credentials.rs` | macOS Keychain via security-framework |
+| `organize.rs` | File rename using format strings. Preview/execute/undo. Moves ancillary files |
+| `lyrics.rs` | LRCLIB lyrics fetching and parsing (synced LRC + plain) |
+
+### koan-music (`crates/koan-music/src/`)
+
+| Module | What |
+|--------|------|
+| `main.rs` | CLI entry point (clap), logger (file + buffer), signal handling |
+| `commands/play.rs` | `cmd_play`, `run_tui` (event loop, picker loading, enqueue routing) |
+| `commands/enqueue.rs` | `enqueue_playlist` (append/play/replace), download coordination |
+| `commands/scan.rs` | `cmd_scan` |
+| `commands/search.rs` | `cmd_search` (FTS5 with tree output) |
+| `commands/pick.rs` | Standalone fuzzy picker TUI |
+| `commands/remote.rs` | Remote login/sync/status |
+| `commands/mod.rs` | Shared helpers: `open_db`, formatters, cache paths, playlist item builders |
+| `tui/app.rs` | `App` state machine, `Mode` enum, event handlers per mode |
+| `tui/ui.rs` | Render pipeline: layout → transport → content → overlays → hints |
+| `tui/transport.rs` | Transport bar widget: seek bar, track info, click-to-seek |
+| `tui/queue.rs` | Album-grouped queue with status icons, selection, drag targets |
+| `tui/library.rs` | Flattened tree (artist→album→track), expand/collapse, substring filter |
+| `tui/picker.rs` | Nucleo fuzzy search, multi-select, colored matches |
+| `tui/cover_art.rs` | Halfblock rendering (2px per terminal cell, Lanczos3 resize) |
+| `tui/visualizer.rs` | Spectrum analyzer widget (reads `VizSnapshot`) |
+| `tui/lyrics.rs` | Lyrics side panel — synced line highlighting, scroll |
+| `tui/organize.rs` | Organize modal: pattern picker → preview table → background execute |
+| `media_keys.rs` | macOS Control Center via souvlaki, manual CFRunLoop pump |
+
+## How to read the code
+
+1. **Start:** `koan-core/src/player/state.rs` — the data model
+2. **Then:** `koan-core/src/player/mod.rs` — the command loop
+3. **Audio:** `audio/buffer.rs` (decode pipeline) → `audio/engine.rs` (CoreAudio setup)
+4. **TUI:** `koan-music/src/tui/app.rs` (state machine) → `tui/ui.rs` (render)
+5. **Database:** `db/schema.rs` (tables) → `db/queries/tracks.rs` (dedup logic)
+
+## Concurrency patterns to follow
+
+- **TUI→Player communication:** always via `PlayerCommand` through the crossbeam channel. Never reach into player internals from the TUI thread.
+- **Player→TUI communication:** via `SharedPlayerState` (atomics + RwLock). TUI polls on tick (50ms).
+- **Audio thread:** atomics and rtrb only. No allocations, no locks, no channels.
+- **Decode thread:** owns the Symphonia decoder. Communicates via rtrb producer + `PlaybackTimeline` (RwLock for boundaries, atomics for counters).
+- **Background work** (downloads, lyrics fetch, organize): spawn named threads, communicate results via crossbeam one-shot channels or `Arc<Mutex<Option<T>>>` polling.
+- **Parallel iteration** (scan, remote sync): rayon. Don't hand-roll thread pools.
+
+## Dependencies (key choices)
+
+| Dep | Why chosen |
+|-----|-----------|
+| `symphonia` | Rust-native decoder, all codecs, gapless support |
+| `rtrb` | Lock-free SPSC ring buffer for audio — the only bridge between decode and CoreAudio |
+| `coreaudio-sys` | Raw CoreAudio AUHAL bindings for bit-perfect output |
+| `crossbeam-channel` | Bounded MPSC with timeout recv — command channel + one-shots |
+| `parking_lot` | Faster RwLock/Mutex, no poisoning |
+| `rusqlite` (bundled) | SQLite with FTS5 for full-text search |
+| `lofty` | Tag read/write across ID3, Vorbis, MP4, APE |
+| `ratatui` + `crossterm` | TUI framework + terminal backend |
+| `nucleo` | Fuzzy matching (same engine as Helix editor) |
+| `souvlaki` | Media key / MPRIS / Now Playing |
+| `reqwest` (blocking, rustls) | HTTP client for Subsonic API |
+| `rayon` | Data parallelism for scan + sync |
+| `ebur128` | EBU R128 loudness measurement for ReplayGain |
+| `realfft` | FFT for spectrum analyzer |
+
+## Roadmap
+
+Active plans live in `.claude/plans/`. Key upcoming work:
+
+1. **Decoupled backends** (plan 06) — trait-based audio/credentials abstraction. Foundational, unblocks everything.
+2. **Linux support** (plan 01) — ALSA/PipeWire backends via `AudioBackend` trait.
+3. **Tag editing** (plan 04) — vimv-style (TSV + $EDITOR) first, TUI inline editor second.
+4. **DSP pipeline** (plan 02) — EQ, headphone profiles, crossfeed. Inserts between decode and ring buffer.
+5. **Artist metadata** (plan 09) — bios, images, similar artists from MusicBrainz/Last.fm.
+
+See `.claude/plans/README.md` for dependency graph and status.

--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ During playback, a full-screen Ratatui TUI shows the transport bar, queue, and k
 | `z`     | zoom album art         |
 | `f`     | favourite / unfavourite |
 | `Ctrl+Z` | undo last queue change |
+| `Ctrl+Y` / `Ctrl+Shift+Z` | redo last undone change |
 | `l`     | library browser        |
 | `L`     | lyrics panel           |
 | `f`     | filter library (in library mode) |

--- a/crates/koan-core/src/config.rs
+++ b/crates/koan-core/src/config.rs
@@ -114,7 +114,7 @@ pub struct VisualizerConfig {
     pub fps: u8,
     /// Frequency scale: "bark" (default), "mel", "log", "linear".
     pub scale: String,
-    /// Amplitude scale: "perceptual" (default, A-weighted + gamma), "aweight", "sqrt", "linear".
+    /// Amplitude scale: "aweight" (default, A-weighted), "perceptual" (A-weighted + gamma), "sqrt", "linear".
     pub amplitude_scale: String,
     /// Bar decay half-life in milliseconds (how fast bars drop).
     pub bar_decay_ms: u32,


### PR DESCRIPTION
## Summary

- **ARCHITECTURE.md** — fixed thread count (4→5), ring buffer size, tick rate, function count (23→55), added 12 missing modules, removed phantom `event.rs`, added viz sync primitives
- **CLAUDE.md** — complete rewrite from 1-liner to full dev reference with threading model, module map, build commands, concurrency patterns
- **README.md** — added Ctrl+Y / Ctrl+Shift+Z (redo) to main key bindings table
- **config.rs** — fixed comment claiming "perceptual" was default amplitude scale (actual: "aweight")

## Test plan

- [x] No code changes beyond a doc comment fix in config.rs
- [ ] Verify ARCHITECTURE.md module tables match `ls crates/*/src/**/*.rs`
- [ ] Verify thread count claim by grepping for `thread::spawn`/`Builder::new`

🤖 Generated with [Claude Code](https://claude.com/claude-code)