### PR TITLE
#37 feat(player): add software volume control with GQL mutation

### DIFF
--- a/crates/koan-core/src/audio/engine.rs
+++ b/crates/koan-core/src/audio/engine.rs
@@ -2,7 +2,7 @@ use std::mem;
 use std::os::raw::c_void;
 use std::ptr;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 
 use coreaudio_sys::*;
 use thiserror::Error;
@@ -36,6 +36,8 @@ struct CallbackData {
     /// Cumulative samples played — incremented by the render callback,
     /// read by the UI to derive current track + position.
     samples_played: Arc<AtomicU64>,
+    /// Software volume (0.0–1.0) stored as f32 bits. Relaxed atomic — no lock.
+    volume: Arc<AtomicU32>,
 }
 
 // SAFETY: `rtrb::Consumer` is `!Send` due to internal raw pointers, but our usage is
@@ -71,6 +73,7 @@ impl AudioEngine {
         channels: u32,
         consumer: rtrb::Consumer<f32>,
         samples_played: Arc<AtomicU64>,
+        volume: Arc<AtomicU32>,
     ) -> Result<Self> {
         let running = Arc::new(AtomicBool::new(false));
 
@@ -138,6 +141,7 @@ impl AudioEngine {
             consumer,
             running: running.clone(),
             samples_played,
+            volume,
         }));
 
         let render_cb = AURenderCallbackStruct {
@@ -280,6 +284,16 @@ unsafe extern "C" fn render_callback(
             }
         }
         chunk.commit_all();
+
+        // Apply software volume. Relaxed load — no ordering needed on the hot path.
+        let vol = f32::from_bits(data.volume.load(Ordering::Relaxed));
+        if vol < 1.0 {
+            let out = unsafe { std::slice::from_raw_parts_mut(out_ptr, to_read) };
+            for s in out {
+                *s *= vol;
+            }
+        }
+
         data.samples_played
             .fetch_add(to_read as u64, Ordering::Relaxed);
     }

--- a/crates/koan-core/src/player/commands.rs
+++ b/crates/koan-core/src/player/commands.rs
@@ -52,6 +52,8 @@ pub enum PlayerCommand {
     BeginUndoBatch,
     /// End the batch — collapse collected entries into one undo step.
     EndUndoBatch,
+    /// Set software volume (0.0–1.0). Clamped by the handler.
+    SetVolume(f32),
     /// Switch output audio device by name. Restarts engine on current track.
     SetOutputDevice(String),
     /// Clear the configured output device, reverting to system default.

--- a/crates/koan-core/src/player/mod.rs
+++ b/crates/koan-core/src/player/mod.rs
@@ -333,6 +333,7 @@ impl Player {
             info.channels as u32,
             consumer,
             self.timeline.samples_played_counter(),
+            self.shared_state.volume_atomic(),
         )?;
         engine.start()?;
 
@@ -548,6 +549,7 @@ impl Player {
             info.channels as u32,
             consumer,
             self.timeline.samples_played_counter(),
+            self.shared_state.volume_atomic(),
         )?;
         engine.start()?;
 
@@ -953,6 +955,9 @@ impl Player {
                         self.undo_stack.push(UndoEntry::Batch(entries));
                     }
                 }
+            }
+            PlayerCommand::SetVolume(v) => {
+                self.shared_state.set_volume(v);
             }
             PlayerCommand::SetOutputDevice(name) => self.set_output_device(name),
             PlayerCommand::ClearOutputDevice => self.clear_output_device(),
@@ -1508,5 +1513,22 @@ mod tests {
         // Undo move: [A, B, C]
         player.process_command(PlayerCommand::Undo);
         assert_eq!(playlist_titles(&player), vec!["A", "B", "C"]);
+    }
+
+    #[test]
+    fn set_volume_command_updates_state() {
+        let mut player = Player::new();
+        player.process_command(PlayerCommand::SetVolume(0.42));
+        let vol = player.shared_state().volume();
+        assert!((vol - 0.42).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn set_volume_command_clamps() {
+        let mut player = Player::new();
+        player.process_command(PlayerCommand::SetVolume(5.0));
+        assert!((player.shared_state().volume() - 1.0).abs() < f32::EPSILON);
+        player.process_command(PlayerCommand::SetVolume(-1.0));
+        assert!(player.shared_state().volume().abs() < f32::EPSILON);
     }
 }

--- a/crates/koan-core/src/player/state.rs
+++ b/crates/koan-core/src/player/state.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU32, AtomicU64, Ordering};
 
 use uuid::Uuid;
 
@@ -185,6 +185,10 @@ pub struct SharedPlayerState {
     /// Radio mode — automatically queue similar tracks when the queue runs low.
     /// Shared so GQL/MCP can toggle it without going through the TUI.
     radio_mode: AtomicBool,
+
+    /// Software volume (0.0–1.0). Stored as f32 bits in AtomicU32.
+    /// Shared with the audio engine — read in the render callback (Relaxed ordering).
+    volume: Arc<AtomicU32>,
 }
 
 impl SharedPlayerState {
@@ -199,6 +203,7 @@ impl SharedPlayerState {
             quit_requested: AtomicBool::new(false),
             metadata_refresh_pending: AtomicBool::new(false),
             radio_mode: AtomicBool::new(false),
+            volume: Arc::new(AtomicU32::new(1.0_f32.to_bits())),
         })
     }
 
@@ -298,6 +303,24 @@ impl SharedPlayerState {
 
     pub fn set_radio_mode(&self, enabled: bool) {
         self.radio_mode.store(enabled, Ordering::Relaxed);
+    }
+
+    // --- Volume ---
+
+    /// Current software volume (0.0–1.0).
+    pub fn volume(&self) -> f32 {
+        f32::from_bits(self.volume.load(Ordering::Relaxed))
+    }
+
+    /// Set software volume, clamped to 0.0–1.0.
+    pub fn set_volume(&self, v: f32) {
+        self.volume
+            .store(v.clamp(0.0, 1.0).to_bits(), Ordering::Relaxed);
+    }
+
+    /// Clone the volume Arc for the audio engine render callback.
+    pub fn volume_atomic(&self) -> Arc<AtomicU32> {
+        self.volume.clone()
     }
 
     // --- Playlist version ---
@@ -1086,5 +1109,43 @@ mod tests {
         assert_eq!(items[1].id, id_d);
         assert_eq!(items[2].id, id_a);
         assert_eq!(items[3].id, id_c);
+    }
+
+    // --- volume ---
+
+    #[test]
+    fn test_volume_default_is_1() {
+        let state = SharedPlayerState::new();
+        assert!((state.volume() - 1.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_volume_set_and_get() {
+        let state = SharedPlayerState::new();
+        state.set_volume(0.5);
+        assert!((state.volume() - 0.5).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_volume_clamped_high() {
+        let state = SharedPlayerState::new();
+        state.set_volume(2.0);
+        assert!((state.volume() - 1.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_volume_clamped_low() {
+        let state = SharedPlayerState::new();
+        state.set_volume(-0.5);
+        assert!(state.volume().abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_volume_atomic_shares_state() {
+        let state = SharedPlayerState::new();
+        let vol = state.volume_atomic();
+        state.set_volume(0.75);
+        let read = f32::from_bits(vol.load(Ordering::Relaxed));
+        assert!((read - 0.75).abs() < f32::EPSILON);
     }
 }

--- a/crates/koan-music/src/commands/graphql.rs
+++ b/crates/koan-music/src/commands/graphql.rs
@@ -339,6 +339,8 @@ struct GqlNowPlaying {
     duration_ms: Option<u64>,
     track: Option<GqlNowPlayingTrack>,
     queue_item_id: Option<String>,
+    /// Software volume level (0.0–1.0).
+    volume: f32,
 }
 
 #[derive(SimpleObject)]
@@ -912,6 +914,7 @@ impl QueryRoot {
             duration_ms,
             track,
             queue_item_id,
+            volume: state.volume(),
         })
     }
 
@@ -1116,6 +1119,13 @@ impl MutationRoot {
     async fn seek(&self, ctx: &Context<'_>, position_ms: i64) -> async_graphql::Result<GqlStatus> {
         send_cmd(ctx, PlayerCommand::Seek(position_ms as u64))?;
         Ok(GqlStatus::success(format!("seeked to {}ms", position_ms)))
+    }
+
+    /// Set software volume (0.0–1.0). Values are clamped.
+    async fn set_volume(&self, ctx: &Context<'_>, level: f64) -> async_graphql::Result<f64> {
+        let clamped = (level as f32).clamp(0.0, 1.0);
+        send_cmd(ctx, PlayerCommand::SetVolume(clamped))?;
+        Ok(clamped as f64)
     }
 
     // -- Queue --
@@ -1948,5 +1958,27 @@ mod tests {
         assert!(resp.errors.is_empty(), "errors: {:?}", resp.errors);
         let cmd = rx.try_recv().unwrap();
         assert!(matches!(cmd, PlayerCommand::ClearPlaylist));
+    }
+
+    #[tokio::test]
+    async fn set_volume_mutation() {
+        let (schema, rx, _tmp) = test_schema();
+        let resp = schema.execute("mutation { setVolume(level: 0.75) }").await;
+        assert!(resp.errors.is_empty(), "errors: {:?}", resp.errors);
+        let data = resp.data.into_json().unwrap();
+        let vol = data["setVolume"].as_f64().unwrap();
+        assert!((vol - 0.75).abs() < 0.001);
+        let cmd = rx.try_recv().unwrap();
+        assert!(matches!(cmd, PlayerCommand::SetVolume(v) if (v - 0.75).abs() < f32::EPSILON));
+    }
+
+    #[tokio::test]
+    async fn now_playing_includes_volume() {
+        let (schema, _rx, _tmp) = test_schema();
+        let resp = schema.execute("{ nowPlaying { state volume } }").await;
+        assert!(resp.errors.is_empty(), "errors: {:?}", resp.errors);
+        let data = resp.data.into_json().unwrap();
+        let vol = data["nowPlaying"]["volume"].as_f64().unwrap();
+        assert!((vol - 1.0).abs() < 0.001, "default volume should be 1.0");
     }
 }


### PR DESCRIPTION
## Summary
- Adds `SetVolume(f32)` PlayerCommand and `volume: Arc<AtomicU32>` to `SharedPlayerState` (f32 bits, Relaxed ordering)
- Volume applied in CoreAudio render callback post-copy — no allocation, no lock, skipped at unity gain (1.0)
- `setVolume(level: Float!)` GQL mutation + `volume` field on `nowPlaying` query
- 7 new tests: state get/set/clamp, atomic sharing, command routing, GQL mutation + query

## Test plan
- [x] `cargo test --workspace` — 60 tests pass, 0 failures
- [x] `cargo clippy --workspace -- -D warnings` — zero warnings
- [x] `cargo fmt --all` — clean

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)