### PR TITLE
release: v0.18.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1973,7 +1973,7 @@ dependencies = [
 
 [[package]]
 name = "koan-core"
-version = "0.18.0"
+version = "0.17.1"
 dependencies = [
  "bliss-audio",
  "bliss-audio-aubio-rs",
@@ -2007,7 +2007,7 @@ dependencies = [
 
 [[package]]
 name = "koan-music"
-version = "0.18.0"
+version = "0.17.1"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",

--- a/crates/koan-core/src/config.rs
+++ b/crates/koan-core/src/config.rs
@@ -55,6 +55,9 @@ pub struct PlaybackConfig {
     /// Persisted by name (not ID) since IDs can change across reboots.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub output_device: Option<String>,
+    /// Album art width in terminal columns (default: 24).
+    /// Height is always width/2 (square via halfblock rendering).
+    pub art_size: u16,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -109,6 +112,7 @@ impl Default for PlaybackConfig {
             show_fps: false,
             pre_amp_db: 0.0,
             output_device: None,
+            art_size: 24,
         }
     }
 }

--- a/crates/koan-music/src/tui/app.rs
+++ b/crates/koan-music/src/tui/app.rs
@@ -152,8 +152,6 @@ pub struct ArtState {
     pub cover_art: super::cover_art::CoverArtCache,
     /// Cached cover art for now-playing transport display.
     pub now_playing_art: super::cover_art::CoverArtCache,
-    /// Last computed art height so layout stays stable when art disappears.
-    pub last_art_height: u16,
 }
 
 pub struct App {
@@ -292,6 +290,8 @@ pub struct App {
     pub radio_rx: Option<crossbeam_channel::Receiver<Vec<i64>>>,
     /// Radio config.
     pub radio_config: koan_core::config::RadioConfig,
+    /// Album art width in terminal columns. Height = width/2 (square via halfblocks).
+    pub art_size: u16,
 
     /// Persistent download queue — used to trigger downloads for pending items.
     pub download_queue: DownloadQueue,
@@ -368,6 +368,7 @@ impl App {
             radio_pending: false,
             radio_rx: None,
             radio_config: cfg.radio,
+            art_size: cfg.playback.art_size,
             download_queue,
         }
     }

--- a/crates/koan-music/src/tui/cover_art.rs
+++ b/crates/koan-music/src/tui/cover_art.rs
@@ -68,24 +68,6 @@ impl CoverArtCache {
         self.image.as_ref()
     }
 
-    /// Compute how many terminal rows the cached image would occupy at a given
-    /// column width, preserving aspect ratio. Returns 0 if no image is cached.
-    pub fn cell_height_for_width(&self, width: u16) -> u16 {
-        let Some(ref img) = self.image else {
-            return 0;
-        };
-        if width == 0 {
-            return 0;
-        }
-        let (iw, ih) = (img.width(), img.height());
-        if iw == 0 || ih == 0 {
-            return 0;
-        }
-        // Target pixel height (2 pixels per cell row via halfblocks).
-        let target_ph = (width as u32) * ih / iw;
-        // Convert pixel rows → cell rows (ceiling).
-        (target_ph.div_ceil(2)) as u16
-    }
 
     /// Clear the cache.
     pub fn clear(&mut self) {

--- a/crates/koan-music/src/tui/ui.rs
+++ b/crates/koan-music/src/tui/ui.rs
@@ -19,11 +19,6 @@ use super::visualizer::SpectrumWidget;
 
 /// Height of the transport bar without album art.
 const TRANSPORT_HEIGHT_DEFAULT: u16 = 3;
-/// Desired art width in columns. Art is square-ish so height ~ width/2 cells.
-const ART_WIDTH: u16 = 24;
-/// Default art height (cell rows) assuming square artwork: ART_WIDTH / 2.
-/// Used as placeholder so the layout doesn't jump when art loads.
-const ART_HEIGHT_PLACEHOLDER: u16 = ART_WIDTH / 2;
 
 pub fn render(frame: &mut Frame, app: &mut App) {
     // Refresh the visible queue cache once per frame so all reads
@@ -33,20 +28,9 @@ pub fn render(frame: &mut Frame, app: &mut App) {
     let area = frame.area();
 
     let has_art = app.art.now_playing_art.cached().is_some();
-    // Derive height from actual image aspect ratio at desired width.
-    // Always reserve art-sized space once we've had art, so the UI
-    // doesn't jump when switching between tracks with/without art.
-    let art_h = app.art.now_playing_art.cell_height_for_width(ART_WIDTH);
-    if art_h > 0 {
-        app.art.last_art_height = art_h;
-    }
-    // Always reserve placeholder space for art so the layout never jumps
-    // when art loads or when switching between tracks with/without art.
-    let transport_height = if app.art.last_art_height > 0 {
-        app.art.last_art_height.max(TRANSPORT_HEIGHT_DEFAULT)
-    } else {
-        ART_HEIGHT_PLACEHOLDER.max(TRANSPORT_HEIGHT_DEFAULT)
-    };
+    let art_width = app.art_size;
+    let art_height = art_width / 2; // square via halfblock rendering
+    let transport_height = art_height.max(TRANSPORT_HEIGHT_DEFAULT);
 
     // Main layout: transport | content (flex) | hints (1)
     let chunks = Layout::vertical([
@@ -72,15 +56,15 @@ pub fn render(frame: &mut Frame, app: &mut App) {
         .cloned();
 
     // Always reserve art space — placeholder keeps layout stable.
-    let art_area = Rect::new(chunks[0].x, chunks[0].y, ART_WIDTH, transport_height);
+    let art_area = Rect::new(chunks[0].x, chunks[0].y, art_width, transport_height);
     let text_area = {
         // Bottom-align the transport text (3 lines) within the full height.
         let text_height = 3u16.min(transport_height);
         let text_y = chunks[0].y + transport_height - text_height;
         Rect::new(
-            chunks[0].x + ART_WIDTH + 1,
+            chunks[0].x + art_width + 1,
             text_y,
-            chunks[0].width.saturating_sub(ART_WIDTH + 1),
+            chunks[0].width.saturating_sub(art_width + 1),
             text_height,
         )
     };
@@ -126,9 +110,9 @@ pub fn render(frame: &mut Frame, app: &mut App) {
     if transport_height > TRANSPORT_HEIGHT_DEFAULT {
         let spectrum_height = transport_height - TRANSPORT_HEIGHT_DEFAULT;
         let spectrum_area = Rect::new(
-            chunks[0].x + ART_WIDTH + 1,
+            chunks[0].x + art_width + 1,
             chunks[0].y,
-            chunks[0].width.saturating_sub(ART_WIDTH + 1),
+            chunks[0].width.saturating_sub(art_width + 1),
             spectrum_height,
         );
         let spectrum = SpectrumWidget::new(&app.visualizer, &app.theme);


### PR DESCRIPTION
## v0.18.1

### Fixed
- CoreAudio crash during sample rate switch — render callback drain (#89)
- Session restore triggers downloads for pending items (#94)
- GraphQL port AddrInUse panic → graceful fallback (#95)
- TUI art placeholder prevents layout jank (#96)
- Path traversal in organize (#99)
- RT safety: try_lock in CPAL callback (#99)
- O(N) LRU query, sequential scanner lookups, memory on playlist build (#99)
- Square album art, configurable via playback.art_size (#107)
- Dead log_messages field removed (#102)

### Added
- Cache management with LRU eviction (#88)
- figment layered config: defaults → config.toml → config.local.toml → KOAN_* env vars (#106)
- Config docs (#108)
- API concurrency limit (#99)
- Composite index on tracks (#99)
- just install-dev / watch-dev tasks

**Tag v0.18.1 after merge.**