### PR TITLE
fix(tui): terminal restore, cursor clamping, art cache, double-click, picker

### DIFF
--- a/crates/koan-music/src/commands/mod.rs
+++ b/crates/koan-music/src/commands/mod.rs
@@ -78,17 +78,18 @@ pub(crate) fn confirm(prompt: &str) -> bool {
 
 /// Install a panic hook that logs the panic to the log file and restores the terminal.
 ///
-/// Terminal restoration only happens when the *main thread* panics. Background
-/// thread panics (decode, download, etc.) are logged but must NOT touch the
-/// terminal — doing so corrupts the TUI and causes escape sequence leaks.
+/// Terminal restoration runs on ANY thread panic — raw mode + alternate screen
+/// must always be disabled so the user gets a usable terminal back. The
+/// restoration sequence is idempotent (safe to call multiple times or from a
+/// thread that never entered raw mode).
 pub(crate) fn install_terminal_panic_hook() {
     use crossterm::{
-        event::DisableMouseCapture,
+        cursor::Show,
+        event::{DisableBracketedPaste, DisableMouseCapture},
         execute,
         terminal::{LeaveAlternateScreen, disable_raw_mode},
     };
     use std::io;
-    let main_thread_id = std::thread::current().id();
     let original_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |panic| {
         // Log the panic to the log file before restoring the terminal.
@@ -109,11 +110,17 @@ pub(crate) fn install_terminal_panic_hook() {
         log::error!("backtrace:\n{}", bt);
         log::logger().flush();
 
-        // Only restore the terminal if this is the main (TUI) thread.
-        if std::thread::current().id() == main_thread_id {
-            let _ = disable_raw_mode();
-            let _ = execute!(io::stdout(), LeaveAlternateScreen, DisableMouseCapture);
-        }
+        // Always restore the terminal regardless of which thread panicked.
+        // All of these are idempotent — harmless if the terminal was never
+        // set up or already restored.
+        let _ = disable_raw_mode();
+        let _ = execute!(
+            io::stdout(),
+            LeaveAlternateScreen,
+            DisableMouseCapture,
+            DisableBracketedPaste,
+            Show
+        );
         original_hook(panic);
     }));
 }

--- a/crates/koan-music/src/tui/app.rs
+++ b/crates/koan-music/src/tui/app.rs
@@ -422,6 +422,15 @@ impl App {
         // Refresh visible queue cache so all tick logic sees current state.
         self.refresh_visible_queue();
 
+        // Clear stale double-click state after 1 second so a slow second click
+        // is never misinterpreted as a double-click.
+        if let Some(t) = self.last_click_time
+            && t.elapsed().as_secs() >= 1
+        {
+            self.last_click_time = None;
+            self.last_click_idx = None;
+        }
+
         self.frame_count = self.frame_count.wrapping_add(1);
 
         // FPS counter: sample every second.
@@ -530,8 +539,11 @@ impl App {
         }
 
         // Update now-playing cover art cache when track changes.
+        // Clear when nothing is playing so the old image gets freed.
         if let Some(ref info) = self.state.track_info() {
             self.art.now_playing_art.get(&info.path);
+        } else {
+            self.art.now_playing_art.clear();
         }
 
         // Update visualizer spectrum at configured FPS.
@@ -2438,10 +2450,7 @@ impl App {
         }
 
         self.queue.selected_ids.clear();
-        let visible_len = self.visible_queue().len();
-        if visible_len > 0 && self.queue.cursor >= visible_len {
-            self.queue.cursor = visible_len - 1;
-        }
+        self.clamp_queue_cursor();
     }
 
     /// Move all selected tracks down by one position.
@@ -2851,6 +2860,17 @@ impl App {
         self.queue.vq_cache.entries.get(idx).map(|e| e.id)
     }
 
+    /// Clamp the queue cursor to valid bounds. Call after any operation that
+    /// may shrink the queue (remove, clear, reorder, external playlist change).
+    fn clamp_queue_cursor(&mut self) {
+        let len = self.queue.vq_cache.entries.len();
+        if len == 0 {
+            self.queue.cursor = 0;
+        } else if self.queue.cursor >= len {
+            self.queue.cursor = len - 1;
+        }
+    }
+
     /// Refresh the cached visible queue snapshot from shared state.
     /// Call once per frame before any queue-related reads.
     pub fn refresh_visible_queue(&mut self) {
@@ -2858,6 +2878,8 @@ impl App {
         if v != self.queue.vq_version {
             self.queue.vq_cache = self.state.derive_visible_queue();
             self.queue.vq_version = v;
+            // Clamp cursor after every external playlist change.
+            self.clamp_queue_cursor();
         }
     }
 

--- a/crates/koan-music/src/tui/cover_art.rs
+++ b/crates/koan-music/src/tui/cover_art.rs
@@ -23,8 +23,9 @@ struct RenderedArt {
 }
 
 /// Transparent single-entry cache for cover art images.
-/// Caches both the decoded image AND the rendered halfblock output
-/// so frames that don't change size are a cheap blit.
+/// Holds at most ONE decoded image + its rendered halfblock output.
+/// When a new path is loaded the old image and all rendered buffers are dropped,
+/// keeping memory bounded (no multi-entry accumulation).
 pub struct CoverArtCache {
     path: Option<PathBuf>,
     image: Option<DynamicImage>,

--- a/crates/koan-music/src/tui/picker.rs
+++ b/crates/koan-music/src/tui/picker.rs
@@ -297,8 +297,15 @@ impl Widget for PickerOverlay<'_> {
         // Results.
         let snap = self.state.nucleo.snapshot();
         let visible_height = chunks[1].height as usize;
-        let start = if self.state.cursor >= visible_height {
-            self.state.cursor - visible_height + 1
+        // Clamp cursor to matched range — matched_count can shrink between
+        // ticks (e.g. background reparse) leaving cursor out of bounds.
+        let cursor = if matched == 0 {
+            0
+        } else {
+            self.state.cursor.min(matched - 1)
+        };
+        let start = if cursor >= visible_height {
+            cursor - visible_height + 1
         } else {
             0
         };
@@ -307,7 +314,7 @@ impl Widget for PickerOverlay<'_> {
         for (row, i) in (start..end).enumerate() {
             if let Some(item) = snap.get_matched_item(i as u32) {
                 let idx = *item.data as usize;
-                let is_cursor = i == self.state.cursor;
+                let is_cursor = i == cursor;
                 let is_selected = self.state.selected.contains(&idx);
 
                 let row_style = if is_cursor {


### PR DESCRIPTION
## Summary

Fixes from code review issue #73 — TUI/CLI layer safety improvements:

- **C7 — Terminal restoration on any thread panic**: Removed the main-thread-only guard from the panic hook. Terminal is now restored (raw mode, alternate screen, mouse capture, bracketed paste, cursor visibility) regardless of which thread panics. All restoration commands are idempotent.
- **H3 — Cursor clamping on queue mutation**: Added `clamp_queue_cursor()` helper called after `delete_selected()` and on every `refresh_visible_queue()` playlist version change. Render-time clamp in `ui.rs` kept as safety net.
- **H7 — Cover art cache bounded**: Documented that `CoverArtCache` is intentionally single-entry (one image at a time). Added explicit `clear()` when nothing is playing so the old `DynamicImage` gets freed.
- **M10 — Double-click timeout clearing**: `last_click_time` and `last_click_idx` are now cleared in the tick handler when older than 1 second, preventing stale state from being misinterpreted as a double-click.
- **L10 — Picker cursor safety**: Render loop now clamps cursor to `matched_count` range before computing scroll offset and cursor highlight, preventing out-of-bounds if matched count shrinks between ticks.

## Test plan

- [ ] Build with `just check` (clippy -D warnings + tests)
- [ ] Verify terminal restores correctly after a panic on any thread
- [ ] Delete tracks from queue, confirm cursor stays valid
- [ ] Change tracks, confirm cover art memory doesn't leak
- [ ] Click items slowly (>1s apart), confirm no false double-clicks
- [ ] Type rapidly in picker while results shrink, confirm no panics

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)