### PR TITLE
fix(graphql): eliminate N+1 queries in genre and favourite filtering

### DIFF
--- a/crates/koan-core/src/db/queries/tracks.rs
+++ b/crates/koan-core/src/db/queries/tracks.rs
@@ -1,3 +1,4 @@
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use rusqlite::{Connection, params};
@@ -573,6 +574,122 @@ pub fn tracks_for_album(conn: &Connection, album_id: i64) -> Result<Vec<TrackRow
     Ok(rows)
 }
 
+/// Build a SQL `IN (?, ?, ...)` clause with the given number of placeholders.
+fn in_clause(n: usize) -> String {
+    let mut s = String::with_capacity(2 + n * 2);
+    s.push('(');
+    for i in 0..n {
+        if i > 0 {
+            s.push(',');
+        }
+        s.push('?');
+    }
+    s.push(')');
+    s
+}
+
+/// Get distinct genres for a batch of artist IDs in a single query.
+/// Returns a map from artist_id → set of lowercased genre strings.
+pub fn genres_by_artist_ids(
+    conn: &Connection,
+    ids: &[i64],
+) -> Result<HashMap<i64, HashSet<String>>, DbError> {
+    if ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+    let sql = format!(
+        "SELECT t.artist_id, t.genre FROM tracks t
+         WHERE t.artist_id IN {} AND t.genre IS NOT NULL
+         UNION
+         SELECT al.artist_id, t.genre FROM tracks t
+         JOIN albums al ON t.album_id = al.id
+         WHERE al.artist_id IN {} AND t.genre IS NOT NULL",
+        in_clause(ids.len()),
+        in_clause(ids.len()),
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let params: Vec<Box<dyn rusqlite::types::ToSql>> = ids
+        .iter()
+        .chain(ids.iter())
+        .map(|id| Box::new(*id) as Box<dyn rusqlite::types::ToSql>)
+        .collect();
+    let param_refs: Vec<&dyn rusqlite::types::ToSql> = params.iter().map(|p| p.as_ref()).collect();
+    let rows = stmt.query_map(param_refs.as_slice(), |row| {
+        Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
+    })?;
+    let mut map: HashMap<i64, HashSet<String>> = HashMap::new();
+    for row in rows {
+        let (artist_id, genre) = row?;
+        map.entry(artist_id)
+            .or_default()
+            .insert(genre.to_lowercase());
+    }
+    Ok(map)
+}
+
+/// Get distinct genres for a batch of album IDs in a single query.
+/// Returns a map from album_id → set of lowercased genre strings.
+pub fn genres_by_album_ids(
+    conn: &Connection,
+    ids: &[i64],
+) -> Result<HashMap<i64, HashSet<String>>, DbError> {
+    if ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+    let sql = format!(
+        "SELECT t.album_id, t.genre FROM tracks t
+         WHERE t.album_id IN {} AND t.genre IS NOT NULL",
+        in_clause(ids.len()),
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let params: Vec<Box<dyn rusqlite::types::ToSql>> = ids
+        .iter()
+        .map(|id| Box::new(*id) as Box<dyn rusqlite::types::ToSql>)
+        .collect();
+    let param_refs: Vec<&dyn rusqlite::types::ToSql> = params.iter().map(|p| p.as_ref()).collect();
+    let rows = stmt.query_map(param_refs.as_slice(), |row| {
+        Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
+    })?;
+    let mut map: HashMap<i64, HashSet<String>> = HashMap::new();
+    for row in rows {
+        let (album_id, genre) = row?;
+        map.entry(album_id)
+            .or_default()
+            .insert(genre.to_lowercase());
+    }
+    Ok(map)
+}
+
+/// Get all artist IDs that have at least one favourited track, in a single query.
+pub fn favourite_artist_ids_batch(conn: &Connection) -> Result<HashSet<i64>, DbError> {
+    let mut stmt = conn.prepare(
+        "SELECT DISTINCT t.artist_id FROM tracks t
+         JOIN favourites f ON (t.path = f.track_path OR t.cached_path = f.track_path)
+         WHERE t.artist_id IS NOT NULL",
+    )?;
+    let rows = stmt.query_map([], |row| row.get::<_, i64>(0))?;
+    let mut ids = HashSet::new();
+    for row in rows {
+        ids.insert(row?);
+    }
+    Ok(ids)
+}
+
+/// Get all album IDs that have at least one favourited track, in a single query.
+pub fn favourite_album_ids_batch(conn: &Connection) -> Result<HashSet<i64>, DbError> {
+    let mut stmt = conn.prepare(
+        "SELECT DISTINCT t.album_id FROM tracks t
+         JOIN favourites f ON (t.path = f.track_path OR t.cached_path = f.track_path)
+         WHERE t.album_id IS NOT NULL",
+    )?;
+    let rows = stmt.query_map([], |row| row.get::<_, i64>(0))?;
+    let mut ids = HashSet::new();
+    for row in rows {
+        ids.insert(row?);
+    }
+    Ok(ids)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -902,5 +1019,142 @@ mod tests {
 
         // Only 1 track — no duplication.
         assert_eq!(library_stats(&db.conn).unwrap().total_tracks, 1);
+    }
+
+    #[test]
+    fn test_genres_by_artist_ids() {
+        let db = test_db();
+        let mut meta1 = sample_meta("Track1", "ArtistA", "Album1");
+        meta1.genre = Some("Rock".into());
+        upsert_track(&db.conn, &meta1).unwrap();
+
+        let mut meta2 = sample_meta("Track2", "ArtistA", "Album1");
+        meta2.genre = Some("Jazz".into());
+        meta2.track_number = Some(2);
+        meta2.path = Some("/music/Album1/Track2.flac".into());
+        upsert_track(&db.conn, &meta2).unwrap();
+
+        let mut meta3 = sample_meta("Track3", "ArtistB", "Album2");
+        meta3.genre = Some("Metal".into());
+        upsert_track(&db.conn, &meta3).unwrap();
+
+        // Look up ArtistA's ID.
+        let artist_a_id: i64 = db
+            .conn
+            .query_row("SELECT id FROM artists WHERE name = 'ArtistA'", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        let artist_b_id: i64 = db
+            .conn
+            .query_row("SELECT id FROM artists WHERE name = 'ArtistB'", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+
+        let genres = genres_by_artist_ids(&db.conn, &[artist_a_id, artist_b_id]).unwrap();
+        let a_genres = genres.get(&artist_a_id).unwrap();
+        assert!(a_genres.contains("rock"));
+        assert!(a_genres.contains("jazz"));
+        let b_genres = genres.get(&artist_b_id).unwrap();
+        assert!(b_genres.contains("metal"));
+    }
+
+    #[test]
+    fn test_genres_by_artist_ids_empty() {
+        let db = test_db();
+        let genres = genres_by_artist_ids(&db.conn, &[]).unwrap();
+        assert!(genres.is_empty());
+    }
+
+    #[test]
+    fn test_genres_by_album_ids() {
+        let db = test_db();
+        let mut meta1 = sample_meta("Track1", "Artist", "AlbumX");
+        meta1.genre = Some("Ambient".into());
+        upsert_track(&db.conn, &meta1).unwrap();
+
+        let mut meta2 = sample_meta("Track2", "Artist", "AlbumX");
+        meta2.genre = Some("IDM".into());
+        meta2.track_number = Some(2);
+        meta2.path = Some("/music/AlbumX/Track2.flac".into());
+        upsert_track(&db.conn, &meta2).unwrap();
+
+        let album_id: i64 = db
+            .conn
+            .query_row("SELECT id FROM albums WHERE title = 'AlbumX'", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+
+        let genres = genres_by_album_ids(&db.conn, &[album_id]).unwrap();
+        let album_genres = genres.get(&album_id).unwrap();
+        assert!(album_genres.contains("ambient"));
+        assert!(album_genres.contains("idm"));
+    }
+
+    #[test]
+    fn test_favourite_artist_ids_batch() {
+        let db = test_db();
+        let meta = sample_meta("FavTrack", "FavArtist", "FavAlbum");
+        upsert_track(&db.conn, &meta).unwrap();
+
+        // Add to favourites.
+        crate::db::queries::add_favourite(
+            &db.conn,
+            std::path::Path::new("/music/FavAlbum/FavTrack.flac"),
+        )
+        .unwrap();
+
+        let artist_id: i64 = db
+            .conn
+            .query_row(
+                "SELECT id FROM artists WHERE name = 'FavArtist'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+
+        let fav_ids = favourite_artist_ids_batch(&db.conn).unwrap();
+        assert!(fav_ids.contains(&artist_id));
+    }
+
+    #[test]
+    fn test_favourite_artist_ids_batch_empty() {
+        let db = test_db();
+        let fav_ids = favourite_artist_ids_batch(&db.conn).unwrap();
+        assert!(fav_ids.is_empty());
+    }
+
+    #[test]
+    fn test_favourite_album_ids_batch() {
+        let db = test_db();
+        let meta = sample_meta("FavTrack", "FavArtist", "FavAlbum");
+        upsert_track(&db.conn, &meta).unwrap();
+
+        crate::db::queries::add_favourite(
+            &db.conn,
+            std::path::Path::new("/music/FavAlbum/FavTrack.flac"),
+        )
+        .unwrap();
+
+        let album_id: i64 = db
+            .conn
+            .query_row(
+                "SELECT id FROM albums WHERE title = 'FavAlbum'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+
+        let fav_ids = favourite_album_ids_batch(&db.conn).unwrap();
+        assert!(fav_ids.contains(&album_id));
+    }
+
+    #[test]
+    fn test_favourite_album_ids_batch_empty() {
+        let db = test_db();
+        let fav_ids = favourite_album_ids_batch(&db.conn).unwrap();
+        assert!(fav_ids.is_empty());
     }
 }

--- a/crates/koan-music/src/commands/graphql.rs
+++ b/crates/koan-music/src/commands/graphql.rs
@@ -1,4 +1,3 @@
-use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -628,16 +627,20 @@ impl QueryRoot {
 
         if let Some(ref g) = genre {
             let g_lower = g.to_lowercase();
+            let artist_ids: Vec<i64> = artists.iter().map(|a| a.id).collect();
+            let genre_map = queries::genres_by_artist_ids(&db.conn, &artist_ids)
+                .map_err(|e| async_graphql::Error::new(format!("db error: {}", e)))?;
             artists.retain(|a| {
-                artist_genres(&db, a.id)
-                    .iter()
-                    .any(|ag| ag.contains(&g_lower))
+                genre_map
+                    .get(&a.id)
+                    .is_some_and(|genres| genres.iter().any(|ag| ag.contains(&g_lower)))
             });
         }
 
         if favourites_only {
-            let fav_artist_ids = favourite_artist_ids(&db)?;
-            artists.retain(|a| fav_artist_ids.contains(&a.id));
+            let fav_ids = queries::favourite_artist_ids_batch(&db.conn)
+                .map_err(|e| async_graphql::Error::new(format!("db error: {}", e)))?;
+            artists.retain(|a| fav_ids.contains(&a.id));
         }
 
         paginate(
@@ -731,16 +734,20 @@ impl QueryRoot {
 
         if let Some(ref g) = genre {
             let g_lower = g.to_lowercase();
+            let album_ids: Vec<i64> = albums.iter().map(|a| a.id).collect();
+            let genre_map = queries::genres_by_album_ids(&db.conn, &album_ids)
+                .map_err(|e| async_graphql::Error::new(format!("db error: {}", e)))?;
             albums.retain(|a| {
-                album_genres(&db, a.id)
-                    .iter()
-                    .any(|ag| ag.contains(&g_lower))
+                genre_map
+                    .get(&a.id)
+                    .is_some_and(|genres| genres.iter().any(|ag| ag.contains(&g_lower)))
             });
         }
 
         if favourites_only {
-            let fav_album_ids = favourite_album_ids(&db)?;
-            albums.retain(|a| fav_album_ids.contains(&a.id));
+            let fav_ids = queries::favourite_album_ids_batch(&db.conn)
+                .map_err(|e| async_graphql::Error::new(format!("db error: {}", e)))?;
+            albums.retain(|a| fav_ids.contains(&a.id));
         }
 
         paginate(
@@ -1850,26 +1857,6 @@ fn album_year(album: &queries::AlbumRow) -> Option<i32> {
     album.date.as_deref().and_then(extract_year)
 }
 
-/// Get genres for an artist (distinct genres from their tracks).
-fn artist_genres(db: &Database, artist_id: i64) -> HashSet<String> {
-    queries::tracks_for_artist(&db.conn, artist_id)
-        .unwrap_or_default()
-        .into_iter()
-        .filter_map(|t| t.genre)
-        .map(|g| g.to_lowercase())
-        .collect()
-}
-
-/// Get genres for an album (distinct genres from its tracks).
-fn album_genres(db: &Database, album_id: i64) -> HashSet<String> {
-    queries::tracks_for_album(&db.conn, album_id)
-        .unwrap_or_default()
-        .into_iter()
-        .filter_map(|t| t.genre)
-        .map(|g| g.to_lowercase())
-        .collect()
-}
-
 /// Get the year for a track via its album's date.
 fn track_year(db: &Database, track: &queries::TrackRow) -> Option<i32> {
     track
@@ -1877,44 +1864,6 @@ fn track_year(db: &Database, track: &queries::TrackRow) -> Option<i32> {
         .and_then(|aid| queries::album_date(&db.conn, aid).ok().flatten())
         .as_deref()
         .and_then(extract_year)
-}
-
-// ---------------------------------------------------------------------------
-// Helper: favourite ID sets for filtering
-// ---------------------------------------------------------------------------
-
-/// Get the set of artist IDs that have at least one favourited track.
-fn favourite_artist_ids(db: &Database) -> async_graphql::Result<HashSet<i64>> {
-    let fav_paths =
-        queries::load_favourites(&db.conn).map_err(|e| async_graphql::Error::new(e.to_string()))?;
-    let mut ids = HashSet::new();
-    for path in &fav_paths {
-        let path_str = path.to_string_lossy();
-        if let Ok(Some(tid)) = queries::track_id_by_path(&db.conn, &path_str)
-            && let Ok(Some(row)) = queries::get_track_row(&db.conn, tid)
-            && let Some(aid) = row.artist_id
-        {
-            ids.insert(aid);
-        }
-    }
-    Ok(ids)
-}
-
-/// Get the set of album IDs that have at least one favourited track.
-fn favourite_album_ids(db: &Database) -> async_graphql::Result<HashSet<i64>> {
-    let fav_paths =
-        queries::load_favourites(&db.conn).map_err(|e| async_graphql::Error::new(e.to_string()))?;
-    let mut ids = HashSet::new();
-    for path in &fav_paths {
-        let path_str = path.to_string_lossy();
-        if let Ok(Some(tid)) = queries::track_id_by_path(&db.conn, &path_str)
-            && let Ok(Some(row)) = queries::get_track_row(&db.conn, tid)
-            && let Some(aid) = row.album_id
-        {
-            ids.insert(aid);
-        }
-    }
-    Ok(ids)
 }
 
 fn sync_favourite_to_remote(db: &Database, path: &str, star: bool) {


### PR DESCRIPTION
## Summary
- Added batch query functions (`genres_by_artist_ids`, `genres_by_album_ids`, `favourite_artist_ids_batch`, `favourite_album_ids_batch`) in koan-core that replace per-item DB calls with single SQL queries
- Replaced N+1 `.retain()` loops in GraphQL artist/album resolvers with pre-loaded HashMap/HashSet lookups
- Removed 4 helper functions from graphql.rs that were doing O(n*m) work

## Test plan
- [x] New unit tests for all 4 batch query functions (including empty-input edge cases)
- [x] All 88 existing tests pass
- [x] Zero clippy warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)