### PR TITLE
fix(player): cull played tracks in radio mode to prevent unbounded memory growth

### DIFF
--- a/crates/koan-core/src/config.rs
+++ b/crates/koan-core/src/config.rs
@@ -256,6 +256,9 @@ impl Default for GraphqlConfig {
     }
 }
 
+/// Default number of played tracks to retain in radio mode before culling.
+pub const RADIO_CULL_KEEP_COUNT: usize = 50;
+
 /// Radio / infinite play mode configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]

--- a/crates/koan-core/src/player/commands.rs
+++ b/crates/koan-core/src/player/commands.rs
@@ -44,6 +44,8 @@ pub enum PlayerCommand {
     TrackReady(QueueItemId),
     /// Enough data buffered for streaming playback — check if cursor is waiting.
     TrackStreamReady(QueueItemId),
+    /// Prune old tracks from the playlist, keeping `usize` items before the cursor.
+    CullPlayed(usize),
     /// Undo the last reversible playlist operation.
     Undo,
     /// Redo the last undone operation.

--- a/crates/koan-core/src/player/mod.rs
+++ b/crates/koan-core/src/player/mod.rs
@@ -913,6 +913,14 @@ impl Player {
                 self.shared_state.insert_items_after(items, after);
                 self.push_undo(UndoEntry::Inserted { ids });
             }
+            PlayerCommand::CullPlayed(keep) => {
+                let culled = self.shared_state.cull_played_items(keep);
+                if culled {
+                    // Culling from the front breaks predecessor ID references in the
+                    // undo stack. We must clear undo history to prevent corruption.
+                    self.undo_stack.clear();
+                }
+            }
             PlayerCommand::ClearPlaylist => {
                 // Stop engine + clear display state WITHOUT touching the playlist,
                 // then snapshot, then clear. This avoids the race where stop()

--- a/crates/koan-core/src/player/state.rs
+++ b/crates/koan-core/src/player/state.rs
@@ -320,6 +320,29 @@ impl SharedPlayerState {
         self.bump_version();
     }
 
+    /// Prune played items from the playlist to prevent unbounded memory growth.
+    /// Keeps `keep_played` items before the cursor, plus the cursor and everything after.
+    /// Returns true if items were actually removed.
+    pub(crate) fn cull_played_items(&self, keep_played: usize) -> bool {
+        let mut pl = self.playlist.write();
+        let cursor_pos = match pl.cursor {
+            Some(cid) => pl.items.iter().position(|item| item.id == cid),
+            None => None,
+        };
+
+        if let Some(pos) = cursor_pos
+            && pos > keep_played
+        {
+            let remove_count = pos - keep_played;
+            pl.items.drain(0..remove_count);
+            drop(pl);
+            self.bump_version();
+            true
+        } else {
+            false
+        }
+    }
+
     /// Insert items after a specific queue item.
     pub fn insert_items_after(&self, items: Vec<PlaylistItem>, after: QueueItemId) {
         let mut pl = self.playlist.write();
@@ -1169,5 +1192,35 @@ mod tests {
         assert_eq!(items[1].id, id_d);
         assert_eq!(items[2].id, id_a);
         assert_eq!(items[3].id, id_c);
+    }
+
+    #[test]
+    fn test_cull_played_items() {
+        let state = SharedPlayerState::new();
+        state.add_items(vec![
+            ready_item("track-0"),
+            ready_item("track-1"),
+            ready_item("track-2"),
+            ready_item("track-3"),
+            ready_item("track-4"),
+        ]);
+        let items = state.playlist.read().items.clone();
+        
+        state.set_cursor(Some(items[0].id));
+        assert!(!state.cull_played_items(1));
+        assert_eq!(state.playlist.read().items.len(), 5);
+
+        state.set_cursor(Some(items[2].id));
+        assert!(state.cull_played_items(1));
+        assert_eq!(state.playlist.read().items.len(), 4);
+        assert_eq!(state.playlist.read().items[0].title, "track-1");
+        
+        state.set_cursor(Some(items[4].id));
+        assert!(state.cull_played_items(0));
+        assert_eq!(state.playlist.read().items.len(), 1);
+        assert_eq!(state.playlist.read().items[0].title, "track-4");
+        
+        state.clear_playlist();
+        assert!(!state.cull_played_items(0));
     }
 }

--- a/crates/koan-core/src/player/undo.rs
+++ b/crates/koan-core/src/player/undo.rs
@@ -65,6 +65,12 @@ impl UndoStack {
         Self::default()
     }
 
+    /// Clear all undo and redo history.
+    pub fn clear(&mut self) {
+        self.undo.clear();
+        self.redo.clear();
+    }
+
     /// Push an undo entry. Clears the redo stack.
     /// Batch entries exceeding `MAX_BATCH_SIZE` are truncated.
     pub fn push(&mut self, entry: UndoEntry) {

--- a/crates/koan-music/src/remote_bridge.rs
+++ b/crates/koan-music/src/remote_bridge.rs
@@ -394,6 +394,7 @@ fn command_loop(
             // catches new variants.
             PlayerCommand::TrackReady(_)
             | PlayerCommand::TrackStreamReady(_)
+            | PlayerCommand::CullPlayed(_)
             | PlayerCommand::BeginUndoBatch
             | PlayerCommand::EndUndoBatch
             | PlayerCommand::UpdatePaths(_)

--- a/crates/koan-music/src/tui/app.rs
+++ b/crates/koan-music/src/tui/app.rs
@@ -763,6 +763,10 @@ impl App {
             };
 
             if remaining <= self.radio_config.lookahead {
+                // Prevent unbounded memory growth by culling played tracks in radio mode.
+                self.tx
+                    .send(PlayerCommand::CullPlayed(koan_core::config::RADIO_CULL_KEEP_COUNT))
+                    .ok();
                 self.trigger_radio_pick();
             }
         }


### PR DESCRIPTION
When Radio Mode is active, tracks are continuously added to the playlist. Previously, already played tracks were never removed, leading to unbounded memory accumulation of `PlaylistItem` structs in the queue. This PR adds a `cull_played_items(keep_played: usize)` method to `SharedPlayerState` and automatically culls the playlist to keep only the last 50 played tracks when triggering new radio picks.