### PR TITLE
release: v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.17.0 (2026-03-26)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,47 @@
 
 ### Fixed
 
-- **Replace hand-rolled ISO 8601 parser with chrono** — the manual RFC 3339 parser in `remote/sync.rs` (~70 lines) could panic on malformed input from Subsonic servers. Replaced with `chrono::DateTime::parse_from_rfc3339()` + fallback patterns for common server quirks (missing timezone, fractional seconds, space separators). Added 11 unit tests ([#73](https://github.com/radiosilence/koan/issues/73))
+#### Remote
+
+- **Replace hand-rolled ISO 8601 parser with chrono** — the manual RFC 3339 parser in `remote/sync.rs` (~70 lines) could panic on malformed input from Subsonic servers. Replaced with `chrono::DateTime::parse_from_rfc3339()` + fallback patterns for common server quirks (missing timezone, fractional seconds, space separators). Added 11 unit tests ([#74](https://github.com/radiosilence/koan/pull/74))
+
+#### Audio
+
+- **Atomic ordering hardened** — `samples_played` uses `AcqRel` on fetch_add, `Acquire` on loads. `running` flag uses `Acquire`/`Release`. No more `Relaxed` for cross-thread state ([#76](https://github.com/radiosilence/koan/pull/76))
+- **Timeline lock ordering** — `PlaybackTimeline::current_playback()` now acquires the boundaries read lock first, then reads `samples_played` inside that scope. Dead standalone `channels`/`sample_rate` atomics removed ([#76](https://github.com/radiosilence/koan/pull/76))
+- **Alignment check in CoreAudio callback** — replaced `debug_assert!` with a runtime check that fills silence on misalignment instead of UB ([#76](https://github.com/radiosilence/koan/pull/76))
+- **Buffer bounds validation** — `ptr::copy_nonoverlapping` in `engine.rs` and `cpal_backend.rs` now clamps to available space and fills remainder with silence ([#76](https://github.com/radiosilence/koan/pull/76))
+- **VizBuffer allocation reuse** — added `VizBuffer::snapshot_into(&self, out: &mut Vec<f32>)` to reuse caller's buffer instead of allocating per frame ([#76](https://github.com/radiosilence/koan/pull/76))
+
+#### Player
+
+- **Atomic ordering across player state** — all cross-thread atomics (`playback_state`, `position_ms`, `playback_generation`, `playlist_version`, `bytes_written`, `quit_requested`, `metadata_refresh_pending`, `radio_mode`, `pump_written`) upgraded from `Relaxed` to `Acquire`/`Release`/`AcqRel` ([#78](https://github.com/radiosilence/koan/pull/78))
+- **Undo stack O(1) eviction** — `Vec` replaced with `VecDeque` for O(1) `pop_front()` instead of O(n) `remove(0)`. Batch depth capped at 500 to prevent unbounded nesting ([#78](https://github.com/radiosilence/koan/pull/78))
+- **Seek underflow on short tracks** — guard `max_ms > 5_000` before subtracting safety margin, preventing short/partially-downloaded tracks from clamping seek to 0 ([#78](https://github.com/radiosilence/koan/pull/78))
+- **ClearPlaylist snapshot race** — `stop_playback_and_clear_state()` (engine teardown only) now runs before snapshotting the playlist for undo, then clears. Previously `stop()` cleared the playlist before the undo snapshot was captured ([#78](https://github.com/radiosilence/koan/pull/78))
+
+#### TUI
+
+- **Terminal restoration on any thread panic** — removed main-thread-only guard from panic hook. Terminal is restored (raw mode, alternate screen, mouse capture, bracketed paste, cursor) regardless of which thread panics ([#77](https://github.com/radiosilence/koan/pull/77))
+- **Cursor clamping on queue mutation** — `clamp_queue_cursor()` called after `delete_selected()` and on every playlist version change. Render-time clamp kept as safety net ([#77](https://github.com/radiosilence/koan/pull/77))
+- **Cover art cache bounded** — `CoverArt::clear()` frees the `DynamicImage` when nothing is playing ([#77](https://github.com/radiosilence/koan/pull/77))
+- **Double-click timeout clearing** — stale `last_click_time`/`last_click_idx` cleared after 1 second, preventing misinterpreted double-clicks ([#77](https://github.com/radiosilence/koan/pull/77))
+- **Picker cursor safety** — render loop clamps cursor to `matched_count` range before computing scroll offset, preventing out-of-bounds when results shrink between ticks ([#77](https://github.com/radiosilence/koan/pull/77))
+
+#### Database
+
+- **Transaction boundaries** — `upsert_track()` wraps the entire artist/album/track/FTS5 operation in a savepoint. Scanner and analyzer use proper `unchecked_transaction()` with error propagation instead of silent `let _ =` drops ([#79](https://github.com/radiosilence/koan/pull/79))
+- **Source column validation** — `CHECK (source IN ('local', 'remote', 'cached'))` constraint on tracks table ([#79](https://github.com/radiosilence/koan/pull/79))
+- **WAL checkpoint on connect** — `PRAGMA wal_checkpoint(PASSIVE)` at connection open prevents unbounded WAL growth across sessions ([#79](https://github.com/radiosilence/koan/pull/79))
+- **LIKE wildcard escaping** — `remove_stale_tracks` now escapes `%`, `_`, `\` in path prefixes via `escape_like()` ([#79](https://github.com/radiosilence/koan/pull/79))
+- **Missing index** — added `idx_library_folders_path` on `library_folders(path)` ([#79](https://github.com/radiosilence/koan/pull/79))
+
+#### Misc
+
+- **Batch ID collision** — `chrono_batch_id()` uses `as_nanos()` instead of `as_millis()` to prevent millisecond-resolution collisions ([#75](https://github.com/radiosilence/koan/pull/75))
+- **Unicode-aware string comparison** — `stricmp` format function uses `.to_lowercase()` instead of ASCII-only `eq_ignore_ascii_case()` ([#75](https://github.com/radiosilence/koan/pull/75))
+- **Ancillary file move errors logged** — `execute_single_move_no_db` now logs warnings via `log::warn!` instead of silently swallowing with `.ok()` ([#75](https://github.com/radiosilence/koan/pull/75))
+- **Tokio features scoped** — `"full"` replaced with `["rt-multi-thread", "net", "macros", "signal"]` in koan-music ([#75](https://github.com/radiosilence/koan/pull/75))
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1973,10 +1973,11 @@ dependencies = [
 
 [[package]]
 name = "koan-core"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "bliss-audio",
  "bliss-audio-aubio-rs",
+ "chrono",
  "core-foundation 0.9.4",
  "coreaudio-sys",
  "cpal",
@@ -2006,7 +2007,7 @@ dependencies = [
 
 [[package]]
 name = "koan-music"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",
@@ -4065,7 +4066,6 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/koan-core", "crates/koan-music"]
 
 [workspace.package]
-version = "0.16.0"
+version = "0.17.0"
 edition = "2024"
 homepage = "https://github.com/radiosilence/koan"
 repository = "https://github.com/radiosilence/koan"

--- a/crates/koan-music/Cargo.toml
+++ b/crates/koan-music/Cargo.toml
@@ -20,7 +20,7 @@ ctrlc = "3"
 crossbeam-channel = "0.5"
 crossterm = "0.28"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "webp"] }
-koan-core = { path = "../koan-core", version = "0.16.0" }
+koan-core = { path = "../koan-core", version = "0.17.0" }
 log = "0.4"
 nucleo = "0.5"
 owo-colors = "4"


### PR DESCRIPTION
## v0.17.0

### Highlights
- **Unified daemon mode** — TUI + GraphQL API in one process (`--headless`, `--daemonize`, `--no-api`)
- **Safety hardening** — comprehensive audit fixes across audio, player, TUI, database, and remote subsystems

### Fixed
- Remote: chrono parser replaces panicky hand-rolled ISO 8601 (#74)
- Audio: atomic ordering, alignment checks, buffer bounds, viz allocation reuse (#76)
- Player: atomics, VecDeque undo stack, seek underflow, ClearPlaylist snapshot race (#78)
- TUI: panic hook terminal restore from any thread, cursor clamping, art cache, double-click, picker (#77)
- Database: transaction boundaries, CHECK constraint, WAL checkpoint, LIKE escaping (#79)
- Misc: batch ID nanos, Unicode stricmp, ancillary logging, tokio features (#75)

### Changed
- Unified daemon mode — all interfaces share one player, one state (#72)
- GraphQL config reflects daemon flags

**Tag `v0.17.0` after merge.**