### PR TITLE
fix(ci): arm64 cross-compile, no force-push tags, add doc tests

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -58,6 +58,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --all-targets
+      - run: cargo test --doc
 
   build:
     name: Build (${{ matrix.os }})
@@ -132,7 +133,11 @@ jobs:
       - name: Install cross-compilation deps (Linux arm64)
         if: matrix.target == 'aarch64-unknown-linux-gnu'
         run: |
-          sudo apt-get install -y gcc-aarch64-linux-gnu libasound2-dev:arm64 || true
+          # NOTE: libasound2-dev:arm64 is not available on ubuntu-latest even with
+          # dpkg --add-architecture arm64. Cross-compile links against host ALSA for now.
+          sudo dpkg --add-architecture arm64
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
           echo "[target.aarch64-unknown-linux-gnu]" >> ~/.cargo/config.toml
           echo 'linker = "aarch64-linux-gnu-gcc"' >> ~/.cargo/config.toml
       - uses: dtolnay/rust-toolchain@stable
@@ -167,8 +172,8 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -fa "v${{ needs.check-version.outputs.version }}" -m "Release v${{ needs.check-version.outputs.version }}"
-          git push --force origin "v${{ needs.check-version.outputs.version }}"
+          git tag -a "v${{ needs.check-version.outputs.version }}" -m "Release v${{ needs.check-version.outputs.version }}"
+          git push origin "v${{ needs.check-version.outputs.version }}"
       - uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ needs.check-version.outputs.version }}


### PR DESCRIPTION
## Summary
- **arm64 cross-compile**: Remove `|| true` that swallowed failures. Add `dpkg --add-architecture arm64` + `apt-get update` before installing `gcc-aarch64-linux-gnu`. Comment documents that `libasound2-dev:arm64` isn't available on ubuntu-latest.
- **No force-push tags**: `git tag -a` / `git push origin` instead of `-fa` / `--force`. If the tag exists, the job fails — version wasn't bumped.
- **Doc tests**: Add `cargo test --doc` step after `cargo test --all-targets` in the test job.

## Test plan
- [ ] Verify CI passes on this PR (fmt, clippy, test, build jobs)
- [ ] Confirm `cargo test --doc` step appears in test job logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)