### PR TITLE
fix(audio): safety hardening — atomics, alignment, bounds checks, viz allocation

### DIFF
--- a/crates/koan-core/src/audio/buffer.rs
+++ b/crates/koan-core/src/audio/buffer.rs
@@ -107,10 +107,6 @@ pub struct PlaybackTimeline {
     /// Total interleaved samples consumed (played) by the audio engine.
     /// Written by CoreAudio render callback, read by UI.
     pub samples_played: Arc<AtomicU64>,
-    /// Channel count — needed to convert samples → frames for position calc.
-    channels: AtomicU64,
-    /// Sample rate — needed for position calc.
-    sample_rate: AtomicU64,
 }
 
 impl PlaybackTimeline {
@@ -119,17 +115,11 @@ impl PlaybackTimeline {
             boundaries: parking_lot::RwLock::new(Vec::new()),
             samples_written: AtomicU64::new(0),
             samples_played: Arc::new(AtomicU64::new(0)),
-            channels: AtomicU64::new(2),
-            sample_rate: AtomicU64::new(44100),
         })
     }
 
     /// Called by decode thread when starting a new track.
     fn push_boundary(&self, boundary: TrackBoundary) {
-        self.channels
-            .store(boundary.info.channels as u64, Ordering::Relaxed);
-        self.sample_rate
-            .store(boundary.info.sample_rate as u64, Ordering::Relaxed);
         self.boundaries.write().push(boundary);
     }
 
@@ -158,13 +148,23 @@ impl PlaybackTimeline {
     /// Derive current track info and position from the playback head.
     /// Called by the UI on every tick.
     /// Returns (id, path, stream_info, position_ms).
+    ///
+    /// Acquires the boundaries read lock BEFORE reading `samples_played` so
+    /// channels/sample_rate/boundaries are all from a consistent snapshot.
+    /// Without this ordering, a track transition could update the atomics
+    /// after we read `samples_played` but before we read the boundary list.
     pub fn current_playback(&self) -> Option<(QueueItemId, PathBuf, StreamInfo, u64)> {
-        let played = self.samples_played.load(Ordering::Relaxed);
+        // Lock first — ensures we see boundaries consistent with the atomic read.
         let bounds = self.boundaries.read();
 
         if bounds.is_empty() {
             return None;
         }
+
+        // Read samples_played while holding the lock. This guarantees we
+        // never observe a stale boundary list with a newer samples_played
+        // (or vice versa).
+        let played = self.samples_played.load(Ordering::Acquire);
 
         // Find which track the playback head is in via binary search.
         // partition_point returns first index where offset > played;

--- a/crates/koan-core/src/audio/cpal_backend.rs
+++ b/crates/koan-core/src/audio/cpal_backend.rs
@@ -193,7 +193,7 @@ impl AudioBackend for CpalBackend {
             dev.build_output_stream(
                 &config,
                 move |data: &mut [f32], _info: &cpal::OutputCallbackInfo| {
-                    if !running_cb.load(Ordering::Relaxed) {
+                    if !running_cb.load(Ordering::Acquire) {
                         data.fill(0.0);
                         return;
                     }
@@ -211,22 +211,22 @@ impl AudioBackend for CpalBackend {
                         && let Ok(chunk) = consumer.read_chunk(to_read)
                     {
                         let (first, second) = chunk.as_slices();
+                        let ring_total = first.len() + second.len();
+                        let copy_total = ring_total.min(total_samples);
+                        let first_copy = first.len().min(copy_total);
+                        let second_copy = copy_total.saturating_sub(first_copy).min(second.len());
                         unsafe {
-                            ptr::copy_nonoverlapping(
-                                first.as_ptr(),
-                                data.as_mut_ptr(),
-                                first.len(),
-                            );
-                            if !second.is_empty() {
+                            ptr::copy_nonoverlapping(first.as_ptr(), data.as_mut_ptr(), first_copy);
+                            if second_copy > 0 {
                                 ptr::copy_nonoverlapping(
                                     second.as_ptr(),
-                                    data.as_mut_ptr().add(first.len()),
-                                    second.len(),
+                                    data.as_mut_ptr().add(first_copy),
+                                    second_copy,
                                 );
                             }
                         }
                         chunk.commit_all();
-                        samples_played.fetch_add(to_read as u64, Ordering::Relaxed);
+                        samples_played.fetch_add(copy_total as u64, Ordering::AcqRel);
                     }
 
                     // Zero-pad remainder on underrun — silence > glitches.
@@ -258,21 +258,21 @@ unsafe impl Send for CpalEngineHandle {}
 
 impl AudioEngineHandle for CpalEngineHandle {
     fn start(&self) -> Result<(), BackendError> {
-        self.running.store(true, Ordering::Relaxed);
+        self.running.store(true, Ordering::Release);
         self.stream
             .play()
             .map_err(|e| BackendError::Platform(e.to_string()))
     }
 
     fn stop(&self) -> Result<(), BackendError> {
-        self.running.store(false, Ordering::Relaxed);
+        self.running.store(false, Ordering::Release);
         self.stream
             .pause()
             .map_err(|e| BackendError::Platform(e.to_string()))
     }
 
     fn is_running(&self) -> bool {
-        self.running.load(Ordering::Relaxed)
+        self.running.load(Ordering::Acquire)
     }
 }
 

--- a/crates/koan-core/src/audio/engine.rs
+++ b/crates/koan-core/src/audio/engine.rs
@@ -166,17 +166,17 @@ impl AudioEngine {
     }
 
     pub fn start(&self) -> Result<()> {
-        self.running.store(true, Ordering::Relaxed);
+        self.running.store(true, Ordering::Release);
         check(unsafe { AudioOutputUnitStart(self.audio_unit) })
     }
 
     pub fn stop(&self) -> Result<()> {
-        self.running.store(false, Ordering::Relaxed);
+        self.running.store(false, Ordering::Release);
         check(unsafe { AudioOutputUnitStop(self.audio_unit) })
     }
 
     pub fn is_running(&self) -> bool {
-        self.running.load(Ordering::Relaxed)
+        self.running.load(Ordering::Acquire)
     }
 }
 
@@ -243,7 +243,7 @@ unsafe extern "C" fn render_callback(
     // SAFETY: `io_data` is provided by CoreAudio and is valid for the callback's duration.
     let buffer_list = unsafe { &mut *io_data };
 
-    if !data.running.load(Ordering::Relaxed) {
+    if !data.running.load(Ordering::Acquire) {
         for i in 0..buffer_list.mNumberBuffers as usize {
             let buf = unsafe { &mut *buffer_list.mBuffers.as_mut_ptr().add(i) };
             if !buf.mData.is_null() {
@@ -260,10 +260,19 @@ unsafe extern "C" fn render_callback(
     let buf = unsafe { &mut *buffer_list.mBuffers.as_mut_ptr() };
     let channels = buf.mNumberChannels;
     let total_samples = (in_number_frames * channels) as usize;
-    debug_assert!(
-        (buf.mData as usize).is_multiple_of(mem::align_of::<f32>()),
-        "CoreAudio buffer not aligned for f32"
-    );
+    if !(buf.mData as usize).is_multiple_of(mem::align_of::<f32>()) {
+        log::error!("CoreAudio buffer not aligned for f32");
+        // Fill silence rather than risking UB from an unaligned cast.
+        for i in 0..buffer_list.mNumberBuffers as usize {
+            let b = unsafe { &mut *buffer_list.mBuffers.as_mut_ptr().add(i) };
+            if !b.mData.is_null() {
+                unsafe {
+                    ptr::write_bytes(b.mData as *mut u8, 0, b.mDataByteSize as usize);
+                }
+            }
+        }
+        return 0;
+    }
     let out_ptr = buf.mData as *mut f32;
 
     let available = data.consumer.slots();
@@ -273,15 +282,19 @@ unsafe extern "C" fn render_callback(
         && let Ok(chunk) = data.consumer.read_chunk(to_read)
     {
         let (first, second) = chunk.as_slices();
+        let ring_total = first.len() + second.len();
+        let copy_total = ring_total.min(total_samples);
+        let first_copy = first.len().min(copy_total);
+        let second_copy = copy_total.saturating_sub(first_copy).min(second.len());
         unsafe {
-            ptr::copy_nonoverlapping(first.as_ptr(), out_ptr, first.len());
-            if !second.is_empty() {
-                ptr::copy_nonoverlapping(second.as_ptr(), out_ptr.add(first.len()), second.len());
+            ptr::copy_nonoverlapping(first.as_ptr(), out_ptr, first_copy);
+            if second_copy > 0 {
+                ptr::copy_nonoverlapping(second.as_ptr(), out_ptr.add(first_copy), second_copy);
             }
         }
         chunk.commit_all();
         data.samples_played
-            .fetch_add(to_read as u64, Ordering::Relaxed);
+            .fetch_add(copy_total as u64, Ordering::AcqRel);
     }
 
     // Zero remaining frames on underrun — silence > glitches.

--- a/crates/koan-core/src/audio/viz.rs
+++ b/crates/koan-core/src/audio/viz.rs
@@ -207,7 +207,7 @@ impl VizBuffer {
         let buf_len = inner.buf.len();
         let pos = inner.write_pos;
         out.clear();
-        out.reserve(buf_len.saturating_sub(out.capacity()));
+        out.reserve(buf_len);
         // Write position is where the *next* sample goes, so the oldest
         // sample is at write_pos and the newest is at write_pos - 1.
         out.extend_from_slice(&inner.buf[pos..]);

--- a/crates/koan-core/src/audio/viz.rs
+++ b/crates/koan-core/src/audio/viz.rs
@@ -188,16 +188,30 @@ impl VizBuffer {
     /// Take a snapshot of the current buffer contents, ordered oldest to newest.
     ///
     /// Returns a contiguous `Vec<f32>` with the most recent samples in chronological order.
+    ///
+    /// Allocates a new Vec on every call. For hot paths (e.g. 60fps analysis),
+    /// prefer `snapshot_into` to reuse an existing buffer.
     pub fn snapshot(&self) -> Vec<f32> {
+        let mut out = Vec::new();
+        self.snapshot_into(&mut out);
+        out
+    }
+
+    /// Take a snapshot into a caller-provided buffer, avoiding allocation when
+    /// the buffer already has sufficient capacity.
+    ///
+    /// The buffer is cleared and filled with the most recent samples in
+    /// chronological order (oldest to newest).
+    pub fn snapshot_into(&self, out: &mut Vec<f32>) {
         let inner = self.samples.lock();
         let buf_len = inner.buf.len();
         let pos = inner.write_pos;
-        let mut out = Vec::with_capacity(buf_len);
+        out.clear();
+        out.reserve(buf_len.saturating_sub(out.capacity()));
         // Write position is where the *next* sample goes, so the oldest
         // sample is at write_pos and the newest is at write_pos - 1.
         out.extend_from_slice(&inner.buf[pos..]);
         out.extend_from_slice(&inner.buf[..pos]);
-        out
     }
 
     /// Take a snapshot bundled with metadata (channels, sample_rate).


### PR DESCRIPTION
## Summary

Addresses audio subsystem items from #73:

- **C1 (audio)**: Fixed atomic ordering — `samples_played` uses `AcqRel` on fetch_add, `Acquire` on loads. `running` flag uses `Acquire`/`Release`. No more `Relaxed` for cross-thread state.
- **C3**: `PlaybackTimeline::current_playback()` now acquires the boundaries read lock *first*, then reads `samples_played` inside that scope. Removed dead standalone `channels`/`sample_rate` atomics — channel count and sample rate are now always read from boundary info under lock.
- **C5**: Replaced `debug_assert!` alignment check in CoreAudio render callback with a runtime check that fills silence on misalignment instead of UB.
- **C6**: Buffer bounds validation before `ptr::copy_nonoverlapping` in both `engine.rs` and `cpal_backend.rs`. Clamps to available space and fills remainder with silence.
- **L1**: Added `VizBuffer::snapshot_into(&self, out: &mut Vec<f32>)` to reuse caller's buffer. `snapshot()` delegates to it for backwards compat.

## Test plan

- [x] All 88 tests pass
- [x] Zero clippy warnings
- [ ] Manual playback test on macOS (CoreAudio path)
- [ ] Verify visualizer still renders correctly

Closes #73 (partial)

🤖 Generated with [Claude Code](https://claude.com/claude-code)