### PR TITLE
#88 feat(cache): Phase 1 — DB tracking, cache_limit config, LRU eviction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Added
 
 - **Album-aware download priority** — when a track starts playing, remaining tracks from the same album are bumped to the front of the download queue, ensuring gapless album playback over remote sources ([#87](https://github.com/radiosilence/koan/issues/87))
+- **Cache management with LRU eviction** — cached remote downloads are now tracked in the DB (path, size, download date). Set `cache_limit` in `[remote]` config (e.g. `"50GB"`) to enable automatic LRU eviction on startup. Evicts whole albums, oldest last-played first. Favourited tracks are never evicted. New `koan cache evict` subcommand for manual eviction ([#88](https://github.com/radiosilence/koan/issues/88))
 
 ## v0.17.0 (2026-03-26)
 

--- a/crates/koan-core/src/config.rs
+++ b/crates/koan-core/src/config.rs
@@ -80,6 +80,10 @@ pub struct RemoteConfig {
     pub cache_dir: Option<PathBuf>,
     /// Parallel download workers for remote tracks (default: 5).
     pub download_workers: usize,
+    /// Maximum cache size on disk. Human-readable: "50GB", "500MB", etc.
+    /// None or empty = unlimited. LRU eviction runs on startup when exceeded.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_limit: Option<String>,
 }
 
 impl Default for LibraryConfig {
@@ -147,8 +151,43 @@ impl Default for RemoteConfig {
             transcode_quality: "original".into(),
             cache_dir: None,
             download_workers: 5,
+            cache_limit: None,
         }
     }
+}
+
+/// Parse a human-readable size string like "50GB", "500 MB", "1.5TB" into bytes.
+/// Supports B, KB, MB, GB, TB (case-insensitive). Returns None for invalid input.
+pub fn parse_size_bytes(s: &str) -> Option<u64> {
+    let s = s.trim();
+    if s.is_empty() {
+        return None;
+    }
+
+    // Split into numeric part and suffix.
+    let mut num_end = 0;
+    for (i, c) in s.char_indices() {
+        if c.is_ascii_digit() || c == '.' {
+            num_end = i + c.len_utf8();
+        } else if !c.is_whitespace() {
+            break;
+        }
+    }
+
+    let num_str = s[..num_end].trim();
+    let suffix = s[num_end..].trim().to_ascii_uppercase();
+
+    let value: f64 = num_str.parse().ok()?;
+    let multiplier: u64 = match suffix.as_str() {
+        "" | "B" => 1,
+        "KB" | "K" => 1024,
+        "MB" | "M" => 1024 * 1024,
+        "GB" | "G" => 1024 * 1024 * 1024,
+        "TB" | "T" => 1024 * 1024 * 1024 * 1024,
+        _ => return None,
+    };
+
+    Some((value * multiplier as f64) as u64)
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -341,6 +380,14 @@ impl Config {
             .cache_dir
             .clone()
             .unwrap_or_else(|| config_dir().join("cache"))
+    }
+
+    /// Parsed cache limit in bytes, or None if unlimited.
+    pub fn cache_limit_bytes(&self) -> Option<u64> {
+        self.remote
+            .cache_limit
+            .as_deref()
+            .and_then(parse_size_bytes)
     }
 }
 
@@ -708,5 +755,63 @@ port = 4000
             deserialized.organize.patterns["standard"],
             "%artist%/%title%"
         );
+    }
+
+    #[test]
+    fn test_parse_size_bytes() {
+        assert_eq!(parse_size_bytes("50GB"), Some(50 * 1024 * 1024 * 1024));
+        assert_eq!(parse_size_bytes("500MB"), Some(500 * 1024 * 1024));
+        assert_eq!(parse_size_bytes("1TB"), Some(1024 * 1024 * 1024 * 1024));
+        assert_eq!(parse_size_bytes("100KB"), Some(100 * 1024));
+        assert_eq!(parse_size_bytes("1024B"), Some(1024));
+        assert_eq!(parse_size_bytes("1024"), Some(1024));
+
+        // Case insensitive.
+        assert_eq!(parse_size_bytes("50gb"), Some(50 * 1024 * 1024 * 1024));
+        assert_eq!(parse_size_bytes("50Gb"), Some(50 * 1024 * 1024 * 1024));
+
+        // Short suffixes.
+        assert_eq!(parse_size_bytes("50G"), Some(50 * 1024 * 1024 * 1024));
+        assert_eq!(parse_size_bytes("500M"), Some(500 * 1024 * 1024));
+
+        // Spaces.
+        assert_eq!(parse_size_bytes("50 GB"), Some(50 * 1024 * 1024 * 1024));
+        assert_eq!(parse_size_bytes(" 50GB "), Some(50 * 1024 * 1024 * 1024));
+
+        // Decimal.
+        assert_eq!(
+            parse_size_bytes("1.5GB"),
+            Some((1.5 * 1024.0 * 1024.0 * 1024.0) as u64)
+        );
+
+        // Invalid.
+        assert_eq!(parse_size_bytes(""), None);
+        assert_eq!(parse_size_bytes("abc"), None);
+        assert_eq!(parse_size_bytes("50XB"), None);
+    }
+
+    #[test]
+    fn test_cache_limit_config_from_toml() {
+        let toml_str = r#"
+[remote]
+cache_limit = "50GB"
+"#;
+        let cfg: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(cfg.remote.cache_limit.as_deref(), Some("50GB"));
+        assert_eq!(cfg.cache_limit_bytes(), Some(50 * 1024 * 1024 * 1024));
+    }
+
+    #[test]
+    fn test_cache_limit_none_by_default() {
+        let cfg = Config::default();
+        assert!(cfg.remote.cache_limit.is_none());
+        assert!(cfg.cache_limit_bytes().is_none());
+    }
+
+    #[test]
+    fn test_cache_limit_not_serialized_when_none() {
+        let cfg = Config::default();
+        let serialized = toml::to_string_pretty(&cfg).unwrap();
+        assert!(!serialized.contains("cache_limit"));
     }
 }

--- a/crates/koan-core/src/db/queries/tracks.rs
+++ b/crates/koan-core/src/db/queries/tracks.rs
@@ -507,16 +507,150 @@ pub fn track_id_by_path(conn: &Connection, path: &str) -> Result<Option<i64>, Db
 
 /// Clear all cached_path values (used when purging the download cache).
 pub fn clear_cached_paths(conn: &Connection) -> Result<(), DbError> {
-    conn.execute("UPDATE tracks SET cached_path = NULL", params![])?;
+    conn.execute(
+        "UPDATE tracks SET cached_path = NULL, cache_size_bytes = NULL, cache_download_date = NULL",
+        params![],
+    )?;
     Ok(())
 }
 
-/// Update the cached_path for a track after downloading.
+/// Update the cached_path for a track after downloading, recording size and timestamp.
 pub fn set_cached_path(conn: &Connection, track_id: i64, path: &str) -> Result<(), DbError> {
+    let size_bytes: Option<i64> = std::fs::metadata(path).ok().map(|m| m.len() as i64);
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64;
     conn.execute(
-        "UPDATE tracks SET cached_path = ?1 WHERE id = ?2",
-        params![path, track_id],
+        "UPDATE tracks SET cached_path = ?1, cache_size_bytes = ?2, cache_download_date = ?3
+         WHERE id = ?4",
+        params![path, size_bytes, now, track_id],
     )?;
+    Ok(())
+}
+
+/// Row returned by the cache eviction query.
+#[derive(Debug, Clone)]
+pub struct CachedAlbumInfo {
+    pub album_id: i64,
+    pub album_title: String,
+    pub artist_name: String,
+    pub total_size: i64,
+    pub track_ids: Vec<i64>,
+    pub cached_paths: Vec<String>,
+}
+
+/// Get cached albums ordered by LRU (oldest last-played first), excluding favourited tracks.
+/// Returns albums with their total cache size and file paths for eviction.
+pub fn cached_albums_lru(conn: &Connection) -> Result<Vec<CachedAlbumInfo>, DbError> {
+    // Get all cached tracks with their last played timestamp.
+    // A track is "protected" if it appears in the favourites table.
+    // We exclude any album that has ANY favourited cached track.
+    let mut stmt = conn.prepare(
+        "SELECT t.id, t.album_id, COALESCE(al.title, 'Unknown'), COALESCE(a.name, 'Unknown'),
+                t.cached_path, COALESCE(t.cache_size_bytes, 0),
+                (SELECT MAX(ph.played_at) FROM play_history ph WHERE ph.track_id = t.id) as last_play,
+                EXISTS(SELECT 1 FROM favourites f
+                       WHERE f.track_path = t.cached_path
+                          OR f.track_path = t.path
+                          OR f.track_path = t.remote_url) as is_fav
+         FROM tracks t
+         LEFT JOIN albums al ON t.album_id = al.id
+         LEFT JOIN artists a ON al.artist_id = a.id
+         WHERE t.cached_path IS NOT NULL
+         ORDER BY t.album_id, t.disc, t.track_number",
+    )?;
+
+    struct CachedTrackRow {
+        track_id: i64,
+        album_id: Option<i64>,
+        album_title: String,
+        artist_name: String,
+        cached_path: String,
+        size: i64,
+        last_play: Option<i64>,
+        is_fav: bool,
+    }
+
+    let rows: Vec<CachedTrackRow> = stmt
+        .query_map([], |row| {
+            Ok(CachedTrackRow {
+                track_id: row.get(0)?,
+                album_id: row.get(1)?,
+                album_title: row.get(2)?,
+                artist_name: row.get(3)?,
+                cached_path: row.get(4)?,
+                size: row.get(5)?,
+                last_play: row.get(6)?,
+                is_fav: row.get(7)?,
+            })
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
+
+    // Group by album_id. Use -1 for tracks without an album.
+    let mut albums: std::collections::BTreeMap<i64, CachedAlbumInfo> =
+        std::collections::BTreeMap::new();
+    // Track max last_play per album, and whether album has any favourites.
+    let mut album_last_play: HashMap<i64, Option<i64>> = HashMap::new();
+    let mut album_has_fav: HashSet<i64> = HashSet::new();
+
+    for r in &rows {
+        let aid = r.album_id.unwrap_or(-r.track_id); // unique key for albumless tracks
+        if r.is_fav {
+            album_has_fav.insert(aid);
+        }
+        let entry = albums.entry(aid).or_insert_with(|| CachedAlbumInfo {
+            album_id: aid,
+            album_title: r.album_title.clone(),
+            artist_name: r.artist_name.clone(),
+            total_size: 0,
+            track_ids: Vec::new(),
+            cached_paths: Vec::new(),
+        });
+        entry.total_size += r.size;
+        entry.track_ids.push(r.track_id);
+        entry.cached_paths.push(r.cached_path.clone());
+
+        let current_max = album_last_play.entry(aid).or_insert(None);
+        *current_max = match (*current_max, r.last_play) {
+            (Some(a), Some(b)) => Some(a.max(b)),
+            (Some(a), None) => Some(a),
+            (None, Some(b)) => Some(b),
+            (None, None) => None,
+        };
+    }
+
+    // Filter out albums with any favourited tracks, then sort by last_play ascending (oldest first).
+    // Never-played albums sort before everything (None < Some).
+    let mut result: Vec<CachedAlbumInfo> = albums
+        .into_values()
+        .filter(|a| !album_has_fav.contains(&a.album_id))
+        .collect();
+
+    result.sort_by_key(|a| album_last_play.get(&a.album_id).copied().unwrap_or(None));
+
+    Ok(result)
+}
+
+/// Get total cache size from DB tracking (sum of cache_size_bytes for all cached tracks).
+pub fn total_cache_size(conn: &Connection) -> Result<i64, DbError> {
+    let size: i64 = conn.query_row(
+        "SELECT COALESCE(SUM(cache_size_bytes), 0) FROM tracks WHERE cached_path IS NOT NULL",
+        [],
+        |row| row.get(0),
+    )?;
+    Ok(size)
+}
+
+/// Clear cache tracking for specific tracks (after eviction deletes files).
+pub fn clear_cache_for_tracks(conn: &Connection, track_ids: &[i64]) -> Result<(), DbError> {
+    for &id in track_ids {
+        conn.execute(
+            "UPDATE tracks SET cached_path = NULL, cache_size_bytes = NULL, cache_download_date = NULL
+             WHERE id = ?1",
+            params![id],
+        )?;
+    }
     Ok(())
 }
 
@@ -1169,5 +1303,199 @@ mod tests {
         let db = test_db();
         let fav_ids = favourite_album_ids_batch(&db.conn).unwrap();
         assert!(fav_ids.is_empty());
+    }
+
+    #[test]
+    fn test_set_cached_path_records_size_and_date() {
+        let db = test_db();
+        let mut meta = sample_meta("Song", "Artist", "Album");
+        meta.source = "remote".into();
+        meta.path = None;
+        meta.remote_id = Some("r1".into());
+        meta.remote_url = Some("https://example.com/r1".into());
+        let id = upsert_track(&db.conn, &meta).unwrap();
+
+        // Create a temp file to simulate a cached download.
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::io::Write::write_all(&mut tmp.as_file().try_clone().unwrap(), &[0u8; 1024]).unwrap();
+        let path = tmp.path().to_string_lossy().to_string();
+
+        set_cached_path(&db.conn, id, &path).unwrap();
+
+        let (cached_path, size, download_date): (Option<String>, Option<i64>, Option<i64>) = db
+            .conn
+            .query_row(
+                "SELECT cached_path, cache_size_bytes, cache_download_date FROM tracks WHERE id = ?1",
+                params![id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+
+        assert_eq!(cached_path.as_deref(), Some(path.as_str()));
+        assert!(size.unwrap() > 0, "cache_size_bytes should be positive");
+        assert!(
+            download_date.unwrap() > 0,
+            "cache_download_date should be set"
+        );
+    }
+
+    #[test]
+    fn test_total_cache_size() {
+        let db = test_db();
+
+        // Start with zero.
+        assert_eq!(total_cache_size(&db.conn).unwrap(), 0);
+
+        // Insert a cached track with known size.
+        let mut meta = sample_meta("Song", "Artist", "Album");
+        meta.source = "remote".into();
+        meta.path = None;
+        meta.remote_id = Some("r1".into());
+        let id = upsert_track(&db.conn, &meta).unwrap();
+
+        db.conn
+            .execute(
+                "UPDATE tracks SET cached_path = '/cache/song.flac', cache_size_bytes = 50000000 WHERE id = ?1",
+                params![id],
+            )
+            .unwrap();
+
+        assert_eq!(total_cache_size(&db.conn).unwrap(), 50_000_000);
+    }
+
+    #[test]
+    fn test_clear_cache_for_tracks() {
+        let db = test_db();
+        let mut meta = sample_meta("Song", "Artist", "Album");
+        meta.source = "remote".into();
+        meta.path = None;
+        meta.remote_id = Some("r1".into());
+        let id = upsert_track(&db.conn, &meta).unwrap();
+
+        db.conn
+            .execute(
+                "UPDATE tracks SET cached_path = '/cache/song.flac', cache_size_bytes = 1000, cache_download_date = 12345 WHERE id = ?1",
+                params![id],
+            )
+            .unwrap();
+
+        clear_cache_for_tracks(&db.conn, &[id]).unwrap();
+
+        let (path, size, date): (Option<String>, Option<i64>, Option<i64>) = db
+            .conn
+            .query_row(
+                "SELECT cached_path, cache_size_bytes, cache_download_date FROM tracks WHERE id = ?1",
+                params![id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+
+        assert!(path.is_none());
+        assert!(size.is_none());
+        assert!(date.is_none());
+    }
+
+    #[test]
+    fn test_cached_albums_lru_excludes_favourites() {
+        let db = test_db();
+
+        // Create two remote-cached albums.
+        for (album, tracks) in &[("AlbumA", vec!["T1", "T2"]), ("AlbumB", vec!["T3", "T4"])] {
+            for (i, title) in tracks.iter().enumerate() {
+                let mut meta = sample_meta(title, "Artist", album);
+                meta.source = "remote".into();
+                meta.path = None;
+                meta.remote_id = Some(format!("r-{}", title));
+                meta.track_number = Some((i + 1) as i32);
+                let id = upsert_track(&db.conn, &meta).unwrap();
+                let cached = format!("/cache/{}/{}.flac", album, title);
+                db.conn
+                    .execute(
+                        "UPDATE tracks SET cached_path = ?1, cache_size_bytes = 10000000 WHERE id = ?2",
+                        params![cached, id],
+                    )
+                    .unwrap();
+            }
+        }
+
+        // Favourite a track from AlbumB.
+        crate::db::queries::add_favourite(&db.conn, std::path::Path::new("/cache/AlbumB/T3.flac"))
+            .unwrap();
+
+        let albums = cached_albums_lru(&db.conn).unwrap();
+
+        // AlbumB should be excluded (has a favourite), only AlbumA returned.
+        assert_eq!(albums.len(), 1);
+        assert_eq!(albums[0].album_title, "AlbumA");
+    }
+
+    #[test]
+    fn test_cached_albums_lru_sorted_by_last_play() {
+        let db = test_db();
+
+        // Create two cached albums.
+        let mut album_ids = Vec::new();
+        for (album, played_at) in &[("OldAlbum", 1000), ("NewAlbum", 9000)] {
+            let mut meta = sample_meta("Track", "Artist", album);
+            meta.source = "remote".into();
+            meta.path = None;
+            meta.remote_id = Some(format!("r-{}", album));
+            let id = upsert_track(&db.conn, &meta).unwrap();
+            let cached = format!("/cache/{}/Track.flac", album);
+            db.conn
+                .execute(
+                    "UPDATE tracks SET cached_path = ?1, cache_size_bytes = 10000000 WHERE id = ?2",
+                    params![cached, id],
+                )
+                .unwrap();
+
+            // Record play history.
+            db.conn
+                .execute(
+                    "INSERT INTO play_history (track_id, played_at) VALUES (?1, ?2)",
+                    params![id, played_at],
+                )
+                .unwrap();
+
+            album_ids.push(id);
+        }
+
+        let albums = cached_albums_lru(&db.conn).unwrap();
+        assert_eq!(albums.len(), 2);
+        // OldAlbum (played_at=1000) should come first (evicted first).
+        assert_eq!(albums[0].album_title, "OldAlbum");
+        assert_eq!(albums[1].album_title, "NewAlbum");
+    }
+
+    #[test]
+    fn test_clear_cached_paths_clears_all_tracking() {
+        let db = test_db();
+        let mut meta = sample_meta("Song", "Artist", "Album");
+        meta.source = "remote".into();
+        meta.path = None;
+        meta.remote_id = Some("r1".into());
+        let id = upsert_track(&db.conn, &meta).unwrap();
+
+        db.conn
+            .execute(
+                "UPDATE tracks SET cached_path = '/x', cache_size_bytes = 100, cache_download_date = 999 WHERE id = ?1",
+                params![id],
+            )
+            .unwrap();
+
+        clear_cached_paths(&db.conn).unwrap();
+
+        let (path, size, date): (Option<String>, Option<i64>, Option<i64>) = db
+            .conn
+            .query_row(
+                "SELECT cached_path, cache_size_bytes, cache_download_date FROM tracks WHERE id = ?1",
+                params![id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+
+        assert!(path.is_none());
+        assert!(size.is_none());
+        assert!(date.is_none());
     }
 }

--- a/crates/koan-core/src/db/schema.rs
+++ b/crates/koan-core/src/db/schema.rs
@@ -152,5 +152,20 @@ pub fn create_tables(conn: &Connection) -> rusqlite::Result<()> {
         );
         ",
     )?;
+    // --- Migrations: add columns that didn't exist in earlier versions ---
+    // SQLite has no ADD COLUMN IF NOT EXISTS, so we catch the "duplicate column" error.
+    let migrations = [
+        "ALTER TABLE tracks ADD COLUMN cache_size_bytes INTEGER",
+        "ALTER TABLE tracks ADD COLUMN cache_download_date INTEGER",
+    ];
+    for sql in &migrations {
+        match conn.execute(sql, []) {
+            Ok(_) => {}
+            Err(rusqlite::Error::ExecuteReturnedResults) => {}
+            Err(e) if e.to_string().contains("duplicate column") => {}
+            Err(e) => return Err(e),
+        }
+    }
+
     Ok(())
 }

--- a/crates/koan-music/src/commands/cache.rs
+++ b/crates/koan-music/src/commands/cache.rs
@@ -16,6 +16,9 @@ pub fn cmd_cache_status() {
             "size:".cyan(),
             "empty (no cache directory)".dimmed()
         );
+        if let Some(limit) = cfg.cache_limit_bytes() {
+            println!("{} {}", "limit:".cyan(), format_bytes(limit));
+        }
         return;
     }
 
@@ -33,12 +36,28 @@ pub fn cmd_cache_status() {
     }
 
     let size = format_bytes(total_bytes);
-    println!(
-        "{} {} {}",
-        "size:".cyan(),
-        size.bold(),
-        format!("({} files)", file_count).dimmed(),
-    );
+    if let Some(limit) = cfg.cache_limit_bytes() {
+        let pct = if limit > 0 {
+            (total_bytes as f64 / limit as f64 * 100.0) as u64
+        } else {
+            0
+        };
+        println!(
+            "{} {} / {} ({}%) {}",
+            "size:".cyan(),
+            size.bold(),
+            format_bytes(limit),
+            pct,
+            format!("({} files)", file_count).dimmed(),
+        );
+    } else {
+        println!(
+            "{} {} {}",
+            "size:".cyan(),
+            size.bold(),
+            format!("({} files)", file_count).dimmed(),
+        );
+    }
 }
 
 pub fn cmd_cache_clear(skip_confirm: bool) {
@@ -98,4 +117,110 @@ pub fn cmd_cache_clear(skip_confirm: bool) {
         format_bytes(total_bytes),
         format!("({} files removed)", file_count).dimmed(),
     );
+}
+
+/// Run LRU cache eviction: remove whole albums (oldest last-played first) until
+/// total cache is under the configured limit. Never evicts favourites.
+/// Returns the number of bytes freed.
+pub fn evict_cache(cfg: &config::Config, verbose: bool) -> u64 {
+    let limit = match cfg.cache_limit_bytes() {
+        Some(l) => l as i64,
+        None => return 0, // no limit configured
+    };
+
+    let db = open_db();
+
+    // Get current total from DB tracking.
+    let mut current_size = match queries::total_cache_size(&db.conn) {
+        Ok(s) => s,
+        Err(e) => {
+            log::warn!("cache eviction: failed to query cache size: {}", e);
+            return 0;
+        }
+    };
+
+    if current_size <= limit {
+        if verbose {
+            log::info!(
+                "cache within limit: {} / {}",
+                format_bytes(current_size as u64),
+                format_bytes(limit as u64)
+            );
+        }
+        return 0;
+    }
+
+    let albums = match queries::cached_albums_lru(&db.conn) {
+        Ok(a) => a,
+        Err(e) => {
+            log::warn!("cache eviction: failed to query cached albums: {}", e);
+            return 0;
+        }
+    };
+
+    let mut freed: i64 = 0;
+    for album in &albums {
+        if current_size <= limit {
+            break;
+        }
+
+        // Delete cached files for this album.
+        for path in &album.cached_paths {
+            match std::fs::remove_file(path) {
+                Ok(()) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => {
+                    log::warn!("cache eviction: failed to delete {}: {}", path, e);
+                }
+            }
+        }
+
+        // Clear DB tracking for evicted tracks.
+        if let Err(e) = queries::clear_cache_for_tracks(&db.conn, &album.track_ids) {
+            log::warn!("cache eviction: failed to clear DB for album: {}", e);
+        }
+
+        if verbose || log::log_enabled!(log::Level::Info) {
+            log::info!(
+                "evicted: {} — {} ({})",
+                album.artist_name,
+                album.album_title,
+                format_bytes(album.total_size as u64),
+            );
+        }
+
+        current_size -= album.total_size;
+        freed += album.total_size;
+    }
+
+    // Clean up empty directories in cache.
+    cleanup_empty_dirs(&cfg.cache_dir());
+
+    let freed = freed as u64;
+    if freed > 0 {
+        log::info!("cache eviction freed {}", format_bytes(freed));
+    }
+
+    freed
+}
+
+/// Remove empty directories left after eviction.
+fn cleanup_empty_dirs(dir: &std::path::Path) {
+    if !dir.is_dir() {
+        return;
+    }
+    // Walk bottom-up: try to remove leaf directories first.
+    for entry in walkdir::WalkDir::new(dir)
+        .contents_first(true)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().is_dir())
+    {
+        // Don't remove the cache root itself.
+        if entry.path() == dir {
+            continue;
+        }
+        // rmdir only succeeds if the directory is empty.
+        let _ = std::fs::remove_dir(entry.path());
+    }
 }

--- a/crates/koan-music/src/commands/mod.rs
+++ b/crates/koan-music/src/commands/mod.rs
@@ -16,7 +16,7 @@ mod search;
 pub mod serve;
 
 pub use analyze::cmd_analyze;
-pub use cache::{cmd_cache_clear, cmd_cache_status};
+pub use cache::{cmd_cache_clear, cmd_cache_status, evict_cache};
 pub use graphql::{cmd_serve, cmd_serve_daemon};
 pub use mcp::cmd_mcp;
 

--- a/crates/koan-music/src/main.rs
+++ b/crates/koan-music/src/main.rs
@@ -248,6 +248,8 @@ enum CacheCommands {
         #[arg(long, short = 'y')]
         yes: bool,
     },
+    /// Evict least-recently-played albums until cache is within limit
+    Evict,
 }
 
 /// Global flag set by SIGINT handler for graceful Ctrl+C shutdown.
@@ -319,6 +321,13 @@ fn main() {
             Commands::Cache(sub) => match sub {
                 CacheCommands::Status => commands::cmd_cache_status(),
                 CacheCommands::Clear { yes } => commands::cmd_cache_clear(yes),
+                CacheCommands::Evict => {
+                    let cfg = config::Config::load().unwrap_or_default();
+                    let freed = commands::evict_cache(&cfg, true);
+                    if freed == 0 {
+                        println!("cache within limit, nothing to evict");
+                    }
+                }
             },
             Commands::Completions { shell } => {
                 clap_complete::generate(shell, &mut Cli::command(), "koan", &mut io::stdout());
@@ -345,6 +354,9 @@ fn main() {
     // Default: TUI mode (with optional API server alongside).
     // CLI flags override config values.
     let cfg = koan_core::config::Config::load_or_default();
+
+    // Run LRU cache eviction on startup if a limit is configured.
+    commands::evict_cache(&cfg, false);
 
     if let Some(ref url) = cli.server {
         commands::cmd_play_remote(url, cli.jukebox);


### PR DESCRIPTION
## Summary

- **DB tracking**: New `cache_size_bytes` and `cache_download_date` columns on `tracks` table (ALTER TABLE migration). `set_cached_path()` now records file size and download timestamp after each download.
- **`cache_limit` config**: New field in `[remote]` section accepts human-readable sizes (`"50GB"`, `"500MB"`, `"1.5TB"`). None = unlimited (default).
- **LRU eviction on startup**: When cache exceeds the configured limit, whole albums are evicted oldest-last-played first (using existing `play_history` table). Albums with any favourited track are never evicted.
- **`koan cache evict`** subcommand for manual eviction.
- **`koan cache status`** now shows usage/limit when configured.

Closes #88

## Test plan

- [x] 88 existing tests pass (0 regressions)
- [x] New tests: `parse_size_bytes` (12 cases), `set_cached_path_records_size_and_date`, `total_cache_size`, `clear_cache_for_tracks`, `cached_albums_lru_excludes_favourites`, `cached_albums_lru_sorted_by_last_play`, `clear_cached_paths_clears_all_tracking`, `cache_limit_config_from_toml`, `cache_limit_none_by_default`, `cache_limit_not_serialized_when_none`
- [x] Zero clippy warnings
- [ ] Manual: set `cache_limit = "1GB"`, cache some albums, restart, verify eviction log

🤖 Generated with [Claude Code](https://claude.com/claude-code)