### PR TITLE
#89 fix(audio): crash in AudioEngine::drop during sample rate switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Fixed
 
+#### Audio
+
+- **Fix CoreAudio crash during sample rate switch** — `stop_engine()` was dropping the `AudioEngine` on a background cleanup thread while the player thread immediately changed the device sample rate. This race caused `AudioUnitUninitialize` to hit a freed `ExtendedAudioBufferList`, crashing in CoreAudio's internal allocator (`caulk::alloc::tiered_allocator::deallocate`). The engine is now dropped synchronously before any sample rate changes; only the decode handle cleanup (thread join) runs in the background ([#89](https://github.com/radiosilence/koan/issues/89))
+
 #### Security
 
 - **GraphQL/Subsonic servers now bind to 127.0.0.1 by default** — previously bound to `0.0.0.0` with no authentication, exposing library enumeration, file moves, and queue clearing to anyone on the network. Added `bind` field to `[graphql]` config and `--bind` CLI flag. Set `bind = "0.0.0.0"` to restore the old behaviour (not recommended without auth) ([#85](https://github.com/radiosilence/koan/issues/85))

--- a/crates/koan-core/src/audio/buffer.rs
+++ b/crates/koan-core/src/audio/buffer.rs
@@ -55,6 +55,12 @@ impl DecodeHandle {
         self.stop.store(true, Ordering::Relaxed);
     }
 
+    /// Create a DecodeHandle with no real thread (for tests only).
+    #[cfg(test)]
+    pub fn new_for_test(stop: Arc<AtomicBool>) -> Self {
+        Self { stop, thread: None }
+    }
+
     /// Signal the decode thread to stop and wait for it.
     pub fn stop(&mut self) {
         self.signal_stop();

--- a/crates/koan-core/src/player/mod.rs
+++ b/crates/koan-core/src/player/mod.rs
@@ -679,10 +679,23 @@ impl Player {
             let _ = playback.engine.stop();
             // Signal decode thread to exit (non-blocking).
             playback.decode_handle.signal_stop();
-            // Heavy cleanup on a background thread.
+
+            // Drop the audio engine synchronously. AudioUnitUninitialize must
+            // complete before any device sample rate change, otherwise CoreAudio's
+            // internal ExtendedAudioBufferList can be freed mid-teardown (crash
+            // in caulk::alloc::tiered_allocator::deallocate — GitHub #89).
+            let ActivePlayback {
+                engine,
+                decode_handle,
+            } = playback;
+            drop(engine);
+
+            // The decode handle join is the heavy part (waits for the decode
+            // thread to exit) — run it on a background thread so we don't block
+            // the player command loop.
             thread::Builder::new()
                 .name("koan-cleanup".into())
-                .spawn(move || drop(playback))
+                .spawn(move || drop(decode_handle))
                 .ok();
         }
     }
@@ -1519,5 +1532,58 @@ mod tests {
         // Undo move: [A, B, C]
         player.process_command(PlayerCommand::Undo);
         assert_eq!(playlist_titles(&player), vec!["A", "B", "C"]);
+    }
+
+    /// Regression test for GitHub #89: AudioEngine must be dropped synchronously
+    /// in stop_engine() before the caller changes sample rates. If the engine is
+    /// dropped on a background thread, CoreAudio's internal buffer list can be
+    /// freed while AudioUnitUninitialize is still tearing it down → crash.
+    #[test]
+    fn stop_engine_drops_engine_synchronously() {
+        use std::sync::atomic::AtomicBool;
+
+        struct MockEngine {
+            dropped: Arc<AtomicBool>,
+        }
+        impl AudioEngineHandle for MockEngine {
+            fn start(&self) -> Result<(), BackendError> {
+                Ok(())
+            }
+            fn stop(&self) -> Result<(), BackendError> {
+                Ok(())
+            }
+            fn is_running(&self) -> bool {
+                false
+            }
+        }
+        impl Drop for MockEngine {
+            fn drop(&mut self) {
+                self.dropped.store(true, Ordering::SeqCst);
+            }
+        }
+
+        let dropped = Arc::new(AtomicBool::new(false));
+
+        // Build a minimal decode handle that won't block.
+        let stop_flag = Arc::new(AtomicBool::new(false));
+        let decode_handle = buffer::DecodeHandle::new_for_test(stop_flag);
+
+        let mut player = Player::new();
+        player.active_playback = Some(ActivePlayback {
+            engine: Box::new(MockEngine {
+                dropped: dropped.clone(),
+            }),
+            decode_handle,
+        });
+
+        player.stop_engine();
+
+        // The engine must already be dropped when stop_engine returns.
+        // If this fails, the engine was moved to a background thread — the
+        // exact race condition that causes the #89 crash.
+        assert!(
+            dropped.load(Ordering::SeqCst),
+            "AudioEngine must be dropped synchronously in stop_engine (GitHub #89)"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- **Root cause**: `stop_engine()` moved the entire `ActivePlayback` (including `AudioEngine`) to a background cleanup thread. When `start_playback()` immediately changed the device sample rate, the old engine's `AudioUnitUninitialize` raced with the rate change — CoreAudio's internal `ExtendedAudioBufferList` was freed mid-teardown → crash in `caulk::alloc::tiered_allocator::deallocate`.
- **Fix**: Destructure `ActivePlayback` — drop the engine synchronously on the player thread (three quick FFI calls: stop, uninitialize, dispose). Only the `DecodeHandle` (which joins the decode thread) goes to the background cleanup thread.
- **Test**: Added `stop_engine_drops_engine_synchronously` regression test with a mock engine that asserts the drop happens before `stop_engine()` returns.

Closes #89

## Test plan

- [x] `cargo test --workspace` — 89 tests pass (new test: `stop_engine_drops_engine_synchronously`)
- [x] `cargo clippy --workspace -- -D warnings` — zero warnings
- [x] `cargo fmt --all -- --check` — clean
- [ ] Manual: play 48kHz album → play 44kHz album → no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)