### PR TITLE
Fix/bump cpal 0.15 to 0.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,9 +37,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alsa"
-version = "0.9.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed7572b7ba83a31e20d1b48970ee402d2e3e0537dcfe0a3ff4d6eb7508617d43"
+checksum = "812947049edcd670a82cd5c73c3661d2e58468577ba8489de58e1a73c04cbd5d"
 dependencies = [
  "alsa-sys",
  "bitflags 2.11.0",
@@ -49,9 +49,9 @@ dependencies = [
 
 [[package]]
 name = "alsa-sys"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8fee663d06c4e303404ef5f40488a53e062f89ba8bfed81f42325aafad1527"
+checksum = "ad7569085a265dd3f607ebecce7458eaab2132a84393534c95b18dcbc3f31e04"
 dependencies = [
  "libc",
  "pkg-config",
@@ -770,13 +770,16 @@ dependencies = [
 
 [[package]]
 name = "coreaudio-rs"
-version = "0.11.3"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321077172d79c662f64f5071a03120748d5bb652f5231570141be24cfcd2bace"
+checksum = "d15c3c3cee7c087938f7ad1c3098840b3ef1f1bdc7f6e496336c3b1e7a6f3914"
 dependencies = [
- "bitflags 1.3.2",
- "core-foundation-sys",
- "coreaudio-sys",
+ "bitflags 2.11.0",
+ "libc",
+ "objc2-audio-toolbox",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -790,12 +793,11 @@ dependencies = [
 
 [[package]]
 name = "cpal"
-version = "0.15.3"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "873dab07c8f743075e57f524c583985fbaf745602acbe916a01539364369a779"
+checksum = "d8942da362c0f0d895d7cac616263f2f9424edc5687364dfd1d25ef7eba506d7"
 dependencies = [
  "alsa",
- "core-foundation-sys",
  "coreaudio-rs",
  "dasp_sample",
  "jni",
@@ -804,11 +806,19 @@ dependencies = [
  "mach2",
  "ndk",
  "ndk-context",
- "oboe",
+ "num-derive",
+ "num-traits",
+ "objc2",
+ "objc2-audio-toolbox",
+ "objc2-avf-audio",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "windows 0.54.0",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -1674,7 +1684,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -2190,9 +2200,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mach2"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+checksum = "6a1b95cd5421ec55b445b5ae102f5ea0e768de1f82bd3001e11f426c269c3aea"
 dependencies = [
  "libc",
 ]
@@ -2328,9 +2338,9 @@ dependencies = [
 
 [[package]]
 name = "ndk"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
+checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
  "bitflags 2.11.0",
  "jni-sys",
@@ -2348,9 +2358,9 @@ checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "ndk-sys"
-version = "0.5.0+25.2.9519653"
+version = "0.6.0+11769913"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
+checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
  "jni-sys",
 ]
@@ -2502,32 +2512,83 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-audio-toolbox"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6948501a91121d6399b79abaa33a8aa4ea7857fe019f341b8c23ad6e81b79b08"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+ "objc2",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-avf-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13a380031deed8e99db00065c45937da434ca987c034e13b87e4441f9e4090be"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1eebcea8b0dbff5f7c8504f3107c68fc061a3eb44932051c8cf8a68d969c3b2"
+dependencies = [
+ "dispatch2",
+ "objc2",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-audio-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a89f2ec274a0cf4a32642b2991e8b351a404d290da87bb6a9a9d8632490bd1c"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2",
+ "dispatch2",
+ "libc",
+ "objc2",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
-name = "oboe"
-version = "0.6.1"
+name = "objc2-foundation"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8b61bebd49e5d43f5f8cc7ee2891c16e0f41ec7954d36bcb6c14c5e0de867fb"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "jni",
- "ndk",
- "ndk-context",
- "num-derive",
- "num-traits",
- "oboe-sys",
-]
-
-[[package]]
-name = "oboe-sys"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bb09a4a2b1d668170cfe0a7d5bc103f8999fb316c98099b6a9939c9f2e79d"
-dependencies = [
- "cc",
+ "bitflags 2.11.0",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -4646,22 +4707,23 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.54.0"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
- "windows-core 0.54.0",
- "windows-targets 0.52.6",
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
 ]
 
 [[package]]
-name = "windows-core"
-version = "0.54.0"
+name = "windows-collections"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-result 0.1.2",
- "windows-targets 0.52.6",
+ "windows-core",
 ]
 
 [[package]]
@@ -4673,8 +4735,19 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link",
- "windows-result 0.4.1",
+ "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -4706,23 +4779,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
 name = "windows-registry"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
  "windows-link",
- "windows-result 0.4.1",
+ "windows-result",
  "windows-strings",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
-dependencies = [
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4834,6 +4908,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/crates/koan-core/Cargo.toml
+++ b/crates/koan-core/Cargo.toml
@@ -56,7 +56,7 @@ coreaudio-sys = "0.2"
 core-foundation = "0.9"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-cpal = "0.15"
+cpal = "0.17"
 
 [dev-dependencies]
 serde_json = "1"

--- a/crates/koan-core/src/audio/cpal_backend.rs
+++ b/crates/koan-core/src/audio/cpal_backend.rs
@@ -87,8 +87,8 @@ impl CpalBackend {
             .map_err(|e| BackendError::Platform(e.to_string()))?;
 
         for dev in devices {
-            if let Ok(name) = dev.name()
-                && name == info.name
+            if let Ok(desc) = dev.description()
+                && desc.name() == info.name
             {
                 return Ok(dev);
             }
@@ -98,13 +98,13 @@ impl CpalBackend {
     }
 
     fn device_info_from_cpal(dev: &cpal::Device, index: u64) -> Option<DeviceInfo> {
-        let name = dev.name().ok()?;
+        let name = dev.description().ok()?.name().to_owned();
         let configs = dev.supported_output_configs().ok()?;
         let mut rates: Vec<f64> = Vec::new();
         for cfg in configs {
             // Collect min and max sample rates from each config range.
-            let min = cfg.min_sample_rate().0 as f64;
-            let max = cfg.max_sample_rate().0 as f64;
+            let min = cfg.min_sample_rate() as f64;
+            let max = cfg.max_sample_rate() as f64;
             if !rates.contains(&min) {
                 rates.push(min);
             }
@@ -157,7 +157,7 @@ impl AudioBackend for CpalBackend {
         let dev = self.resolve_device(device)?;
         let config = suppress_stderr(|| dev.default_output_config())
             .map_err(|e| BackendError::Platform(e.to_string()))?;
-        Ok(config.sample_rate().0 as f64)
+        Ok(config.sample_rate() as f64)
     }
 
     fn set_device_sample_rate(&self, _device: &DeviceInfo, _rate: f64) -> Result<(), BackendError> {
@@ -178,7 +178,7 @@ impl AudioBackend for CpalBackend {
 
         let config = cpal::StreamConfig {
             channels: channels as u16,
-            sample_rate: cpal::SampleRate(sample_rate as u32),
+            sample_rate: sample_rate as u32,
             buffer_size: cpal::BufferSize::Default,
         };
 

--- a/crates/koan-core/src/config.rs
+++ b/crates/koan-core/src/config.rs
@@ -341,21 +341,21 @@ impl Config {
     /// Apply `KOAN_REMOTE_*` env var overrides on top of file-based config.
     /// Non-empty env values win; unset or empty vars are ignored.
     fn apply_env_overrides(&mut self) {
-        if let Ok(url) = std::env::var("KOAN_REMOTE_URL") {
-            if !url.is_empty() {
-                self.remote.url = url;
-                self.remote.enabled = true;
-            }
+        if let Ok(url) = std::env::var("KOAN_REMOTE_URL")
+            && !url.is_empty()
+        {
+            self.remote.url = url;
+            self.remote.enabled = true;
         }
-        if let Ok(username) = std::env::var("KOAN_REMOTE_USERNAME") {
-            if !username.is_empty() {
-                self.remote.username = username;
-            }
+        if let Ok(username) = std::env::var("KOAN_REMOTE_USERNAME")
+            && !username.is_empty()
+        {
+            self.remote.username = username;
         }
-        if let Ok(password) = std::env::var("KOAN_REMOTE_PASSWORD") {
-            if !password.is_empty() {
-                self.remote.password = password;
-            }
+        if let Ok(password) = std::env::var("KOAN_REMOTE_PASSWORD")
+            && !password.is_empty()
+        {
+            self.remote.password = password;
         }
     }
 }

--- a/crates/koan-core/src/config.rs
+++ b/crates/koan-core/src/config.rs
@@ -280,15 +280,19 @@ impl Config {
             deep_merge(&mut base_val, local_val);
         }
 
-        let config: Config = base_val.try_into()?;
+        let mut config: Config = base_val.try_into()?;
+        config.apply_env_overrides();
         Ok(config)
     }
 
     /// Load config, logging and falling back to defaults on error.
+    /// Env overrides are always applied (via `load()`, or on the default fallback).
     pub fn load_or_default() -> Self {
         Self::load().unwrap_or_else(|e| {
             log::warn!("failed to load config, using defaults: {}", e);
-            Self::default()
+            let mut cfg = Self::default();
+            cfg.apply_env_overrides();
+            cfg
         })
     }
 
@@ -333,6 +337,27 @@ impl Config {
             .clone()
             .unwrap_or_else(|| config_dir().join("cache"))
     }
+
+    /// Apply `KOAN_REMOTE_*` env var overrides on top of file-based config.
+    /// Non-empty env values win; unset or empty vars are ignored.
+    fn apply_env_overrides(&mut self) {
+        if let Ok(url) = std::env::var("KOAN_REMOTE_URL") {
+            if !url.is_empty() {
+                self.remote.url = url;
+                self.remote.enabled = true;
+            }
+        }
+        if let Ok(username) = std::env::var("KOAN_REMOTE_USERNAME") {
+            if !username.is_empty() {
+                self.remote.username = username;
+            }
+        }
+        if let Ok(password) = std::env::var("KOAN_REMOTE_PASSWORD") {
+            if !password.is_empty() {
+                self.remote.password = password;
+            }
+        }
+    }
 }
 
 /// Recursively merge `overlay` into `base`. Only keys present in `overlay`
@@ -353,8 +378,11 @@ fn deep_merge(base: &mut toml::Value, overlay: toml::Value) {
     }
 }
 
-/// `~/.config/koan/`
+/// Config directory — `KOAN_CONFIG_DIR` env var, or `~/.config/koan/`.
 pub fn config_dir() -> PathBuf {
+    if let Ok(dir) = std::env::var("KOAN_CONFIG_DIR") {
+        return PathBuf::from(dir);
+    }
     dirs::home_dir()
         .unwrap_or_else(|| PathBuf::from("."))
         .join(".config")


### PR DESCRIPTION
## Summary

- Bumps cpal 0.15 → 0.17 on Linux
- Migrates to 0.17 API: `SampleRate` is now `u32` (not a newtype)
- Replaces deprecated `dev.name()` with `dev.description().name()`
- Prepares for PulseAudio/PipeWire host support landing in cpal 0.18 (based on their git, which is probably big for the majority of modern linux users)

## Note

This branch is stacked on #83 (env var overrides) locally. The diff here includes that commit — the cpal-specific changes are in the last commit only.

## Test plan

- [x] Verify Linux playback still works with ALSA backend
- [x] Confirm no clippy warnings or test regressions
- [ ] macOS unaffected (uses CoreAudio bindings, not cpal) (I don't have a mac, so I'll leave that to others)