### PR TITLE
fix(remote-bridge): harden download checks, exhaust command match, add timeout

### DIFF
--- a/crates/koan-music/src/remote_bridge.rs
+++ b/crates/koan-music/src/remote_bridge.rs
@@ -104,7 +104,10 @@ fn download_and_play(
         return;
     }
 
-    let http = reqwest::blocking::Client::new();
+    let http = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .build()
+        .unwrap();
     let resp = match http.get(stream_url).send() {
         Ok(r) => r,
         Err(e) => {
@@ -170,6 +173,23 @@ fn download_and_play(
     }
 
     std::io::Write::flush(&mut file).ok();
+
+    let written = bytes_written.load(Ordering::Acquire);
+    if total > 0 && written < total {
+        log::warn!(
+            "incomplete download for {}: {} of {} bytes",
+            queue_id.0,
+            written,
+            total
+        );
+        std::fs::remove_file(&dest).ok();
+        state.update_load_state(
+            queue_id,
+            LoadState::Failed("incomplete download".to_string()),
+        );
+        return;
+    }
+
     state.update_load_state(queue_id, LoadState::Ready);
     local_tx.send(PlayerCommand::TrackReady(queue_id)).ok();
 }
@@ -370,8 +390,19 @@ fn command_loop(
             PlayerCommand::ClearOutputDevice => {
                 local_tx.send(PlayerCommand::ClearOutputDevice).ok();
             }
-            // Not applicable in remote mode.
-            _ => {}
+            // Not applicable in remote mode — listed explicitly so the compiler
+            // catches new variants.
+            PlayerCommand::TrackReady(_)
+            | PlayerCommand::TrackStreamReady(_)
+            | PlayerCommand::BeginUndoBatch
+            | PlayerCommand::EndUndoBatch
+            | PlayerCommand::UpdatePaths(_)
+            | PlayerCommand::MoveInPlaylist { .. }
+            | PlayerCommand::MoveItemsInPlaylist { .. }
+            | PlayerCommand::InsertInPlaylist { .. }
+            | PlayerCommand::AddToPlaylist(_) => {
+                log::debug!("ignoring {:?} in remote mode", cmd);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- **Exhaustive command match**: Replaced catch-all `_ => {}` in `command_loop` with explicit listing of all `PlayerCommand` variants. Ignored-in-remote-mode variants log at debug level. Compiler now catches new variants.
- **Incomplete download detection**: After the download loop exits, checks `bytes_written < total` (when content-length is known). Marks as `LoadState::Failed` and deletes the partial file instead of falsely reporting `Ready`.
- **Request timeout**: Builds the reqwest client with a 30s timeout instead of unbounded `Client::new()`.

## Test plan
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo test --workspace` — 88 passed
- [ ] Manual: kill server mid-download, verify partial file is cleaned up and state shows failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)