### PR TITLE
#89/#94/#95 fix(audio,server,player): render callback drain, cache verify, port fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Fixed
 
 - **CoreAudio crash during sample rate switch** — `stop_engine()` was dropping the `AudioEngine` on a background cleanup thread while the player thread immediately changed the device sample rate. The engine is now dropped synchronously before any sample rate changes; only the decode handle cleanup runs in the background ([#89](https://github.com/radiosilence/koan/issues/89))
+- **Render callback drain on AudioEngine drop** — `AudioOutputUnitStop` can return before the render callback finishes during sample rate switches. Added `in_callback` atomic flag and spin-wait in `Drop` to ensure the callback has fully exited before tearing down buffers ([#89](https://github.com/radiosilence/koan/issues/89))
+- **Stale cache paths on session restore** — restored queue items were unconditionally marked `Ready` even if their cached files had been deleted (e.g. by cache eviction). Now verifies paths exist on disk; missing files are marked `Pending` to re-trigger download ([#94](https://github.com/radiosilence/koan/issues/94))
+- **GraphQL/Subsonic port bind panic** — `run_api_blocking` called `.expect()` on port bind, crashing the entire app on `AddrInUse`. Now logs a warning and gracefully disables the API server ([#95](https://github.com/radiosilence/koan/issues/95))
 
 ### Added
 

--- a/crates/koan-core/src/audio/engine.rs
+++ b/crates/koan-core/src/audio/engine.rs
@@ -36,6 +36,9 @@ struct CallbackData {
     /// Cumulative samples played — incremented by the render callback,
     /// read by the UI to derive current track + position.
     samples_played: Arc<AtomicU64>,
+    /// Set true while the render callback is executing.
+    /// Drop spins on this to avoid tearing down while a callback is in flight.
+    in_callback: Arc<AtomicBool>,
 }
 
 // SAFETY: `rtrb::Consumer` is `!Send` due to internal raw pointers, but our usage is
@@ -53,6 +56,7 @@ pub struct AudioEngine {
     audio_unit: AudioUnit,
     callback_data: *mut CallbackData,
     running: Arc<AtomicBool>,
+    in_callback: Arc<AtomicBool>,
 }
 
 // SAFETY: AudioEngine contains an AudioUnit (opaque C pointer) and a *mut CallbackData.
@@ -73,6 +77,7 @@ impl AudioEngine {
         samples_played: Arc<AtomicU64>,
     ) -> Result<Self> {
         let running = Arc::new(AtomicBool::new(false));
+        let in_callback = Arc::new(AtomicBool::new(false));
 
         let desc = AudioComponentDescription {
             componentType: kAudioUnitType_Output,
@@ -138,6 +143,7 @@ impl AudioEngine {
             consumer,
             running: running.clone(),
             samples_played,
+            in_callback: in_callback.clone(),
         }));
 
         let render_cb = AURenderCallbackStruct {
@@ -162,6 +168,7 @@ impl AudioEngine {
             audio_unit,
             callback_data,
             running,
+            in_callback,
         })
     }
 
@@ -184,8 +191,24 @@ impl Drop for AudioEngine {
     fn drop(&mut self) {
         let _ = self.stop();
 
+        // Wait for any in-flight render callback to finish. AudioOutputUnitStop
+        // is documented as synchronous, but during sample rate switches the
+        // callback can still be executing when stop() returns. Spin on the
+        // in_callback flag with a hard timeout to avoid hanging forever.
+        let mut spins = 0u32;
+        while self.in_callback.load(Ordering::Acquire) {
+            std::hint::spin_loop();
+            spins += 1;
+            if spins > 1_000_000 {
+                // ~10ms of spinning on a modern CPU. Give up — better to risk
+                // a crash than deadlock the player thread during shutdown.
+                log::warn!("AudioEngine drop: timed out waiting for render callback to drain");
+                break;
+            }
+        }
+
         // Remove the render callback before tearing down. This ensures no
-        // in-flight callback can race with AudioUnitUninitialize, which
+        // future callback can race with AudioUnitUninitialize, which
         // otherwise crashes in CoreAudio's internal allocator (caulk) —
         // especially during sample rate changes.
         let silent_cb = AURenderCallbackStruct {
@@ -205,16 +228,10 @@ impl Drop for AudioEngine {
             );
         }
 
-        // No explicit wait needed here: AudioOutputUnitStop (called by stop()
-        // above) is synchronous — CoreAudio guarantees the render callback has
-        // fully returned before it hands control back. The callback removal
-        // above is belt-and-suspenders for the (extremely rare) case where
-        // stop() returns an error and the unit is in a degraded state.
-
         // SAFETY: AudioUnit was successfully created in new(). Uninitialize and
         // Dispose are the documented teardown sequence. callback_data was created
         // via Box::into_raw in new() and is not aliased — the render callback
-        // has been removed and AudioOutputUnitStop guarantees it's not in flight.
+        // has been removed and the spin-wait above ensures it's not in flight.
         unsafe {
             AudioUnitUninitialize(self.audio_unit);
             AudioComponentInstanceDispose(self.audio_unit);
@@ -238,8 +255,10 @@ unsafe extern "C" fn render_callback(
     // SAFETY: `in_ref_con` points to a heap-allocated CallbackData created via
     // Box::into_raw in AudioEngine::new. It remains valid for the lifetime of the
     // engine — the callback is removed and the pointer freed only in Drop, after
-    // AudioOutputUnitStop guarantees no callbacks are in flight.
+    // the spin-wait on in_callback ensures no callbacks are in flight.
     let data = unsafe { &mut *(in_ref_con as *mut CallbackData) };
+    data.in_callback.store(true, Ordering::Release);
+
     // SAFETY: `io_data` is provided by CoreAudio and is valid for the callback's duration.
     let buffer_list = unsafe { &mut *io_data };
 
@@ -252,6 +271,7 @@ unsafe extern "C" fn render_callback(
                 }
             }
         }
+        data.in_callback.store(false, Ordering::Release);
         return 0;
     }
 
@@ -271,6 +291,7 @@ unsafe extern "C" fn render_callback(
                 }
             }
         }
+        data.in_callback.store(false, Ordering::Release);
         return 0;
     }
     let out_ptr = buf.mData as *mut f32;
@@ -308,5 +329,6 @@ unsafe extern "C" fn render_callback(
         }
     }
 
+    data.in_callback.store(false, Ordering::Release);
     0
 }

--- a/crates/koan-core/src/db/queries/playback_state.rs
+++ b/crates/koan-core/src/db/queries/playback_state.rs
@@ -98,11 +98,23 @@ impl PersistedQueueItem {
         }
     }
 
-    /// Convert back to a PlaylistItem with fresh ID and Pending load state.
+    /// Convert back to a PlaylistItem with fresh ID.
+    /// Verifies the file path still exists on disk — missing cache files
+    /// get `LoadState::Pending` so the player re-triggers their download.
     pub fn to_playlist_item(&self) -> crate::player::state::PlaylistItem {
+        let path = PathBuf::from(&self.path);
+        let load_state = if path.exists() {
+            crate::player::state::LoadState::Ready
+        } else {
+            log::debug!(
+                "session restore: path missing, marking pending: {}",
+                self.path,
+            );
+            crate::player::state::LoadState::Pending
+        };
         crate::player::state::PlaylistItem {
             id: crate::player::state::QueueItemId::new(),
-            path: PathBuf::from(&self.path),
+            path,
             title: self.title.clone(),
             artist: self.artist.clone(),
             album_artist: self.album_artist.clone(),
@@ -112,7 +124,7 @@ impl PersistedQueueItem {
             track_number: self.track_number,
             disc: self.disc,
             duration_ms: self.duration_ms,
-            load_state: crate::player::state::LoadState::Ready,
+            load_state,
         }
     }
 }
@@ -195,6 +207,59 @@ mod tests {
 
         clear_playback_state(&conn).unwrap();
         assert!(load_playback_state(&conn).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_to_playlist_item_marks_missing_path_as_pending() {
+        let item = PersistedQueueItem {
+            path: "/nonexistent/path/track.flac".into(),
+            title: "Ghost".into(),
+            artist: "Nobody".into(),
+            album_artist: "Nobody".into(),
+            album: "Void".into(),
+            year: None,
+            codec: None,
+            track_number: None,
+            disc: None,
+            duration_ms: None,
+        };
+        let playlist_item = item.to_playlist_item();
+        assert!(
+            matches!(
+                playlist_item.load_state,
+                crate::player::state::LoadState::Pending
+            ),
+            "missing file should be Pending, got {:?}",
+            playlist_item.load_state,
+        );
+    }
+
+    #[test]
+    fn test_to_playlist_item_marks_existing_path_as_ready() {
+        // Use cargo's own manifest as a file that definitely exists.
+        let manifest = env!("CARGO_MANIFEST_DIR");
+        let existing_path = format!("{}/Cargo.toml", manifest);
+        let item = PersistedQueueItem {
+            path: existing_path,
+            title: "Real".into(),
+            artist: "Someone".into(),
+            album_artist: "Someone".into(),
+            album: "Exists".into(),
+            year: None,
+            codec: None,
+            track_number: None,
+            disc: None,
+            duration_ms: None,
+        };
+        let playlist_item = item.to_playlist_item();
+        assert!(
+            matches!(
+                playlist_item.load_state,
+                crate::player::state::LoadState::Ready
+            ),
+            "existing file should be Ready, got {:?}",
+            playlist_item.load_state,
+        );
     }
 
     #[test]

--- a/crates/koan-music/src/commands/graphql/server.rs
+++ b/crates/koan-music/src/commands/graphql/server.rs
@@ -70,35 +70,58 @@ fn run_api_blocking(
         let gql_app = gql_app.with_state(schema);
 
         let gql_addr = std::net::SocketAddr::new(bind, port);
-        log::info!("GraphQL API on http://{}:{}/graphql", bind, port);
-        if playground_enabled {
-            log::info!("GraphiQL: http://{}:{}/graphql", bind, port);
-        }
 
-        let gql_listener = tokio::net::TcpListener::bind(gql_addr)
-            .await
-            .expect("failed to bind GraphQL port");
+        let gql_listener = match tokio::net::TcpListener::bind(gql_addr).await {
+            Ok(l) => {
+                log::info!("GraphQL API on http://{}:{}/graphql", bind, port);
+                if playground_enabled {
+                    log::info!("GraphiQL: http://{}:{}/graphql", bind, port);
+                }
+                l
+            }
+            Err(e) => {
+                log::warn!(
+                    "API disabled: failed to bind GraphQL port {} — {} (another instance running?)",
+                    port,
+                    e,
+                );
+                return;
+            }
+        };
         let gql_server =
             axum::serve(gql_listener, gql_app).with_graceful_shutdown(shutdown_signal());
 
         if let Some(sub_port) = subsonic_port {
             let sub_app = super::super::serve::subsonic_router(db_path);
             let sub_addr = std::net::SocketAddr::new(bind, sub_port);
-            log::info!("Subsonic REST on http://{}:{}/rest/", bind, sub_port);
 
-            let sub_listener = tokio::net::TcpListener::bind(sub_addr)
-                .await
-                .expect("failed to bind Subsonic port");
-            let sub_server =
-                axum::serve(sub_listener, sub_app).with_graceful_shutdown(shutdown_signal());
+            match tokio::net::TcpListener::bind(sub_addr).await {
+                Ok(sub_listener) => {
+                    log::info!("Subsonic REST on http://{}:{}/rest/", bind, sub_port);
+                    let sub_server = axum::serve(sub_listener, sub_app)
+                        .with_graceful_shutdown(shutdown_signal());
 
-            // Run both servers concurrently.
-            tokio::select! {
-                r = gql_server => r.expect("GraphQL server error"),
-                r = sub_server => r.expect("Subsonic server error"),
+                    tokio::select! {
+                        r = gql_server => { if let Err(e) = r { log::error!("GraphQL server error: {e}"); } },
+                        r = sub_server => { if let Err(e) = r { log::error!("Subsonic server error: {e}"); } },
+                    }
+                }
+                Err(e) => {
+                    log::warn!(
+                        "Subsonic API disabled: failed to bind port {} — {}",
+                        sub_port,
+                        e,
+                    );
+                    // Run GraphQL-only.
+                    if let Err(e) = gql_server.await {
+                        log::error!("GraphQL server error: {e}");
+                    }
+                }
             }
         } else {
-            gql_server.await.expect("server error");
+            if let Err(e) = gql_server.await {
+                log::error!("GraphQL server error: {e}");
+            }
         }
     });
 }


### PR DESCRIPTION
## Summary

- **#89 AudioEngine crash fix**: Added `in_callback` atomic flag to the CoreAudio render callback. `Drop` impl now spin-waits for the flag to clear before tearing down buffers, preventing crashes when `AudioOutputUnitStop` returns while the callback is still mid-execution during sample rate switches.
- **#94 Cache path verification on session restore**: `to_playlist_item()` now checks whether the persisted file path exists on disk. Missing cache files (e.g. evicted by LRU) get `LoadState::Pending` instead of `Ready`, so the player re-triggers downloads rather than failing on stale refs.
- **#95 Graceful port bind failure**: Replaced `.expect()` on `TcpListener::bind` with proper error handling. `AddrInUse` (e.g. from a prior crash leaving the port open) now logs a warning and disables the API instead of panicking the whole application.

## Test plan

- [x] New unit tests for `to_playlist_item` verifying Pending/Ready based on path existence
- [ ] Manual: kill koan mid-playback, restart — should not crash on port rebind
- [ ] Manual: delete a cached file, restart — queue should show pending download state
- [ ] Manual: trigger sample rate switch — no crash on engine teardown

🤖 Generated with [Claude Code](https://claude.com/claude-code)