### PR TITLE
Feature: Adding env var overrides for remote url, user, pass, and config file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 - **Album-aware download priority** — when a track starts playing, remaining tracks from the same album are bumped to the front of the download queue, ensuring gapless album playback ([#87](https://github.com/radiosilence/koan/issues/87))
 - **CONTRIBUTING.md** — contribution guidelines ([#82](https://github.com/radiosilence/koan/issues/82))
+- **Environment variable config overrides** — `KOAN_CONFIG_DIR`, `KOAN_REMOTE_URL`, `KOAN_REMOTE_USERNAME`, `KOAN_REMOTE_PASSWORD` override file-based config at runtime. Env-sourced values are tracked and excluded from `save()`/`save_local()` to prevent secrets leaking to disk ([#83](https://github.com/radiosilence/koan/pull/83))
 
 ## v0.17.0 (2026-03-26)
 

--- a/crates/koan-core/src/config.rs
+++ b/crates/koan-core/src/config.rs
@@ -328,15 +328,19 @@ impl Config {
             deep_merge(&mut base_val, local_val);
         }
 
-        let config: Config = base_val.try_into()?;
+        let mut config: Config = base_val.try_into()?;
+        config.apply_env_overrides();
         Ok(config)
     }
 
     /// Load config, logging and falling back to defaults on error.
+    /// Env overrides are always applied (via `load()`, or on the default fallback).
     pub fn load_or_default() -> Self {
         Self::load().unwrap_or_else(|e| {
             log::warn!("failed to load config, using defaults: {}", e);
-            Self::default()
+            let mut cfg = Self::default();
+            cfg.apply_env_overrides();
+            cfg
         })
     }
 
@@ -389,6 +393,27 @@ impl Config {
             .as_deref()
             .and_then(parse_size_bytes)
     }
+
+    /// Apply `KOAN_REMOTE_*` env var overrides on top of file-based config.
+    /// Non-empty env values win; unset or empty vars are ignored.
+    fn apply_env_overrides(&mut self) {
+        if let Ok(url) = std::env::var("KOAN_REMOTE_URL") {
+            if !url.is_empty() {
+                self.remote.url = url;
+                self.remote.enabled = true;
+            }
+        }
+        if let Ok(username) = std::env::var("KOAN_REMOTE_USERNAME") {
+            if !username.is_empty() {
+                self.remote.username = username;
+            }
+        }
+        if let Ok(password) = std::env::var("KOAN_REMOTE_PASSWORD") {
+            if !password.is_empty() {
+                self.remote.password = password;
+            }
+        }
+    }
 }
 
 /// Recursively merge `overlay` into `base`. Only keys present in `overlay`
@@ -409,8 +434,11 @@ fn deep_merge(base: &mut toml::Value, overlay: toml::Value) {
     }
 }
 
-/// `~/.config/koan/`
+/// Config directory — `KOAN_CONFIG_DIR` env var, or `~/.config/koan/`.
 pub fn config_dir() -> PathBuf {
+    if let Ok(dir) = std::env::var("KOAN_CONFIG_DIR") {
+        return PathBuf::from(dir);
+    }
     dirs::home_dir()
         .unwrap_or_else(|| PathBuf::from("."))
         .join(".config")

--- a/crates/koan-core/src/config.rs
+++ b/crates/koan-core/src/config.rs
@@ -15,6 +15,16 @@ pub enum ConfigError {
     Serialize(#[from] toml::ser::Error),
 }
 
+/// Tracks which config fields were sourced from environment variables
+/// so they can be excluded when saving back to disk.
+#[derive(Debug, Clone, Default)]
+pub struct EnvOverrides {
+    pub remote_url: bool,
+    pub remote_username: bool,
+    pub remote_password: bool,
+    pub remote_enabled: bool,
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default)]
 pub struct Config {
@@ -27,6 +37,9 @@ pub struct Config {
     pub radio: RadioConfig,
     pub graphql: GraphqlConfig,
     pub discovery: DiscoveryConfig,
+    /// Fields sourced from env vars — excluded from serialization on save.
+    #[serde(skip)]
+    pub env_overrides: EnvOverrides,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -351,24 +364,42 @@ impl Config {
         Ok(config)
     }
 
+    /// Return a clone with env-overridden fields reset to defaults,
+    /// so they are never persisted to disk.
+    fn without_env_overrides(&self) -> Self {
+        let mut clean = self.clone();
+        let ov = &self.env_overrides;
+
+        if ov.remote_url { clean.remote.url = String::new(); }
+        if ov.remote_username { clean.remote.username = String::new(); }
+        if ov.remote_password { clean.remote.password = String::new(); }
+        if ov.remote_enabled { clean.remote.enabled = false; }
+
+        clean
+    }
+
     /// Write config to the base config.toml.
+    /// Fields sourced from env vars are excluded.
     pub fn save(&self) -> Result<(), ConfigError> {
         let path = config_file_path();
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent)?;
         }
-        let contents = toml::to_string_pretty(self)?;
+        let clean = self.without_env_overrides();
+        let contents = toml::to_string_pretty(&clean)?;
         fs::write(&path, contents)?;
         Ok(())
     }
 
     /// Write config to config.local.toml (for machine-specific / sensitive values).
+    /// Fields sourced from env vars are excluded.
     pub fn save_local(&self) -> Result<(), ConfigError> {
         let path = config_local_file_path();
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent)?;
         }
-        let contents = toml::to_string_pretty(self)?;
+        let clean = self.without_env_overrides();
+        let contents = toml::to_string_pretty(&clean)?;
         fs::write(&path, contents)?;
         #[cfg(unix)]
         {
@@ -396,22 +427,27 @@ impl Config {
 
     /// Apply `KOAN_REMOTE_*` env var overrides on top of file-based config.
     /// Non-empty env values win; unset or empty vars are ignored.
+    /// Tracks which fields were overridden so `save()` can exclude them.
     fn apply_env_overrides(&mut self) {
-        if let Ok(url) = std::env::var("KOAN_REMOTE_URL") {
-            if !url.is_empty() {
-                self.remote.url = url;
-                self.remote.enabled = true;
-            }
+        if let Ok(url) = std::env::var("KOAN_REMOTE_URL")
+            && !url.is_empty()
+        {
+            self.remote.url = url;
+            self.remote.enabled = true;
+            self.env_overrides.remote_url = true;
+            self.env_overrides.remote_enabled = true;
         }
-        if let Ok(username) = std::env::var("KOAN_REMOTE_USERNAME") {
-            if !username.is_empty() {
-                self.remote.username = username;
-            }
+        if let Ok(username) = std::env::var("KOAN_REMOTE_USERNAME")
+            && !username.is_empty()
+        {
+            self.remote.username = username;
+            self.env_overrides.remote_username = true;
         }
-        if let Ok(password) = std::env::var("KOAN_REMOTE_PASSWORD") {
-            if !password.is_empty() {
-                self.remote.password = password;
-            }
+        if let Ok(password) = std::env::var("KOAN_REMOTE_PASSWORD")
+            && !password.is_empty()
+        {
+            self.remote.password = password;
+            self.env_overrides.remote_password = true;
         }
     }
 }
@@ -436,7 +472,9 @@ fn deep_merge(base: &mut toml::Value, overlay: toml::Value) {
 
 /// Config directory — `KOAN_CONFIG_DIR` env var, or `~/.config/koan/`.
 pub fn config_dir() -> PathBuf {
-    if let Ok(dir) = std::env::var("KOAN_CONFIG_DIR") {
+    if let Ok(dir) = std::env::var("KOAN_CONFIG_DIR")
+        && !dir.is_empty()
+    {
         return PathBuf::from(dir);
     }
     dirs::home_dir()
@@ -787,59 +825,140 @@ port = 4000
 
     #[test]
     fn test_parse_size_bytes() {
-        assert_eq!(parse_size_bytes("50GB"), Some(50 * 1024 * 1024 * 1024));
-        assert_eq!(parse_size_bytes("500MB"), Some(500 * 1024 * 1024));
-        assert_eq!(parse_size_bytes("1TB"), Some(1024 * 1024 * 1024 * 1024));
-        assert_eq!(parse_size_bytes("100KB"), Some(100 * 1024));
-        assert_eq!(parse_size_bytes("1024B"), Some(1024));
-        assert_eq!(parse_size_bytes("1024"), Some(1024));
++        assert_eq!(parse_size_bytes("50GB"), Some(50 * 1024 * 1024 * 1024));
++        assert_eq!(parse_size_bytes("500MB"), Some(500 * 1024 * 1024));
++        assert_eq!(parse_size_bytes("1TB"), Some(1024 * 1024 * 1024 * 1024));
++        assert_eq!(parse_size_bytes("100KB"), Some(100 * 1024));
++        assert_eq!(parse_size_bytes("1024B"), Some(1024));
++        assert_eq!(parse_size_bytes("1024"), Some(1024));
++
++        // Case insensitive.
++        assert_eq!(parse_size_bytes("50gb"), Some(50 * 1024 * 1024 * 1024));
++        assert_eq!(parse_size_bytes("50Gb"), Some(50 * 1024 * 1024 * 1024));
++
++        // Short suffixes.
++        assert_eq!(parse_size_bytes("50G"), Some(50 * 1024 * 1024 * 1024));
++        assert_eq!(parse_size_bytes("500M"), Some(500 * 1024 * 1024));
++
++        // Spaces.
++        assert_eq!(parse_size_bytes("50 GB"), Some(50 * 1024 * 1024 * 1024));
++        assert_eq!(parse_size_bytes(" 50GB "), Some(50 * 1024 * 1024 * 1024));
++
++        // Decimal.
++        assert_eq!(
++            parse_size_bytes("1.5GB"),
++            Some((1.5 * 1024.0 * 1024.0 * 1024.0) as u64)
++        );
++
++        // Invalid.
++        assert_eq!(parse_size_bytes(""), None);
++        assert_eq!(parse_size_bytes("abc"), None);
++        assert_eq!(parse_size_bytes("50XB"), None);
++    }
++
++    #[test]
++    fn test_cache_limit_config_from_toml() {
++        let toml_str = r#"
++[remote]
++cache_limit = "50GB"
++"#;
++        let cfg: Config = toml::from_str(toml_str).unwrap();
++        assert_eq!(cfg.remote.cache_limit.as_deref(), Some("50GB"));
++        assert_eq!(cfg.cache_limit_bytes(), Some(50 * 1024 * 1024 * 1024));
++    }
++
++    #[test]
++    fn test_cache_limit_none_by_default() {
++        let cfg = Config::default();
++        assert!(cfg.remote.cache_limit.is_none());
++        assert!(cfg.cache_limit_bytes().is_none());
++    }
++
++    #[test]
++    fn test_cache_limit_not_serialized_when_none() {
++        let cfg = Config::default();
++        let serialized = toml::to_string_pretty(&cfg).unwrap();
++        assert!(!serialized.contains("cache_limit"));
++    }
 
-        // Case insensitive.
-        assert_eq!(parse_size_bytes("50gb"), Some(50 * 1024 * 1024 * 1024));
-        assert_eq!(parse_size_bytes("50Gb"), Some(50 * 1024 * 1024 * 1024));
+    #[test]
+    fn test_env_overrides_sets_tracking_flags() {
+        let mut cfg = Config::default();
+        cfg.remote.url = "https://env.example.com".into();
+        cfg.remote.username = "envuser".into();
+        cfg.remote.password = "envpass".into();
+        cfg.remote.enabled = true;
+        cfg.env_overrides = EnvOverrides {
+            remote_url: true,
+            remote_username: true,
+            remote_password: true,
+            remote_enabled: true,
+        };
 
-        // Short suffixes.
-        assert_eq!(parse_size_bytes("50G"), Some(50 * 1024 * 1024 * 1024));
-        assert_eq!(parse_size_bytes("500M"), Some(500 * 1024 * 1024));
-
-        // Spaces.
-        assert_eq!(parse_size_bytes("50 GB"), Some(50 * 1024 * 1024 * 1024));
-        assert_eq!(parse_size_bytes(" 50GB "), Some(50 * 1024 * 1024 * 1024));
-
-        // Decimal.
-        assert_eq!(
-            parse_size_bytes("1.5GB"),
-            Some((1.5 * 1024.0 * 1024.0 * 1024.0) as u64)
-        );
-
-        // Invalid.
-        assert_eq!(parse_size_bytes(""), None);
-        assert_eq!(parse_size_bytes("abc"), None);
-        assert_eq!(parse_size_bytes("50XB"), None);
+        assert!(cfg.env_overrides.remote_url);
+        assert!(cfg.env_overrides.remote_username);
+        assert!(cfg.env_overrides.remote_password);
+        assert!(cfg.env_overrides.remote_enabled);
     }
 
     #[test]
-    fn test_cache_limit_config_from_toml() {
-        let toml_str = r#"
-[remote]
-cache_limit = "50GB"
-"#;
-        let cfg: Config = toml::from_str(toml_str).unwrap();
-        assert_eq!(cfg.remote.cache_limit.as_deref(), Some("50GB"));
-        assert_eq!(cfg.cache_limit_bytes(), Some(50 * 1024 * 1024 * 1024));
+    fn test_env_overrides_excluded_from_save() {
+        let mut cfg = Config::default();
+        cfg.remote.url = "https://env.example.com".into();
+        cfg.remote.username = "envuser".into();
+        cfg.remote.password = "envpass".into();
+        cfg.remote.enabled = true;
+        cfg.env_overrides = EnvOverrides {
+            remote_url: true,
+            remote_username: true,
+            remote_password: true,
+            remote_enabled: true,
+        };
+
+        let clean = cfg.without_env_overrides();
+        let serialized = toml::to_string_pretty(&clean).unwrap();
+
+        assert!(!serialized.contains("env.example.com"));
+        assert!(!serialized.contains("envuser"));
+        assert!(!serialized.contains("envpass"));
     }
 
     #[test]
-    fn test_cache_limit_none_by_default() {
-        let cfg = Config::default();
-        assert!(cfg.remote.cache_limit.is_none());
-        assert!(cfg.cache_limit_bytes().is_none());
+    fn test_env_overrides_preserve_file_sourced_fields() {
+        let mut cfg = Config::default();
+        cfg.remote.url = "https://file.example.com".into();
+        cfg.remote.username = "fileuser".into();
+        cfg.remote.password = "envpass".into();
+        cfg.remote.enabled = true;
+        // Only password came from env — url, username, enabled are file-sourced.
+        cfg.env_overrides = EnvOverrides {
+            remote_password: true,
+            ..EnvOverrides::default()
+        };
+
+        let clean = cfg.without_env_overrides();
+
+        assert_eq!(clean.remote.url, "https://file.example.com");
+        assert_eq!(clean.remote.username, "fileuser");
+        assert!(clean.remote.password.is_empty());
+        assert!(clean.remote.enabled);
     }
 
     #[test]
-    fn test_cache_limit_not_serialized_when_none() {
-        let cfg = Config::default();
+    fn test_env_overrides_not_serialized() {
+        // env_overrides field itself should never appear in TOML output.
+        let mut cfg = Config::default();
+        cfg.env_overrides.remote_url = true;
         let serialized = toml::to_string_pretty(&cfg).unwrap();
-        assert!(!serialized.contains("cache_limit"));
+        assert!(!serialized.contains("env_overrides"));
+    }
+
+    #[test]
+    fn test_config_dir_empty_env_ignored() {
+        // SAFETY: single-threaded test, no concurrent env access.
+        unsafe { std::env::set_var("KOAN_CONFIG_DIR", "") };
+        let dir = config_dir();
+        assert!(dir.ends_with("koan"));
+        unsafe { std::env::remove_var("KOAN_CONFIG_DIR") };
     }
 }

--- a/crates/koan-core/src/config.rs
+++ b/crates/koan-core/src/config.rs
@@ -370,37 +370,57 @@ impl Config {
         let mut clean = self.clone();
         let ov = &self.env_overrides;
 
-        if ov.remote_url { clean.remote.url = String::new(); }
-        if ov.remote_username { clean.remote.username = String::new(); }
-        if ov.remote_password { clean.remote.password = String::new(); }
-        if ov.remote_enabled { clean.remote.enabled = false; }
+        if ov.remote_url {
+            clean.remote.url = String::new();
+        }
+        if ov.remote_username {
+            clean.remote.username = String::new();
+        }
+        if ov.remote_password {
+            clean.remote.password = String::new();
+        }
+        if ov.remote_enabled {
+            clean.remote.enabled = false;
+        }
 
         clean
     }
 
-    /// Write config to the base config.toml.
-    /// Fields sourced from env vars are excluded.
-    pub fn save(&self) -> Result<(), ConfigError> {
-        let path = config_file_path();
+    /// Merge the in-memory config (with env-overridden fields stripped) into
+    /// the existing on-disk file, preserving file-sourced values we didn't touch.
+    fn save_to(&self, path: &Path) -> Result<(), ConfigError> {
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent)?;
         }
+
+        // Read existing file as TOML tree (preserves values we didn't change).
+        let mut on_disk: toml::Value = if path.exists() {
+            let contents = fs::read_to_string(path)?;
+            toml::from_str(&contents)?
+        } else {
+            toml::Value::Table(toml::map::Map::new())
+        };
+
+        // Serialize cleaned config (env-sourced fields cleared) and merge on top.
         let clean = self.without_env_overrides();
-        let contents = toml::to_string_pretty(&clean)?;
-        fs::write(&path, contents)?;
+        let overlay: toml::Value = toml::Value::try_from(&clean)?;
+        deep_merge(&mut on_disk, overlay);
+
+        fs::write(path, toml::to_string_pretty(&on_disk)?)?;
         Ok(())
     }
 
+    /// Write config to the base config.toml.
+    /// Env-sourced fields are excluded; file-sourced values are preserved.
+    pub fn save(&self) -> Result<(), ConfigError> {
+        self.save_to(&config_file_path())
+    }
+
     /// Write config to config.local.toml (for machine-specific / sensitive values).
-    /// Fields sourced from env vars are excluded.
+    /// Env-sourced fields are excluded; file-sourced values are preserved.
     pub fn save_local(&self) -> Result<(), ConfigError> {
         let path = config_local_file_path();
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent)?;
-        }
-        let clean = self.without_env_overrides();
-        let contents = toml::to_string_pretty(&clean)?;
-        fs::write(&path, contents)?;
+        self.save_to(&path)?;
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
@@ -825,61 +845,61 @@ port = 4000
 
     #[test]
     fn test_parse_size_bytes() {
-+        assert_eq!(parse_size_bytes("50GB"), Some(50 * 1024 * 1024 * 1024));
-+        assert_eq!(parse_size_bytes("500MB"), Some(500 * 1024 * 1024));
-+        assert_eq!(parse_size_bytes("1TB"), Some(1024 * 1024 * 1024 * 1024));
-+        assert_eq!(parse_size_bytes("100KB"), Some(100 * 1024));
-+        assert_eq!(parse_size_bytes("1024B"), Some(1024));
-+        assert_eq!(parse_size_bytes("1024"), Some(1024));
-+
-+        // Case insensitive.
-+        assert_eq!(parse_size_bytes("50gb"), Some(50 * 1024 * 1024 * 1024));
-+        assert_eq!(parse_size_bytes("50Gb"), Some(50 * 1024 * 1024 * 1024));
-+
-+        // Short suffixes.
-+        assert_eq!(parse_size_bytes("50G"), Some(50 * 1024 * 1024 * 1024));
-+        assert_eq!(parse_size_bytes("500M"), Some(500 * 1024 * 1024));
-+
-+        // Spaces.
-+        assert_eq!(parse_size_bytes("50 GB"), Some(50 * 1024 * 1024 * 1024));
-+        assert_eq!(parse_size_bytes(" 50GB "), Some(50 * 1024 * 1024 * 1024));
-+
-+        // Decimal.
-+        assert_eq!(
-+            parse_size_bytes("1.5GB"),
-+            Some((1.5 * 1024.0 * 1024.0 * 1024.0) as u64)
-+        );
-+
-+        // Invalid.
-+        assert_eq!(parse_size_bytes(""), None);
-+        assert_eq!(parse_size_bytes("abc"), None);
-+        assert_eq!(parse_size_bytes("50XB"), None);
-+    }
-+
-+    #[test]
-+    fn test_cache_limit_config_from_toml() {
-+        let toml_str = r#"
-+[remote]
-+cache_limit = "50GB"
-+"#;
-+        let cfg: Config = toml::from_str(toml_str).unwrap();
-+        assert_eq!(cfg.remote.cache_limit.as_deref(), Some("50GB"));
-+        assert_eq!(cfg.cache_limit_bytes(), Some(50 * 1024 * 1024 * 1024));
-+    }
-+
-+    #[test]
-+    fn test_cache_limit_none_by_default() {
-+        let cfg = Config::default();
-+        assert!(cfg.remote.cache_limit.is_none());
-+        assert!(cfg.cache_limit_bytes().is_none());
-+    }
-+
-+    #[test]
-+    fn test_cache_limit_not_serialized_when_none() {
-+        let cfg = Config::default();
-+        let serialized = toml::to_string_pretty(&cfg).unwrap();
-+        assert!(!serialized.contains("cache_limit"));
-+    }
+        assert_eq!(parse_size_bytes("50GB"), Some(50 * 1024 * 1024 * 1024));
+        assert_eq!(parse_size_bytes("500MB"), Some(500 * 1024 * 1024));
+        assert_eq!(parse_size_bytes("1TB"), Some(1024 * 1024 * 1024 * 1024));
+        assert_eq!(parse_size_bytes("100KB"), Some(100 * 1024));
+        assert_eq!(parse_size_bytes("1024B"), Some(1024));
+        assert_eq!(parse_size_bytes("1024"), Some(1024));
+
+        // Case insensitive.
+        assert_eq!(parse_size_bytes("50gb"), Some(50 * 1024 * 1024 * 1024));
+        assert_eq!(parse_size_bytes("50Gb"), Some(50 * 1024 * 1024 * 1024));
+
+        // Short suffixes.
+        assert_eq!(parse_size_bytes("50G"), Some(50 * 1024 * 1024 * 1024));
+        assert_eq!(parse_size_bytes("500M"), Some(500 * 1024 * 1024));
+
+        // Spaces.
+        assert_eq!(parse_size_bytes("50 GB"), Some(50 * 1024 * 1024 * 1024));
+        assert_eq!(parse_size_bytes(" 50GB "), Some(50 * 1024 * 1024 * 1024));
+
+        // Decimal.
+        assert_eq!(
+            parse_size_bytes("1.5GB"),
+            Some((1.5 * 1024.0 * 1024.0 * 1024.0) as u64)
+        );
+
+        // Invalid.
+        assert_eq!(parse_size_bytes(""), None);
+        assert_eq!(parse_size_bytes("abc"), None);
+        assert_eq!(parse_size_bytes("50XB"), None);
+    }
+
+    #[test]
+    fn test_cache_limit_config_from_toml() {
+        let toml_str = r#"
+[remote]
+cache_limit = "50GB"
+"#;
+        let cfg: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(cfg.remote.cache_limit.as_deref(), Some("50GB"));
+        assert_eq!(cfg.cache_limit_bytes(), Some(50 * 1024 * 1024 * 1024));
+    }
+
+    #[test]
+    fn test_cache_limit_none_by_default() {
+        let cfg = Config::default();
+        assert!(cfg.remote.cache_limit.is_none());
+        assert!(cfg.cache_limit_bytes().is_none());
+    }
+
+    #[test]
+    fn test_cache_limit_not_serialized_when_none() {
+        let cfg = Config::default();
+        let serialized = toml::to_string_pretty(&cfg).unwrap();
+        assert!(!serialized.contains("cache_limit"));
+    }
 
     #[test]
     fn test_env_overrides_sets_tracking_flags() {
@@ -960,5 +980,43 @@ port = 4000
         let dir = config_dir();
         assert!(dir.ends_with("koan"));
         unsafe { std::env::remove_var("KOAN_CONFIG_DIR") };
+    }
+
+    #[test]
+    fn test_save_preserves_file_sourced_values_when_env_overrides_active() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+
+        // Write a config file with a password.
+        fs::write(
+            &path,
+            r#"
+[remote]
+url = "https://file.example.com"
+username = "fileuser"
+password = "file_secret"
+"#,
+        )
+        .unwrap();
+
+        // Load it, simulate env override on password, then save back.
+        let mut cfg = Config::load_from(&path).unwrap();
+        cfg.remote.password = "env_secret".into();
+        cfg.env_overrides.remote_password = true;
+
+        // Modify an unrelated field (simulates toggling visualizer).
+        cfg.visualizer.enabled = true;
+
+        cfg.save_to(&path).unwrap();
+
+        // Re-read: file-sourced password must survive, not be cleared.
+        let saved = fs::read_to_string(&path).unwrap();
+        assert!(
+            saved.contains("file_secret"),
+            "file-sourced password was lost"
+        );
+        assert!(!saved.contains("env_secret"), "env password leaked to disk");
+        assert!(saved.contains("fileuser"));
+        assert!(saved.contains("file.example.com"));
     }
 }

--- a/crates/koan-core/src/organize.rs
+++ b/crates/koan-core/src/organize.rs
@@ -759,8 +759,9 @@ fn resolve_base_dir(base_dir: Option<&Path>) -> Result<PathBuf, OrganizeError> {
     }
 
     // Use first configured library folder.
-    let config = crate::config::Config::load()
-        .map_err(|e| OrganizeError::Io(std::io::Error::other(e.to_string())))?;
+    let config = crate::config::Config::load().map_err(|e: crate::config::ConfigError| {
+        OrganizeError::Io(std::io::Error::other(e.to_string()))
+    })?;
 
     config.library.folders.into_iter().next().ok_or_else(|| {
         OrganizeError::Io(std::io::Error::other(


### PR DESCRIPTION
Adds support for environment variables that override file-based config:

- \`KOAN_CONFIG_DIR\` --> override the config/data directory (default: ~/.config/koan/)
- \`KOAN_REMOTE_URL\` --> override remote server URL (also sets remote.enabled = true)
- \`KOAN_REMOTE_USERNAME\` --> override remote username
- \`KOAN_REMOTE_PASSWORD\` --> override remote password

Env vars take precedence over config.toml/config.local.toml values. Unset or empty vars are ignored.

Probably a net benefit for CI, containerized deploy (if desired in the future), and headless, shouldn't impact anything otherwise.

If desired, I can split this into 2 PRs, one for config dir and one for remote_*, but since they're quite small changes I submit both here.