### PR TITLE
fix(server): bind GraphQL to 127.0.0.1 by default, add --bind flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Fixed
+
+#### Security
+
+- **GraphQL/Subsonic servers now bind to 127.0.0.1 by default** — previously bound to `0.0.0.0` with no authentication, exposing library enumeration, file moves, and queue clearing to anyone on the network. Added `bind` field to `[graphql]` config and `--bind` CLI flag. Set `bind = "0.0.0.0"` to restore the old behaviour (not recommended without auth) ([#85](https://github.com/radiosilence/koan/issues/85))
+
 ### Added
 
 - **Album-aware download priority** — when a track starts playing, remaining tracks from the same album are bumped to the front of the download queue, ensuring gapless album playback over remote sources ([#87](https://github.com/radiosilence/koan/issues/87))

--- a/README.md
+++ b/README.md
@@ -264,11 +264,12 @@ koan --artist 3               # play artist by ID
 koan --no-api                 # TUI only (no GraphQL server)
 koan --clear                  # clear persisted queue
 
-# server
-koan --headless                     # GraphQL API on :4000, no TUI
+# server (binds to 127.0.0.1 by default)
+koan --headless                     # GraphQL API on 127.0.0.1:4000, no TUI
 koan --headless --playground        # with GraphiQL web IDE
 koan --headless --subsonic 4040     # + Subsonic REST on port 4040
 koan --port 8080                    # custom GraphQL port
+koan --bind 0.0.0.0                 # listen on all interfaces (⚠️ no auth)
 koan -d                             # background daemon
 koan -d --subsonic 4040             # daemon with Subsonic
 
@@ -349,7 +350,7 @@ If koan isn't on Claude Desktop's PATH (common with Homebrew or mise), use the f
 
 ### GraphQL API
 
-The GraphQL API runs alongside the TUI by default (port 4000). For headless operation, use `koan --headless`. Full programmatic control — everything the TUI can do, minus the visualizer.
+The GraphQL API runs alongside the TUI by default (port 4000, bound to localhost). For headless operation, use `koan --headless`. Full programmatic control — everything the TUI can do, minus the visualizer. The server binds to `127.0.0.1` by default — use `--bind 0.0.0.0` or `bind = "0.0.0.0"` in `[graphql]` config to expose on all interfaces (not recommended without auth).
 
 ```bash
 # Headless server with GraphiQL IDE

--- a/crates/koan-core/src/config.rs
+++ b/crates/koan-core/src/config.rs
@@ -190,6 +190,10 @@ pub struct GraphqlConfig {
     pub enabled: bool,
     /// GraphQL API port (default: 4000).
     pub port: u16,
+    /// Bind address for the API server (default: 127.0.0.1).
+    /// Use "0.0.0.0" to listen on all interfaces (NOT RECOMMENDED without auth).
+    #[serde(default = "default_bind")]
+    pub bind: std::net::IpAddr,
     /// Enable GraphiQL web IDE at GET /graphql.
     pub playground: bool,
     /// Enable Subsonic REST API on this port. Omit or null to disable.
@@ -197,11 +201,16 @@ pub struct GraphqlConfig {
     pub subsonic_port: Option<u16>,
 }
 
+fn default_bind() -> std::net::IpAddr {
+    std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST)
+}
+
 impl Default for GraphqlConfig {
     fn default() -> Self {
         Self {
             enabled: true,
             port: 4000,
+            bind: default_bind(),
             playground: false,
             subsonic_port: None,
         }
@@ -644,6 +653,43 @@ output_device = "External Speakers"
         assert_eq!(
             cfg.playback.output_device.as_deref(),
             Some("External Speakers")
+        );
+    }
+
+    #[test]
+    fn test_graphql_bind_defaults_to_localhost() {
+        let cfg = GraphqlConfig::default();
+        assert_eq!(
+            cfg.bind,
+            std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST)
+        );
+    }
+
+    #[test]
+    fn test_graphql_bind_from_toml() {
+        let toml_str = r#"
+[graphql]
+bind = "0.0.0.0"
+port = 5000
+"#;
+        let cfg: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            cfg.graphql.bind,
+            std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED)
+        );
+        assert_eq!(cfg.graphql.port, 5000);
+    }
+
+    #[test]
+    fn test_graphql_bind_omitted_defaults_to_localhost() {
+        let toml_str = r#"
+[graphql]
+port = 4000
+"#;
+        let cfg: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            cfg.graphql.bind,
+            std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST)
         );
     }
 

--- a/crates/koan-music/src/commands/graphql/server.rs
+++ b/crates/koan-music/src/commands/graphql/server.rs
@@ -12,7 +12,12 @@ use super::{KoanSchema, build_schema};
 // `koan --headless` entry point (standalone headless server)
 // ---------------------------------------------------------------------------
 
-pub fn cmd_serve(port: Option<u16>, subsonic_port: Option<u16>, playground: bool) {
+pub fn cmd_serve(
+    port: Option<u16>,
+    bind: Option<std::net::IpAddr>,
+    subsonic_port: Option<u16>,
+    playground: bool,
+) {
     use koan_core::player::Player;
 
     // Validate DB is accessible before starting the server.
@@ -21,7 +26,15 @@ pub fn cmd_serve(port: Option<u16>, subsonic_port: Option<u16>, playground: bool
 
     let (state, _timeline, _viz, cmd_tx) = Player::spawn();
 
-    run_api_blocking(state, cmd_tx, db_path, port, subsonic_port, playground);
+    run_api_blocking(
+        state,
+        cmd_tx,
+        db_path,
+        port,
+        bind,
+        subsonic_port,
+        playground,
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -35,6 +48,7 @@ fn run_api_blocking(
     cmd_tx: Sender<PlayerCommand>,
     db_path: PathBuf,
     port: Option<u16>,
+    bind: Option<std::net::IpAddr>,
     subsonic_port: Option<u16>,
     playground: bool,
 ) {
@@ -42,6 +56,7 @@ fn run_api_blocking(
 
     let cfg = Config::load().unwrap_or_default();
     let port = port.unwrap_or(cfg.graphql.port);
+    let bind = bind.unwrap_or(cfg.graphql.bind);
     let playground_enabled = playground || cfg.graphql.playground;
 
     let schema = build_schema(state, cmd_tx, db_path.clone());
@@ -54,10 +69,10 @@ fn run_api_blocking(
         }
         let gql_app = gql_app.with_state(schema);
 
-        let gql_addr = std::net::SocketAddr::from(([0, 0, 0, 0], port));
-        log::info!("GraphQL API on http://0.0.0.0:{}/graphql", port);
+        let gql_addr = std::net::SocketAddr::new(bind, port);
+        log::info!("GraphQL API on http://{}:{}/graphql", bind, port);
         if playground_enabled {
-            log::info!("GraphiQL: http://localhost:{}/graphql", port);
+            log::info!("GraphiQL: http://{}:{}/graphql", bind, port);
         }
 
         let gql_listener = tokio::net::TcpListener::bind(gql_addr)
@@ -68,8 +83,8 @@ fn run_api_blocking(
 
         if let Some(sub_port) = subsonic_port {
             let sub_app = super::super::serve::subsonic_router(db_path);
-            let sub_addr = std::net::SocketAddr::from(([0, 0, 0, 0], sub_port));
-            log::info!("Subsonic REST on http://0.0.0.0:{}/rest/", sub_port);
+            let sub_addr = std::net::SocketAddr::new(bind, sub_port);
+            log::info!("Subsonic REST on http://{}:{}/rest/", bind, sub_port);
 
             let sub_listener = tokio::net::TcpListener::bind(sub_addr)
                 .await
@@ -95,10 +110,19 @@ pub fn start_api_background(
     cmd_tx: Sender<PlayerCommand>,
     db_path: PathBuf,
     port: Option<u16>,
+    bind: Option<std::net::IpAddr>,
     subsonic_port: Option<u16>,
     playground: bool,
 ) {
-    run_api_blocking(state, cmd_tx, db_path, port, subsonic_port, playground);
+    run_api_blocking(
+        state,
+        cmd_tx,
+        db_path,
+        port,
+        bind,
+        subsonic_port,
+        playground,
+    );
 }
 
 async fn shutdown_signal() {
@@ -123,18 +147,25 @@ async fn graphql_playground() -> axum::response::Html<String> {
 }
 
 /// Run the server as a background daemon (fork + detach).
-pub fn cmd_serve_daemon(port: Option<u16>, subsonic_port: Option<u16>, playground: bool) {
+pub fn cmd_serve_daemon(
+    port: Option<u16>,
+    bind: Option<std::net::IpAddr>,
+    subsonic_port: Option<u16>,
+    playground: bool,
+) {
     use std::fs;
     use std::process::Command;
 
     let cfg = Config::load().unwrap_or_default();
     let port_val = port.unwrap_or(cfg.graphql.port);
+    let bind_val = bind.unwrap_or(cfg.graphql.bind);
 
     let exe = std::env::current_exe().expect("failed to get current exe path");
     let mut cmd = Command::new(exe);
     // Use the new unified CLI: `koan --headless --port <port>`
     cmd.arg("--headless");
     cmd.arg("--port").arg(port_val.to_string());
+    cmd.arg("--bind").arg(bind_val.to_string());
     if let Some(sp) = subsonic_port {
         cmd.arg("--subsonic").arg(sp.to_string());
     }

--- a/crates/koan-music/src/commands/play.rs
+++ b/crates/koan-music/src/commands/play.rs
@@ -24,6 +24,7 @@ use crate::tui::picker::{
 /// `None` means no API server (--no-api).
 pub struct ApiOptions {
     pub port: Option<u16>,
+    pub bind: Option<std::net::IpAddr>,
     pub subsonic: Option<u16>,
     pub playground: bool,
 }
@@ -123,6 +124,7 @@ pub fn cmd_play(
                     tx_api,
                     db_path,
                     opts.port,
+                    opts.bind,
                     opts.subsonic,
                     opts.playground,
                 );

--- a/crates/koan-music/src/main.rs
+++ b/crates/koan-music/src/main.rs
@@ -154,6 +154,10 @@ struct Cli {
     #[arg(long)]
     port: Option<u16>,
 
+    /// Bind address for the API server (default: 127.0.0.1)
+    #[arg(long)]
+    bind: Option<std::net::IpAddr>,
+
     /// Enable Subsonic REST API on this port (e.g. --subsonic 4040)
     #[arg(long)]
     subsonic: Option<u16>,
@@ -328,13 +332,13 @@ fn main() {
     // MCP mode: headless MCP server on stdio.
     // Daemon mode: fork a headless child and exit.
     if cli.daemonize {
-        commands::cmd_serve_daemon(cli.port, cli.subsonic, cli.playground);
+        commands::cmd_serve_daemon(cli.port, cli.bind, cli.subsonic, cli.playground);
         return;
     }
 
     // Headless mode: GraphQL API server, no TUI.
     if cli.headless {
-        commands::cmd_serve(cli.port, cli.subsonic, cli.playground);
+        commands::cmd_serve(cli.port, cli.bind, cli.subsonic, cli.playground);
         return;
     }
 
@@ -349,6 +353,7 @@ fn main() {
         let api_opts = if api_enabled {
             Some(commands::ApiOptions {
                 port: cli.port.or(Some(cfg.graphql.port)),
+                bind: cli.bind.or(Some(cfg.graphql.bind)),
                 subsonic: cli.subsonic.or(cfg.graphql.subsonic_port),
                 playground: cli.playground || cfg.graphql.playground,
             })


### PR DESCRIPTION
## Summary

- **Security fix**: GraphQL and Subsonic servers were binding to `0.0.0.0` with no auth — anyone on the network could enumerate the library, move files, and clear the queue
- Default bind address changed to `127.0.0.1` (localhost only)
- Added `bind` field to `[graphql]` config section and `--bind` CLI flag
- Bind address threaded through all server modes: headless, daemon, and TUI+API background

## Config

```toml
[graphql]
bind = "0.0.0.0"  # restore old behaviour (not recommended without auth)
```

Or via CLI: `koan --bind 0.0.0.0`

## Test plan

- [x] 3 new config tests: default value, TOML parsing, omission fallback
- [x] Full test suite passes (88 tests)
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] Verified bind address propagates through headless, daemon, and TUI+API paths

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)