### PR TITLE
feat(config): adopt figment for 12-factor env var overrides, fix secret round-trip leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ## Unreleased
 
+### Changed
+
+- **Config loading uses figment** — replaced hand-rolled TOML deep-merge with [figment](https://docs.rs/figment) for layered config: defaults → `config.toml` → `config.local.toml` → `KOAN_*` env vars. Any config field is now overridable via environment variables using `KOAN_SECTION__FIELD` naming (e.g. `KOAN_REMOTE__PASSWORD`, `KOAN_GRAPHQL__PORT`, `KOAN_PLAYBACK__TARGET_FPS`)
+
 ### Fixed
+
+- **Secret round-trip leak in config save** — `save()` on a merged Config would serialize secrets from `config.local.toml` and env vars back into `config.toml`. Callers now use `Config::update_base()` which reads only `config.toml`, applies the mutation, and writes back without leaking sensitive fields
 
 - **Path traversal in organize** — `sanitize_relative_path` now strips `..` and `.` components, and `plan_single_move` validates the destination stays under the base directory. Prevents malicious metadata from writing files outside the library ([#99](https://github.com/radiosilence/koan/issues/99))
 - **RT safety in CPAL audio callback** — changed `Mutex::lock()` to `try_lock()` in the audio render callback so the real-time thread never blocks; outputs silence on contention instead ([#99](https://github.com/radiosilence/koan/issues/99))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,6 +265,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1251,6 +1260,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "figment"
+version = "0.10.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
+dependencies = [
+ "atomic",
+ "pear",
+ "serde",
+ "toml 0.8.23",
+ "uncased",
+ "version_check",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1848,6 +1871,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "inlinable_string"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
+
+[[package]]
 name = "instability"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1973,7 +2002,7 @@ dependencies = [
 
 [[package]]
 name = "koan-core"
-version = "0.18.0"
+version = "0.17.1"
 dependencies = [
  "bliss-audio",
  "bliss-audio-aubio-rs",
@@ -1984,6 +2013,7 @@ dependencies = [
  "crossbeam-channel",
  "dirs",
  "ebur128",
+ "figment",
  "getrandom 0.2.17",
  "keyring",
  "lofty",
@@ -2000,14 +2030,14 @@ dependencies = [
  "symphonia",
  "tempfile",
  "thiserror 2.0.18",
- "toml",
+ "toml 0.9.12+spec-1.1.0",
  "uuid",
  "walkdir",
 ]
 
 [[package]]
 name = "koan-music"
-version = "0.18.0"
+version = "0.17.1"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",
@@ -2039,7 +2069,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-util",
- "toml",
+ "toml 0.9.12+spec-1.1.0",
  "tower",
  "uuid",
  "walkdir",
@@ -2611,6 +2641,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
 
 [[package]]
+name = "pear"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdeeaa00ce488657faba8ebf44ab9361f9365a97bd39ffb8a60663f57ff4b467"
+dependencies = [
+ "inlinable_string",
+ "pear_codegen",
+ "yansi",
+]
+
+[[package]]
+name = "pear_codegen"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bab5b985dc082b345f812b7df84e1bef27e7207b39e448439ba8bd69c93f147"
+dependencies = [
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2768,7 +2821,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.25.5+spec-1.1.0",
 ]
 
 [[package]]
@@ -2778,6 +2831,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "version_check",
+ "yansi",
 ]
 
 [[package]]
@@ -3525,6 +3591,15 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
@@ -4133,17 +4208,38 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
 version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned",
+ "serde_spanned 1.0.4",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
  "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -4166,6 +4262,20 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.25.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ca1a40644a28bce036923f6a431df0b34236949d111cc07cb6dca830c9ef2e1"
@@ -4184,6 +4294,12 @@ checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
 dependencies = [
  "winnow 1.0.0",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -4314,6 +4430,15 @@ name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "uncased"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unicode-ident"
@@ -4980,6 +5105,9 @@ name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"
@@ -5083,6 +5211,12 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/crates/koan-core/Cargo.toml
+++ b/crates/koan-core/Cargo.toml
@@ -16,6 +16,7 @@ crossbeam-channel = "0.5"
 chrono = "0.4"
 # Config
 dirs = "6"
+figment = { version = "0.10", features = ["toml", "env"] }
 ebur128 = "0.1"
 # Credentials (cross-platform: macOS Keychain, Linux secret-service)
 keyring = { version = "3", features = ["apple-native", "sync-secret-service"] }

--- a/crates/koan-core/src/config.rs
+++ b/crates/koan-core/src/config.rs
@@ -2,6 +2,8 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use figment::Figment;
+use figment::providers::{Env, Format, Serialized, Toml};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -13,6 +15,8 @@ pub enum ConfigError {
     Parse(#[from] toml::de::Error),
     #[error("serialize error: {0}")]
     Serialize(#[from] toml::ser::Error),
+    #[error("config error: {0}")]
+    Figment(#[from] Box<figment::Error>),
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -71,7 +75,7 @@ pub struct RemoteConfig {
     pub enabled: bool,
     pub url: String,
     pub username: String,
-    /// Password — stored in config.local.toml (gitignored), not Keychain.
+    /// Password — stored in config.local.toml (gitignored), not config.toml.
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub password: String,
     /// original | opus-128 | mp3-320
@@ -308,28 +312,26 @@ impl Default for DiscoveryConfig {
 }
 
 impl Config {
-    /// Load config.toml then deep-merge config.local.toml on top.
-    /// Only keys actually present in config.local.toml override — missing keys
-    /// keep their values from config.toml (not serde defaults).
-    pub fn load() -> Result<Self, ConfigError> {
+    /// Build the figment provider chain:
+    /// defaults → config.toml → config.local.toml → KOAN_* env vars.
+    ///
+    /// Env vars use `KOAN_` prefix with `__` as section separator:
+    ///   KOAN_REMOTE__PASSWORD, KOAN_GRAPHQL__PORT, KOAN_PLAYBACK__TARGET_FPS, etc.
+    fn figment() -> Figment {
         let base_path = config_file_path();
         let local_path = config_local_file_path();
 
-        let mut base_val: toml::Value = if base_path.exists() {
-            let contents = fs::read_to_string(&base_path)?;
-            toml::from_str(&contents)?
-        } else {
-            toml::Value::Table(toml::map::Map::new())
-        };
+        Figment::from(Serialized::defaults(Config::default()))
+            .merge(Toml::file(&base_path))
+            .merge(Toml::file(&local_path))
+            .merge(Env::prefixed("KOAN_").split("__"))
+    }
 
-        if local_path.exists() {
-            let local_contents = fs::read_to_string(&local_path)?;
-            let local_val: toml::Value = toml::from_str(&local_contents)?;
-            deep_merge(&mut base_val, local_val);
-        }
-
-        let config: Config = base_val.try_into()?;
-        Ok(config)
+    /// Load config from all layers: defaults → config.toml → config.local.toml → KOAN_* env vars.
+    pub fn load() -> Result<Self, ConfigError> {
+        Self::figment()
+            .extract()
+            .map_err(|e| ConfigError::Figment(Box::new(e)))
     }
 
     /// Load config, logging and falling back to defaults on error.
@@ -340,32 +342,54 @@ impl Config {
         })
     }
 
-    /// Load from a specific path.
+    /// Load from a specific TOML file (no env var overlay).
     pub fn load_from(path: &Path) -> Result<Self, ConfigError> {
         let contents = fs::read_to_string(path)?;
         let config: Config = toml::from_str(&contents)?;
         Ok(config)
     }
 
-    /// Write config to the base config.toml.
-    pub fn save(&self) -> Result<(), ConfigError> {
+    /// Patch config.toml with a mutation closure. Reads the base file only (not
+    /// config.local.toml or env vars), applies the closure, writes back.
+    /// This prevents secrets from config.local.toml or env vars leaking into config.toml.
+    pub fn update_base<F>(mutate: F) -> Result<(), ConfigError>
+    where
+        F: FnOnce(&mut Config),
+    {
         let path = config_file_path();
+        let mut cfg = if path.exists() {
+            Config::load_from(&path)?
+        } else {
+            Config::default()
+        };
+        mutate(&mut cfg);
+        cfg.write_to(&path)?;
+        Ok(())
+    }
+
+    /// Write this config to a specific path as TOML.
+    fn write_to(&self, path: &Path) -> Result<(), ConfigError> {
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent)?;
         }
         let contents = toml::to_string_pretty(self)?;
-        fs::write(&path, contents)?;
+        fs::write(path, contents)?;
         Ok(())
+    }
+
+    /// Write config to the base config.toml.
+    ///
+    /// **Warning**: If this Config was loaded via `load()` (merged from all layers),
+    /// calling `save()` will write secrets from config.local.toml/env into config.toml.
+    /// Prefer `update_base()` for targeted field changes.
+    pub fn save(&self) -> Result<(), ConfigError> {
+        self.write_to(&config_file_path())
     }
 
     /// Write config to config.local.toml (for machine-specific / sensitive values).
     pub fn save_local(&self) -> Result<(), ConfigError> {
         let path = config_local_file_path();
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent)?;
-        }
-        let contents = toml::to_string_pretty(self)?;
-        fs::write(&path, contents)?;
+        self.write_to(&path)?;
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
@@ -388,24 +412,6 @@ impl Config {
             .cache_limit
             .as_deref()
             .and_then(parse_size_bytes)
-    }
-}
-
-/// Recursively merge `overlay` into `base`. Only keys present in `overlay`
-/// are touched — everything else in `base` is preserved.
-fn deep_merge(base: &mut toml::Value, overlay: toml::Value) {
-    match (base, overlay) {
-        (toml::Value::Table(base_map), toml::Value::Table(overlay_map)) => {
-            for (key, overlay_val) in overlay_map {
-                let entry = base_map
-                    .entry(key)
-                    .or_insert(toml::Value::Table(toml::map::Map::new()));
-                deep_merge(entry, overlay_val);
-            }
-        }
-        (base, overlay) => {
-            *base = overlay;
-        }
     }
 }
 
@@ -496,57 +502,150 @@ replaygain = "track"
     }
 
     #[test]
-    fn test_deep_merge_local_overrides_base() {
-        // Test deep_merge directly on TOML values (no temp files needed).
-        let base_toml = r#"
-[library]
-folders = ["/base/music"]
+    fn test_figment_layered_loading() {
+        let dir = tempfile::tempdir().unwrap();
+        let base_path = dir.path().join("config.toml");
+        let local_path = dir.path().join("config.local.toml");
 
+        fs::write(
+            &base_path,
+            r#"
 [remote]
 url = "https://base.example.com"
-"#;
-        let local_toml = r#"
-[library]
-folders = ["/local/music"]
-
+"#,
+        )
+        .unwrap();
+        fs::write(
+            &local_path,
+            r#"
 [remote]
 enabled = true
 url = "https://local.example.com"
 username = "admin"
-"#;
+password = "secret"
+"#,
+        )
+        .unwrap();
 
-        let mut base_val: toml::Value = toml::from_str(base_toml).unwrap();
-        let local_val: toml::Value = toml::from_str(local_toml).unwrap();
-        deep_merge(&mut base_val, local_val);
+        // Build a figment with explicit paths (can't use load() since it reads from ~/.config).
+        let cfg: Config = Figment::from(Serialized::defaults(Config::default()))
+            .merge(Toml::file(&base_path))
+            .merge(Toml::file(&local_path))
+            .extract()
+            .unwrap();
 
-        let cfg: Config = base_val.try_into().unwrap();
-        assert_eq!(cfg.library.folders, vec![PathBuf::from("/local/music")]);
         assert!(cfg.remote.enabled);
         assert_eq!(cfg.remote.url, "https://local.example.com");
         assert_eq!(cfg.remote.username, "admin");
+        assert_eq!(cfg.remote.password, "secret");
     }
 
     #[test]
-    fn test_deep_merge_missing_keys_preserved() {
-        let base_toml = r#"
+    fn test_figment_missing_keys_preserved() {
+        let dir = tempfile::tempdir().unwrap();
+        let base_path = dir.path().join("config.toml");
+        let local_path = dir.path().join("config.local.toml");
+
+        fs::write(
+            &base_path,
+            r#"
 [remote]
 url = "https://keep.me"
 username = "keepuser"
-"#;
-        // Local only sets password — url and username should survive.
-        let local_toml = r#"
+"#,
+        )
+        .unwrap();
+        fs::write(
+            &local_path,
+            r#"
 [remote]
 password = "secret"
-"#;
+"#,
+        )
+        .unwrap();
 
-        let mut base_val: toml::Value = toml::from_str(base_toml).unwrap();
-        let local_val: toml::Value = toml::from_str(local_toml).unwrap();
-        deep_merge(&mut base_val, local_val);
+        let cfg: Config = Figment::from(Serialized::defaults(Config::default()))
+            .merge(Toml::file(&base_path))
+            .merge(Toml::file(&local_path))
+            .extract()
+            .unwrap();
 
-        let cfg: Config = base_val.try_into().unwrap();
         assert_eq!(cfg.remote.url, "https://keep.me");
         assert_eq!(cfg.remote.username, "keepuser");
         assert_eq!(cfg.remote.password, "secret");
+    }
+
+    #[test]
+    fn test_env_var_override() {
+        let dir = tempfile::tempdir().unwrap();
+        let base_path = dir.path().join("config.toml");
+
+        fs::write(
+            &base_path,
+            r#"
+[remote]
+url = "https://file.example.com"
+"#,
+        )
+        .unwrap();
+
+        // SAFETY: test is single-threaded and vars are cleaned up immediately after.
+        unsafe {
+            std::env::set_var("KOAN_REMOTE__URL", "https://env.example.com");
+            std::env::set_var("KOAN_REMOTE__PASSWORD", "env-secret");
+            std::env::set_var("KOAN_GRAPHQL__PORT", "9999");
+        }
+
+        let cfg: Config = Figment::from(Serialized::defaults(Config::default()))
+            .merge(Toml::file(&base_path))
+            .merge(Env::prefixed("KOAN_").split("__"))
+            .extract()
+            .unwrap();
+
+        assert_eq!(cfg.remote.url, "https://env.example.com");
+        assert_eq!(cfg.remote.password, "env-secret");
+        assert_eq!(cfg.graphql.port, 9999);
+
+        // Clean up env vars.
+        unsafe {
+            std::env::remove_var("KOAN_REMOTE__URL");
+            std::env::remove_var("KOAN_REMOTE__PASSWORD");
+            std::env::remove_var("KOAN_GRAPHQL__PORT");
+        }
+    }
+
+    #[test]
+    fn test_update_base_does_not_leak_secrets() {
+        let dir = tempfile::tempdir().unwrap();
+        let base_path = dir.path().join("config.toml");
+
+        // Write an initial base config.
+        fs::write(
+            &base_path,
+            r#"
+[playback]
+target_fps = 60
+
+[remote]
+url = "https://base.example.com"
+"#,
+        )
+        .unwrap();
+
+        // Simulate: update_base patches base config only.
+        let mut base_cfg = Config::load_from(&base_path).unwrap();
+        base_cfg.visualizer.enabled = false;
+        base_cfg.write_to(&base_path).unwrap();
+
+        // Verify: no password leaked into config.toml.
+        let written = fs::read_to_string(&base_path).unwrap();
+        assert!(!written.contains("secret"));
+        assert!(!written.contains("password"));
+
+        // Verify the field was saved.
+        let reloaded = Config::load_from(&base_path).unwrap();
+        assert!(!reloaded.visualizer.enabled);
+        assert_eq!(reloaded.remote.url, "https://base.example.com");
     }
 
     #[test]
@@ -629,30 +728,43 @@ va-aware = "%album artist%/$if($stricmp(%album artist%,Various Artists),,%album%
     }
 
     #[test]
-    fn test_deep_merge_organize_patterns() {
-        let base_toml = r#"
+    fn test_figment_organize_patterns_merge() {
+        let dir = tempfile::tempdir().unwrap();
+        let base_path = dir.path().join("config.toml");
+        let local_path = dir.path().join("config.local.toml");
+
+        fs::write(
+            &base_path,
+            r#"
 [organize]
 default = "standard"
 
 [organize.patterns]
 standard = "base-pattern"
-"#;
-        let local_toml = r#"
+"#,
+        )
+        .unwrap();
+        fs::write(
+            &local_path,
+            r#"
 [organize]
 default = "custom"
 
 [organize.patterns]
 custom = "local-pattern"
-"#;
+"#,
+        )
+        .unwrap();
 
-        let mut base_val: toml::Value = toml::from_str(base_toml).unwrap();
-        let local_val: toml::Value = toml::from_str(local_toml).unwrap();
-        deep_merge(&mut base_val, local_val);
+        let cfg: Config = Figment::from(Serialized::defaults(Config::default()))
+            .merge(Toml::file(&base_path))
+            .merge(Toml::file(&local_path))
+            .extract()
+            .unwrap();
 
-        let cfg: Config = base_val.try_into().unwrap();
-        // Local default wins
+        // Local default wins.
         assert_eq!(cfg.organize.default.as_deref(), Some("custom"));
-        // Both patterns present (deep merge into [organize.patterns] table)
+        // Both patterns present (figment merges maps).
         assert_eq!(cfg.organize.patterns.len(), 2);
         assert_eq!(cfg.organize.patterns["standard"], "base-pattern");
         assert_eq!(cfg.organize.patterns["custom"], "local-pattern");

--- a/crates/koan-core/src/player/mod.rs
+++ b/crates/koan-core/src/player/mod.rs
@@ -143,12 +143,11 @@ impl Player {
         log::info!("switching output device to: {}", name);
         self.output_device_name = Some(name.clone());
 
-        // Persist to config.
-        if let Ok(mut cfg) = crate::config::Config::load() {
+        // Persist to config.toml (not the merged config — avoids leaking secrets).
+        if let Err(e) = crate::config::Config::update_base(|cfg| {
             cfg.playback.output_device = Some(name);
-            if let Err(e) = cfg.save() {
-                log::error!("failed to save output device config: {}", e);
-            }
+        }) {
+            log::error!("failed to save output device config: {}", e);
         }
 
         self.restart_on_current_track();
@@ -159,11 +158,10 @@ impl Player {
         log::info!("reverting to system default output device");
         self.output_device_name = None;
 
-        if let Ok(mut cfg) = crate::config::Config::load() {
+        if let Err(e) = crate::config::Config::update_base(|cfg| {
             cfg.playback.output_device = None;
-            if let Err(e) = cfg.save() {
-                log::error!("failed to save output device config: {}", e);
-            }
+        }) {
+            log::error!("failed to save output device config: {}", e);
         }
 
         self.restart_on_current_track();

--- a/crates/koan-music/src/commands/config.rs
+++ b/crates/koan-music/src/commands/config.rs
@@ -28,6 +28,21 @@ pub fn cmd_config() {
         );
     }
     println!("  {} {}", "db:".cyan(), config::db_path().display());
+
+    // Show any active KOAN_* env var overrides.
+    let env_overrides: Vec<_> = std::env::vars()
+        .filter(|(k, _)| k.starts_with("KOAN_"))
+        .collect();
+    if !env_overrides.is_empty() {
+        println!(
+            "  {} {} active",
+            "env:".cyan(),
+            format!("{} KOAN_* vars", env_overrides.len()).green()
+        );
+        for (k, _) in &env_overrides {
+            println!("    {}", k.dimmed());
+        }
+    }
     println!();
 
     println!("{}", "resolved".bold());

--- a/crates/koan-music/src/tui/app.rs
+++ b/crates/koan-music/src/tui/app.rs
@@ -983,11 +983,11 @@ impl App {
                     },
                     std::time::Instant::now(),
                 ));
-                // Persist to config
-                if let Ok(mut cfg) = koan_core::config::Config::load() {
-                    cfg.visualizer.enabled = self.viz_config.enabled;
-                    let _ = cfg.save();
-                }
+                // Persist to config.toml (not the merged config — avoids leaking secrets).
+                let viz_enabled = self.viz_config.enabled;
+                let _ = koan_core::config::Config::update_base(|cfg| {
+                    cfg.visualizer.enabled = viz_enabled;
+                });
             }
             KeyCode::Up => {
                 let visible = self.visible_queue();


### PR DESCRIPTION
## Summary
- Adopts figment for 12-factor compliant env var configuration overrides
- Fixes secret round-trip leak in config serialization

Polecat: guzzle/figment
MR: ko-wisp-wpl

## Test plan
- [x] cargo fmt clean
- [x] cargo clippy clean (0 warnings)
- [x] 561 tests passed, 0 failures