### PR TITLE
fix(misc): batch ID precision, tokio features, unicode stricmp, ancillary logging

### DIFF
--- a/crates/koan-core/src/format/functions.rs
+++ b/crates/koan-core/src/format/functions.rs
@@ -168,7 +168,7 @@ pub fn call_function(name: &str, args: &[String]) -> Option<String> {
         "stricmp" => {
             let a = args.first()?;
             let b = args.get(1)?;
-            Some(bool_str(a.eq_ignore_ascii_case(b)))
+            Some(bool_str(a.to_lowercase() == b.to_lowercase()))
         }
         "longer" => {
             let a = args.first()?;

--- a/crates/koan-core/src/organize.rs
+++ b/crates/koan-core/src/organize.rs
@@ -461,7 +461,13 @@ fn execute_single_move_no_db(file_move: &FileMove) -> Result<(), OrganizeError> 
         if let Some(parent) = anc_to.parent() {
             std::fs::create_dir_all(parent).ok();
         }
-        move_file(anc_from, anc_to).ok();
+        if let Err(e) = move_file(anc_from, anc_to) {
+            log::warn!(
+                "failed to move ancillary file {}: {}",
+                anc_from.display(),
+                e
+            );
+        }
     }
 
     if let Some(source_dir) = file_move.from.parent() {
@@ -767,7 +773,7 @@ fn chrono_batch_id() -> String {
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default();
-    format!("batch-{}", now.as_millis())
+    format!("batch-{}", now.as_nanos())
 }
 
 #[cfg(test)]

--- a/crates/koan-music/Cargo.toml
+++ b/crates/koan-music/Cargo.toml
@@ -32,7 +32,7 @@ souvlaki = "0.8"
 toml = "0.9"
 walkdir = { workspace = true }
 rmcp = { version = "1.2.0", features = ["server", "macros", "transport-async-rw", "transport-io"] }
-tokio = { version = "1.50.0", features = ["full"] }
+tokio = { version = "1.50.0", features = ["rt-multi-thread", "net", "macros", "signal"] }
 serde_json = "1.0.149"
 serde = { version = "1.0.228", features = ["derive"] }
 uuid = { version = "1.22.0", features = ["v7"] }


### PR DESCRIPTION
## Summary

Fixes misc review items from #73:

- **M11** — `chrono_batch_id()` now uses `as_nanos()` instead of `as_millis()` to prevent millisecond-resolution collisions
- **L3** — `tokio` features in koan-music reduced from `"full"` to `["rt-multi-thread", "net", "macros", "signal"]`
- **L6** — `stricmp` format function uses Unicode-aware `.to_lowercase()` comparison instead of ASCII-only `eq_ignore_ascii_case()`
- **L8** — Ancillary file move errors in `execute_single_move_no_db` now log warnings via `log::warn!` instead of being silently swallowed with `.ok()`

## Test plan

- [x] `cargo clippy --workspace -- -D warnings` passes clean
- [x] `cargo fmt --all` applied
- [x] Full workspace compiles with reduced tokio features

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)