### PR TITLE
refactor: extract subsonic_client() factory + 30s HTTP timeout

### DIFF
--- a/crates/koan-core/src/remote/client.rs
+++ b/crates/koan-core/src/remote/client.rs
@@ -34,7 +34,10 @@ impl SubsonicClient {
             base_url,
             username: username.to_string(),
             password: password.to_string(),
-            http: reqwest::blocking::Client::new(),
+            http: reqwest::blocking::Client::builder()
+                .timeout(std::time::Duration::from_secs(30))
+                .build()
+                .expect("failed to build HTTP client"),
         }
     }
 

--- a/crates/koan-music/src/commands/enqueue.rs
+++ b/crates/koan-music/src/commands/enqueue.rs
@@ -9,7 +9,7 @@ use koan_core::player::commands::PlayerCommand;
 use koan_core::player::state::{LoadState, QueueItemId, SharedPlayerState};
 use owo_colors::OwoColorize;
 
-use super::{cache_path_for_track, get_remote_password, open_db, playlist_item_from_track};
+use super::{cache_path_for_track, open_db, playlist_item_from_track};
 use crate::tui::app::PickerAction;
 
 /// Build PlaylistItems from track IDs and enqueue according to the action:
@@ -222,12 +222,16 @@ pub(crate) fn download_track(
         return;
     }
 
-    let password = get_remote_password(cfg);
-    let client = koan_core::remote::client::SubsonicClient::new(
-        &cfg.remote.url,
-        &cfg.remote.username,
-        &password,
-    );
+    let client = match super::subsonic_client(cfg) {
+        Some(c) => c,
+        None => {
+            log::warn!(
+                "remote not configured — skipping download for {}",
+                remote_id
+            );
+            return;
+        }
+    };
 
     // Shared counter: download thread writes, StreamingSource reads.
     let bytes_written: Arc<AtomicU64> = Arc::new(AtomicU64::new(0));

--- a/crates/koan-music/src/commands/graphql.rs
+++ b/crates/koan-music/src/commands/graphql.rs
@@ -1769,15 +1769,8 @@ impl MutationRoot {
     async fn trigger_remote_sync(&self, ctx: &Context<'_>) -> async_graphql::Result<GqlStatus> {
         let db = ctx.data::<DbHandle>()?.open()?;
         let cfg = Config::load().unwrap_or_default();
-        if !cfg.remote.enabled {
-            return Err(async_graphql::Error::new("remote not configured"));
-        }
-        let password = super::get_remote_password(&cfg);
-        let client = koan_core::remote::client::SubsonicClient::new(
-            &cfg.remote.url,
-            &cfg.remote.username,
-            &password,
-        );
+        let client = super::subsonic_client(&cfg)
+            .ok_or_else(|| async_graphql::Error::new("remote not configured"))?;
         koan_core::remote::sync::sync_library(
             &db,
             &client,
@@ -1799,15 +1792,8 @@ impl MutationRoot {
     ) -> async_graphql::Result<GqlShare> {
         let db = ctx.data::<DbHandle>()?.open()?;
         let cfg = Config::load().unwrap_or_default();
-        if !cfg.remote.enabled {
-            return Err(async_graphql::Error::new("remote not configured"));
-        }
-        let password = super::get_remote_password(&cfg);
-        let client = koan_core::remote::client::SubsonicClient::new(
-            &cfg.remote.url,
-            &cfg.remote.username,
-            &password,
-        );
+        let client = super::subsonic_client(&cfg)
+            .ok_or_else(|| async_graphql::Error::new("remote not configured"))?;
 
         // Resolve track IDs to remote IDs.
         let mut remote_ids = Vec::new();
@@ -1926,12 +1912,9 @@ fn sync_favourite_to_remote(db: &Database, path: &str, star: bool) {
         .ok()
         .flatten();
     if let Some(rid) = remote_id {
-        let password = super::get_remote_password(&cfg);
-        let client = koan_core::remote::client::SubsonicClient::new(
-            &cfg.remote.url,
-            &cfg.remote.username,
-            &password,
-        );
+        let Some(client) = super::subsonic_client(&cfg) else {
+            return;
+        };
         std::thread::Builder::new()
             .name("koan-fav-sync".into())
             .spawn(move || {

--- a/crates/koan-music/src/commands/mod.rs
+++ b/crates/koan-music/src/commands/mod.rs
@@ -139,6 +139,22 @@ pub(crate) fn get_remote_password(cfg: &core_config::Config) -> String {
     }
 }
 
+/// Build a `SubsonicClient` from the merged config, returning `None` if remote
+/// is disabled or has no URL configured.
+pub(crate) fn subsonic_client(
+    cfg: &koan_core::config::Config,
+) -> Option<koan_core::remote::client::SubsonicClient> {
+    if !cfg.remote.enabled || cfg.remote.url.is_empty() {
+        return None;
+    }
+    let password = get_remote_password(cfg);
+    Some(koan_core::remote::client::SubsonicClient::new(
+        &cfg.remote.url,
+        &cfg.remote.username,
+        &password,
+    ))
+}
+
 /// Sanitise and truncate a string for use as a path component.
 /// Strips illegal chars and caps at 240 bytes (macOS 255-byte filename limit minus room for ext).
 pub(crate) fn sanitise_filename(s: &str) -> String {

--- a/crates/koan-music/src/commands/remote.rs
+++ b/crates/koan-music/src/commands/remote.rs
@@ -1,7 +1,7 @@
 use koan_core::config;
 use owo_colors::OwoColorize;
 
-use super::{get_remote_password, open_db};
+use super::open_db;
 
 pub fn cmd_remote_login(url: &str, username: &str) {
     if !url.starts_with("https://") && !url.contains("localhost") && !url.contains("127.0.0.1") {
@@ -42,22 +42,17 @@ pub fn cmd_remote_login(url: &str, username: &str) {
 
 pub fn cmd_remote_sync(full: bool) {
     let cfg = config::Config::load().unwrap_or_default();
-    if !cfg.remote.enabled || cfg.remote.url.is_empty() {
-        eprintln!(
-            "{} no remote server configured — run {} first",
-            "error:".red().bold(),
-            "koan remote login".bold()
-        );
-        std::process::exit(1);
-    }
-
-    let password = get_remote_password(&cfg);
-
-    let client = koan_core::remote::client::SubsonicClient::new(
-        &cfg.remote.url,
-        &cfg.remote.username,
-        &password,
-    );
+    let client = match super::subsonic_client(&cfg) {
+        Some(c) => c,
+        None => {
+            eprintln!(
+                "{} no remote server configured — run {} first",
+                "error:".red().bold(),
+                "koan remote login".bold()
+            );
+            std::process::exit(1);
+        }
+    };
 
     let db = open_db();
     let start = std::time::Instant::now();
@@ -148,12 +143,9 @@ pub fn cmd_remote_status() {
         }
     );
 
-    if has_password {
-        let client = koan_core::remote::client::SubsonicClient::new(
-            &cfg.remote.url,
-            &cfg.remote.username,
-            &cfg.remote.password,
-        );
+    if has_password
+        && let Some(client) = super::subsonic_client(&cfg)
+    {
         match client.ping() {
             Ok(()) => println!("{} {}", "status:".cyan(), "connected".green()),
             Err(e) => println!(

--- a/crates/koan-music/src/commands/remote.rs
+++ b/crates/koan-music/src/commands/remote.rs
@@ -143,9 +143,7 @@ pub fn cmd_remote_status() {
         }
     );
 
-    if has_password
-        && let Some(client) = super::subsonic_client(&cfg)
-    {
+    if has_password && let Some(client) = super::subsonic_client(&cfg) {
         match client.ping() {
             Ok(()) => println!("{} {}", "status:".cyan(), "connected".green()),
             Err(e) => println!(

--- a/crates/koan-music/src/commands/serve.rs
+++ b/crates/koan-music/src/commands/serve.rs
@@ -1025,16 +1025,10 @@ async fn proxy_stream_from_upstream(
     client_headers: &HeaderMap,
 ) -> Result<Response, SubsonicError> {
     let cfg = Config::load().unwrap_or_default();
-    if !cfg.remote.enabled {
-        return Err(SubsonicError::not_found("Remote server not configured"));
-    }
-
-    let password = super::get_remote_password(&cfg);
-    let client = koan_core::remote::client::SubsonicClient::new(
-        &cfg.remote.url,
-        &cfg.remote.username,
-        &password,
-    );
+    let client = match super::subsonic_client(&cfg) {
+        Some(c) => c,
+        None => return Err(SubsonicError::not_found("Remote server not configured")),
+    };
     let upstream_url = client.stream_url(remote_id);
 
     // Use reqwest async to proxy the stream.

--- a/crates/koan-music/src/tui/app.rs
+++ b/crates/koan-music/src/tui/app.rs
@@ -401,12 +401,7 @@ impl App {
             if let Ok(Some(remote_id)) = koan_core::db::queries::remote_id_for_path(&db.conn, path)
             {
                 let cfg = koan_core::config::Config::load().unwrap_or_default();
-                if cfg.remote.enabled && !cfg.remote.password.is_empty() {
-                    let client = koan_core::remote::client::SubsonicClient::new(
-                        &cfg.remote.url,
-                        &cfg.remote.username,
-                        &cfg.remote.password,
-                    );
+                if let Some(client) = crate::commands::subsonic_client(&cfg) {
                     let rid = remote_id.clone();
                     let star = is_fav;
                     std::thread::spawn(move || {
@@ -832,14 +827,7 @@ impl App {
                 let client = if radio_config.use_subsonic {
                     koan_core::config::Config::load()
                         .ok()
-                        .filter(|cfg| cfg.remote.enabled)
-                        .map(|cfg| {
-                            koan_core::remote::client::SubsonicClient::new(
-                                &cfg.remote.url,
-                                &cfg.remote.username,
-                                &cfg.remote.password,
-                            )
-                        })
+                        .and_then(|cfg| crate::commands::subsonic_client(&cfg))
                 } else {
                     None
                 };
@@ -1491,9 +1479,10 @@ impl App {
             return;
         }
 
-        let url = cfg.remote.url.clone();
-        let username = cfg.remote.username.clone();
-        let password = cfg.remote.password.clone();
+        let Some(client) = crate::commands::subsonic_client(&cfg) else {
+            self.status_message = Some(("Remote not configured".into(), std::time::Instant::now()));
+            return;
+        };
         let log_buffer = Arc::clone(&self.log_buffer);
 
         // Fire off share creation in a background thread to avoid blocking the UI.
@@ -1501,7 +1490,6 @@ impl App {
         let status_clone = Arc::clone(&status_msg);
 
         std::thread::spawn(move || {
-            let client = koan_core::remote::client::SubsonicClient::new(&url, &username, &password);
             let id_refs: Vec<&str> = share_ids.iter().map(|s| s.as_str()).collect();
             match client.create_share(&id_refs, None) {
                 Ok(share) => {


### PR DESCRIPTION
## Summary
- Adds `commands::subsonic_client(cfg)` factory that centralises remote-enabled check, password resolution, and client construction
- Replaces 9 duplicated `SubsonicClient::new()` call sites across enqueue, remote, graphql, serve, and tui/app
- Adds 30-second timeout to the reqwest HTTP client builder to prevent indefinite hangs on unresponsive Subsonic/Navidrome servers
- Net -20 lines (63 added, 83 removed)

## Test plan
- [x] `cargo test --workspace` — 88 passed
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --all` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)