### PR TITLE
docs: comprehensive documentation rewrite — slim README, add guides and references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.18.2 (2026-03-28)
+
+### Changed
+
+- **Documentation rewrite** — slimmed README from 740 lines to a focused hook + install + quickstart + feature list + doc links. All detailed content moved to dedicated guides and references under `docs/`:
+  - `docs/getting-started.md` — progressive first-time setup tutorial
+  - `docs/guide/` — radio mode, remote servers, file organization, GraphQL API, MCP integration, headless server
+  - `docs/reference/` — configuration (all fields including previously undocumented `ticker_fps`, `target_fps`, `show_fps`, `art_size`, `output_device`), keybindings (every key in every mode), CLI reference
+  - `docs/recipes/` — troubleshooting, cache management
+
 ## v0.18.1 (2026-03-28)
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,17 +1,14 @@
-# kōan
+# koan
 
 A music player for people who give a shit about audio quality.
 
 <img width="874" height="942" alt="Screenshot 2026-03-04 at 18 30 07" src="https://github.com/user-attachments/assets/99782de3-5683-4dd9-97b6-10782e8e4099" />
 
-
 Pure Rust, Ratatui TUI. Bit-perfect playback, gapless transitions, fast library indexing, Subsonic/Navidrome integration, fb2k-style format strings. No Electron. No subscriptions. No bullshit.
 
 <img width="406" height="182" alt="Screenshot 2026-03-04 at 18 30 32" src="https://github.com/user-attachments/assets/d4fff1f7-7c1f-4aaa-87aa-41bd2b9c22f7" />
 
-## Getting started
-
-### Install
+## Install
 
 ```bash
 # homebrew (recommended)
@@ -41,85 +38,57 @@ sudo dnf install alsa-lib-devel dbus-devel
 sudo pacman -S alsa-lib dbus
 ```
 
-### Set up your music
+## 30-second quickstart
 
 ```bash
-# Create config directory with sensible defaults
-koan init
+koan init                                   # create config dir
+# edit ~/.config/koan/config.local.toml:
+#   [library]
+#   folders = ["/path/to/your/music"]
+koan scan                                   # index your library
+koan                                        # launch the TUI
 ```
 
-This creates `~/.config/koan/` with two config files. kōan needs at least one music source — local files, a remote server, or both.
+`space` to pause, `<`/`>` to skip, `p` to pick tracks, `a` for albums, `q` to quit. That's it.
 
-**Local files** — point kōan at your music directory:
-
-```toml
-# ~/.config/koan/config.local.toml
-[library]
-folders = ["/Volumes/Music/library"]
-```
-
-Then scan:
-
-```bash
-koan scan
-```
-
-Indexing runs in parallel — fast even for large collections.
-
-**Remote server (Navidrome/Subsonic):**
-
-If you run Navidrome, Subsonic, or anything with a Subsonic-compatible API:
+**Remote server?** If you run Navidrome or Subsonic:
 
 ```bash
 koan remote login https://music.example.com admin
 koan remote sync
-```
-
-Remote and local tracks merge seamlessly into one library — if the same track exists in both sources (matched by artist + album + title + track number), it becomes a single entry. Local files always take playback priority; remote is only used as a fallback if the local file is missing. Remote-only tracks download on first play and cache locally — subsequent plays are instant.
-
-Syncs are **incremental by default** — after the first full sync, subsequent runs only fetch albums added since the last sync. Use `--full` to force a complete re-sync. If a local drive is unplugged, tracks with remote backing are demoted to remote-only (streaming fallback) instead of deleted; when the drive comes back, the next scan re-merges them automatically.
-
-You can use both sources together. Run `koan remote sync` periodically (or after adding music to your server) to pull new tracks.
-
-### Play something
-
-```bash
-# Open the TUI (+ GraphQL API on port 4000)
 koan
-
-# Play files/directories directly
-koan ~/Music/Aphex\ Twin/
-koan ~/Music/album/*.flac
-
-# Headless server (no TUI)
-koan --headless
 ```
 
-The TUI launches immediately — no waiting. If tracks need downloading (remote library), they appear in the queue with animated spinners while loading in the background.
+Local and remote tracks merge into one library. Local files take playback priority; remote tracks stream with progressive download.
 
-### The TUI
+## What it does
 
-kōan is built around a full-screen terminal interface. The transport bar shows what's playing with album art (halfblock rendering) and a real-time spectrum analyzer, the queue groups tracks by album, and a hint bar at the bottom shows available keys for the current mode.
-
-**The basics:** `space` to pause, `<`/`>` to skip tracks, `,`/`.` or arrow keys to seek. `p` opens a fuzzy track picker, `a` for albums, `r` for artists. `l` opens the library browser for tree-style browsing. `L` opens a lyrics panel. `i` shows track info with cover art. `q` to quit.
-
-**Building a queue:** Use the pickers (`p`/`a`/`r`) or library browser (`l`) to find music. `Enter` appends to the queue, `Ctrl+Enter` appends and starts playing, `Ctrl+R` replaces the entire queue. You can also drag files from Finder straight into the terminal.
-
-**Editing the queue:** Press `e` to enter edit mode. Select tracks with shift-arrows or ctrl-click, `d` to delete, `j`/`k` to reorder. `Ctrl+Z` undoes any queue change, `Ctrl+Y` or `Ctrl+Shift+Z` to redo. Everything is mouse-friendly too — click, drag, scroll wheel all work.
-
-**Your DAC matters:** kōan sends bit-perfect audio to CoreAudio with automatic sample rate switching. No resampling, no mixing — the bits that left the encoder are the bits that hit your DAC. Run `koan devices` to see your audio outputs.
-
----
-
-## How it compares
+- **Bit-perfect playback** -- CoreAudio AUHAL / ALSA via cpal, automatic sample rate switching, no resampling
+- **Gapless transitions** -- decode thread keeps the ring buffer alive across track boundaries
+- **Format support** -- FLAC, MP3, AAC, Vorbis, Opus, ALAC, WavPack, WAV/AIFF (via Symphonia)
+- **Full-screen TUI** -- transport bar with album art, album-grouped queue, fuzzy picker, library browser, track info modal, spectrum analyzer, lyrics panel, mouse support
+- **Subsonic/Navidrome** -- incremental sync, unified local+remote browsing, streaming playback, favourite sync
+- **Radio mode** -- infinite play using Subsonic similarity, cached artist relationships, and genre matching
+- **ReplayGain** -- track and album modes with peak limiting and configurable pre-amp
+- **Format strings** -- fb2k-compatible `%field%`, `[conditionals]`, `$functions()` for display and file organization
+- **File organization** -- rename/reorganize your library from inside the TUI using format string patterns
+- **GraphQL API** -- full programmatic control alongside the TUI, or headless. Relay pagination, rich filters, mutations for everything
+- **MCP server** -- `koan --mcp` exposes the player to Claude Desktop via Model Context Protocol
+- **Queue management** -- undo/redo (100-deep), multi-select, drag-reorder, Finder drag & drop, session persistence
+- **SQLite FTS5 search** -- full-text search across your entire library
+- **Media keys** -- macOS Control Center integration (play/pause, next/prev, now playing info)
+- **Lyrics** -- synced (LRC) and plain lyrics from LRCLIB, current line highlighting
+- **Spectrum analyzer** -- 48-band FFT on a dedicated thread, configurable frequency/amplitude scales
 
 <img width="815" height="598" alt="Screenshot 2026-03-04 at 18 30 43" src="https://github.com/user-attachments/assets/9dab1d13-5d48-4e60-8625-7d72dd2e7957" />
+
+## How it compares
 
 No TUI player combines bit-perfect audio, Subsonic streaming, album art, fb2k-style format strings, and file organization in one binary. Most either need a daemon, lack remote support, or skip the audiophile bits.
 
 ### TUI / terminal players
 
-| | kōan | ncmpcpp | cmus | musikcube | termusic | rmpc | stmp |
+| | koan | ncmpcpp | cmus | musikcube | termusic | rmpc | stmp |
 |---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
 | **Language** | Rust | C++ | C | C++ | Rust | Rust | Go |
 | **Standalone** | **Yes** | No (MPD) | Yes | Yes | Yes | No (MPD) | No (Subsonic) |
@@ -127,31 +96,29 @@ No TUI player combines bit-perfect audio, Subsonic streaming, album art, fb2k-st
 | **Gapless** | **Yes** | Yes | Yes | Yes | Yes | Yes | No |
 | **Subsonic/Navidrome** | **Yes** | No | No | No | No | No | **Yes** |
 | **Local library** | **Yes** | Via MPD | Yes | Yes | Yes | Via MPD | No |
-| **Local + remote unified** | **Yes** | — | — | — | — | — | — |
-| **Album art** | **Halfblock** | Kitty¹ | No | No | Kitty/Sixel | Kitty/Sixel | No |
+| **Local + remote unified** | **Yes** | -- | -- | -- | -- | -- | -- |
+| **Album art** | **Halfblock** | Kitty | No | No | Kitty/Sixel | Kitty/Sixel | No |
 | **ReplayGain** | **Yes** | Via MPD | Yes | Yes | No | Via MPD | No |
 | **fb2k format strings** | **55+ functions** | Column fmt | Basic | No | No | Basic | No |
 | **File organization** | **Yes** | No | No | No | No | No | No |
 | **FTS search** | **SQLite FTS5** | MPD search | Filter | Text | Filter | MPD search | Basic |
 | **Queue undo/redo** | **100-deep** | No | No | No | No | No | No |
-| **Mouse support** | **Full** | Yes | Yes² | Basic | Yes | Yes | No |
-| **Media keys** | **macOS CC** | Via MPRIS | Via MPRIS | — | Via MPRIS | Via MPRIS | — |
-| **Drag & drop** | **Finder → TUI** | No | No | No | No | No | No |
+| **Mouse support** | **Full** | Yes | Yes | Basic | Yes | Yes | No |
+| **Media keys** | **macOS CC** | Via MPRIS | Via MPRIS | -- | Via MPRIS | Via MPRIS | -- |
+| **Drag & drop** | **Finder -> TUI** | No | No | No | No | No | No |
 | **Lyrics** | **Synced + plain** | Via MPD | No | Plugin | No | Via MPD | No |
 | **Spectrum analyzer** | **48-band FFT** | No | No | No | No | No | No |
 | **Favourites** | **Yes (syncs)** | Via MPD | No | Yes | No | Via MPD | **Yes** |
 | **Streaming playback** | **Yes (256KB)** | Via MPD | No | No | No | Via MPD | **Yes** |
 | **API / MCP** | **GraphQL + MCP** | MPD protocol | No | No | No | MPD protocol | No |
-| **Tag editing** | Soon³ | Via MPD | No | Yes | Yes | Via MPD | No |
-| **DSP / EQ** | Soon³ | Via MPD | Yes | Yes | No | Via MPD | No |
-| **Platforms** | macOS³ | Linux/macOS | Linux/macOS/BSD | Linux/macOS/Win | Linux/macOS/Win | Linux/macOS | Linux/macOS |
+| **Tag editing** | Soon | Via MPD | No | Yes | Yes | Via MPD | No |
+| **DSP / EQ** | Soon | Via MPD | Yes | Yes | No | Via MPD | No |
+| **Platforms** | macOS | Linux/macOS | Linux/macOS/BSD | Linux/macOS/Win | Linux/macOS/Win | Linux/macOS | Linux/macOS |
 | **Maintained** | Yes | Yes | Yes (2.12.0) | Slowing | Yes | Very active | Stale |
-
-¹ PR pending, not merged. ² Added in 2.12.0. ³ Planned — see [roadmap](/.claude/plans/).
 
 ### Desktop players (GUI)
 
-| | kōan | foobar2000 | Strawberry | DeaDBeeF |
+| | koan | foobar2000 | Strawberry | DeaDBeeF |
 |---|:---:|:---:|:---:|:---:|
 | **Type** | TUI | GUI | GUI (Qt) | GUI (GTK) |
 | **Bit-perfect** | **Yes** | Yes (WASAPI/ASIO) | Yes (Linux) | Yes (ALSA) |
@@ -165,567 +132,42 @@ No TUI player combines bit-perfect audio, Subsonic streaming, album art, fb2k-st
 | **Spectrum analyzer** | **48-band FFT** | Plugin | No | Plugin |
 | **Tag editing** | Soon | **Yes** | Yes | **Yes** |
 | **DSP / EQ** | Soon | **Yes (VST)** | Yes | Yes |
-| **Platforms** | macOS¹ | Windows/macOS | All | All |
-
-¹ Linux planned — see [roadmap](/.claude/plans/).
-
-### The gap kōan fills
-
-- **Only standalone TUI with Subsonic + bit-perfect.** stmp does Subsonic but has no gapless, no art, no local library. MPD clients need a separate daemon.
-- **Only TUI with fb2k-compatible format strings.** ncmpcpp has column formatting, but nothing close to `$if($stricmp(%album artist%,Various Artists),...)`.
-- **Only TUI with file organization.** No other terminal player can rename/reorganize your library from inside the player.
-- **Only TUI with queue undo/redo.** 100-deep stack. DeaDBeeF added this in v1.10.0 (2025) — no TUI has it.
-- **Only TUI with Finder drag & drop.** Drop files from macOS Finder directly into the terminal to enqueue.
-- **Only standalone TUI with synced lyrics.** Auto-fetches synced (LRC) or plain lyrics from LRCLIB — no API key needed. Current line highlights and scrolls with playback.
-- **Only TUI with a real-time spectrum analyzer.** 48-band FFT on a dedicated thread, A-weighted amplitude, peak hold markers — runs at 60fps without blocking the UI.
-- **Only TUI with a GraphQL API.** Full programmatic control with rich metadata filtering, nested queries, and named queue snapshots. MPD has a protocol; kōan has a modern API.
-
-### Coming soon
-
-- **Linux support** — ALSA/PipeWire backends via trait-based audio abstraction ([plan](/.claude/plans/01-linux-and-audio-backends.md))
-- **DSP pipeline** — EQ, headphone correction profiles, crossfeed ([plan](/.claude/plans/02-dsp-and-profiles.md))
-- **Tag editing** — inline editing, bulk operations, vimv-style external editor, MusicBrainz lookups ([plan](/.claude/plans/04-tagging.md))
-- **Artist metadata** — artist bios, images, similar artists, discography from MusicBrainz/Last.fm ([plan](/.claude/plans/09-artist-metadata.md))
+| **Platforms** | macOS | Windows/macOS | All | All |
 
 <img width="768" height="612" alt="Screenshot 2026-03-04 at 18 31 01" src="https://github.com/user-attachments/assets/0ad4879e-815f-42f3-8ebe-f6d01616bc96" />
 
----
+## Documentation
 
-## What works
-
-- **Bit-perfect playback** — CoreAudio AUHAL, no resampling, automatic device sample rate switching
-- **Gapless** — decode thread keeps the ring buffer alive across track boundaries, AudioUnit never stops
-- **Format support** — FLAC, MP3, AAC, Vorbis, Opus, ALAC, WavPack, WAV/AIFF (via Symphonia)
-- **Ratatui TUI** — full-screen terminal UI with transport bar, album-grouped queue, fuzzy picker overlay, library browser, track info modal with embedded album art (halfblock rendering), real-time spectrum analyzer, scrollbar, mouse support (click-to-seek, click-to-play, drag-to-reorder, scrollbar drag, scroll wheel)
-- **Spectrum visualizer** — 80s hi-fi LED-segment spectrum analyzer rendered in the transport area. 48-band FFT on a dedicated analysis thread (never blocks the UI), configurable frequency scale (Bark/Mel/Log/Linear), sub-cell resolution using Unicode block characters, amplitude-based coloring (green/yellow/red near clipping), peak hold markers, and smooth exponential decay. Configurable via `[visualizer]` in config
-- **Media keys** — macOS Control Center integration via souvlaki (play/pause, next/prev, seek, now playing info with album art)
-- **Library indexing** — parallel metadata scanning with rayon, SQLite FTS5 full-text search
-- **Radio mode** — press `R` to toggle infinite play. Automatically queues similar tracks using Subsonic getSimilarSongs2, cached similar-artist relationships, and local genre/artist matching. Configurable via `[radio]` in config
-- **ReplayGain** — track and album modes with peak limiting. Reads ReplayGain tags via lofty at decode time, applies gain with a configurable pre-amp. Zero overhead when disabled
-- **Streaming playback** — remote tracks start playing after just 256KB is buffered instead of waiting for the full download. The seek bar dims the not-yet-downloaded portion and prevents seeking past it. Duration always shows the full track length. When the download finishes, full metadata and cover art are re-read
-- **Favourites** — press `f` to star/unstar tracks (persisted to SQLite). Favourites sync bidirectionally with Navidrome — starring in kōan stars on the server and vice versa
-- **Subsonic/Navidrome** — incremental remote library sync (only fetches new albums after first full sync), unified local+remote browsing, streaming playback with progressive download. Resilient deduplication — unplugging a local drive demotes tracks to remote-only streaming instead of deleting them; re-scanning re-merges automatically
-- **Format string engine** — fb2k-compatible `%field%`, `[conditionals]`, `$functions()` for library views and file organization
-- **File organization** — in-TUI organize modal: select tracks → context menu → pick a named pattern → preview moves → execute. Playlist paths update live, playback continues uninterrupted
-- **Queue management** — playlist-style display (played tracks stay visible dimmed), album-grouped headers, edit mode with Finder-style multi-selection (shift/option-click, shift-arrows), reorder/delete, multi-drag, undo/redo (Ctrl+Z/Y, 100-deep stack covering all playlist operations). Mouse editing (select, drag-reorder) works in any mode; double-click to skip to any track (forward or backward). Drag/drop files from Finder into the terminal to add them to the queue. Queue and playback position persist across sessions — reopen koan to pick up where you left off (`--clear` to start fresh)
-- **Track deduplication** — 3-strategy match (path → remote ID → content) merges local and remote into one DB row. No duplicates in search or browse. Playback priority: local file → cached download → remote stream
-- **Lyrics** — toggle a lyrics side panel with `L`. Fetches synced (LRC) or plain lyrics automatically; synced lyrics highlight the current line and scroll with playback. Lyrics are cached in the database per track
-- **Proper artist handling** — track artist stored separately from album artist; compilations/VA albums display correctly
-- **GraphQL API** — always-on alongside the TUI (or `koan --headless` for API-only). Full Relay-style cursor pagination, rich metadata filters (year range, codec, genre, sample rate, bit depth, duration), nested queries (artists→albums→tracks), mutations for all playback/queue/device/favourite control, named queue snapshots, radio mode control. Optional GraphiQL at `/graphql`. Daemon mode (`-d`) for background operation
-- **MCP server** — `koan --mcp` exposes the player as an MCP server on stdio for Claude Desktop. 2 tools: `schema_sdl` + `graphql`. Claude reads the schema, drives everything through one tool
+| Guide | What it covers |
+|-------|---------------|
+| **[Getting Started](docs/getting-started.md)** | First-time setup, local and remote libraries, your first session |
+| **[Radio Mode](docs/guide/radio-mode.md)** | Infinite play, similarity scoring, tuning discovery |
+| **[Remote Servers](docs/guide/remote-servers.md)** | Navidrome/Subsonic setup, sync, streaming, cache management |
+| **[File Organization](docs/guide/file-organization.md)** | Rename and reorganize your library from the TUI |
+| **[GraphQL API](docs/guide/graphql-api.md)** | Headless operation, queries, mutations, daemon mode |
+| **[MCP Integration](docs/guide/mcp-integration.md)** | Claude Desktop setup, example prompts |
+| **[Headless Server](docs/guide/headless-server.md)** | Running koan as a background music server |
+| **[Configuration](docs/reference/configuration.md)** | All config fields, layered config, env var overrides |
+| **[Keybindings](docs/reference/keybindings.md)** | Every key in every mode |
+| **[CLI Reference](docs/reference/cli.md)** | All commands, flags, and shell completions |
+| **[Format Strings](docs/format-strings.md)** | fb2k-compatible template syntax and all 55+ functions |
+| **[Troubleshooting](docs/recipes/troubleshooting.md)** | Common issues and fixes |
+| **[Cache Management](docs/recipes/cache-management.md)** | Download cache, eviction, disk usage |
 
 ## Architecture
 
 ```
-Pure Rust.
-
-File → Symphonia → f32 samples → rtrb ring buffer → CoreAudio render callback → DAC
-
-Lock-free audio thread. See ARCHITECTURE.md for the full technical manual.
+File -> Symphonia -> f32 samples -> rtrb ring buffer -> CoreAudio/cpal callback -> DAC
 ```
 
-Two crates:
+Two crates: `koan-core` (audio engine, player, database, indexer) and `koan-music` (`koan` binary, TUI). See [ARCHITECTURE.md](ARCHITECTURE.md) for the full technical manual.
 
-- `koan-core` — audio engine, player, database, indexer, format strings, file organization, remote client
-- `koan-music` — `koan` binary (Ratatui TUI)
+## Coming soon
 
-## Shell completions
-
-Dynamic completions that know your library — artist/album IDs tab-complete from the DB.
-
-```bash
-# zsh (add to .zshrc)
-source <(COMPLETE=zsh koan)
-
-# bash
-source <(COMPLETE=bash koan)
-
-# fish
-COMPLETE=fish koan | source
-```
-
-Then `koan --album <TAB>` shows your actual albums with artist names.
-
-## CLI reference
-
-```bash
-# setup
-koan init                     # create config directory with defaults
-koan scan                     # scan configured library folders
-koan scan --analyze           # scan + acoustic analysis in one pass
-
-# play (all top-level — `koan` IS play)
-koan                          # TUI + GraphQL API on :4000
-koan --library                # TUI in library browse mode
-koan ~/Music/album/           # play a directory (recursive)
-koan ~/Music/*.flac           # play specific files
-koan --album 5                # play album by ID (use tab completion)
-koan --artist 3               # play artist by ID
-koan --no-api                 # TUI only (no GraphQL server)
-koan --clear                  # clear persisted queue
-
-# server (binds to 127.0.0.1 by default)
-koan --headless                     # GraphQL API on 127.0.0.1:4000, no TUI
-koan --headless --playground        # with GraphiQL web IDE
-koan --headless --subsonic 4040     # + Subsonic REST on port 4040
-koan --port 8080                    # custom GraphQL port
-koan --bind 0.0.0.0                 # listen on all interfaces (⚠️ no auth)
-koan -d                             # background daemon
-koan -d --subsonic 4040             # daemon with Subsonic
-
-# remote TUI
-koan --server http://host:4000      # TUI connected to remote koan
-koan --server http://host:4000 --jukebox  # remote control only
-
-# search & info
-koan search "radiohead"       # text search (CLI output)
-koan library                  # library statistics
-
-# remote server
-koan remote login URL user    # authenticate with Subsonic/Navidrome server
-koan remote sync              # incremental sync (only new albums since last sync)
-koan remote sync --full       # full re-sync of entire remote library
-koan remote status            # show remote server info
-
-# utilities
-koan config                   # show resolved config from both layers
-koan devices                  # list audio output devices
-koan cache status             # show download cache size
-koan cache clear              # clear cached remote downloads
-koan probe track.flac         # show format/codec info for a file
-
-# mcp
-koan --mcp                    # MCP server on stdio (Claude Desktop)
-```
-
-### MCP server (Claude Desktop integration)
-
-`koan --mcp` runs koan as a headless player controllable by Claude Desktop (or any MCP client). No TUI, no terminal — just the audio engine and 2 tools (schema_sdl + graphql) exposed over the Model Context Protocol. The LLM reads the schema, drives everything through GraphQL.
-
-**Setup:**
-
-1. Make sure `koan` is on your PATH (or note the full path from `which koan`)
-
-2. Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
-
-```json
-{
-  "mcpServers": {
-    "koan": {
-      "command": "koan",
-      "args": ["--mcp"]
-    }
-  }
-}
-```
-
-If koan isn't on Claude Desktop's PATH (common with Homebrew or mise), use the full path:
-
-```json
-{
-  "mcpServers": {
-    "koan": {
-      "command": "/opt/homebrew/bin/koan",
-      "args": ["--mcp"]
-    }
-  }
-}
-```
-
-3. Restart Claude Desktop. You should see koan in the MCP server list (🔌 icon).
-
-4. Make sure you've run `koan scan` at least once so your library is indexed.
-
-**What you can ask Claude:**
-
-- "Play me some ambient music"
-- "What albums do I have by Aphex Twin?"
-- "Queue up Tri Repetae but skip the interludes"
-- "Pause" / "Skip this" / "What's playing?"
-- "Play something like what's on now but more upbeat"
-- "Search my library for anything with 'rain' in the title"
-- "Switch audio output to my DAC"
-- "Save this queue as 'techno friday'" / "Restore my chill mix"
-- "Turn on radio mode" / "Star this track"
-
-### GraphQL API
-
-The GraphQL API runs alongside the TUI by default (port 4000, bound to localhost). For headless operation, use `koan --headless`. Full programmatic control — everything the TUI can do, minus the visualizer. The server binds to `127.0.0.1` by default — use `--bind 0.0.0.0` or `bind = "0.0.0.0"` in `[graphql]` config to expose on all interfaces (not recommended without auth).
-
-```bash
-# Headless server with GraphiQL IDE
-koan --headless --playground
-
-# Or as a daemon (for Claude Code / scripts)
-koan -d --playground
-```
-
-Then query at `http://localhost:4000/graphql`:
-
-```graphql
-# Find early FLAC albums
-{ albums(yearEnd: 1995, codec: "FLAC") { edges { node { title, artistName, date } } } }
-
-# Hi-res techno tracks
-{ tracks(genre: "techno", minSampleRate: 96000, minBitDepth: 24) { edges { node { title, artist, codec, sampleRate } } } }
-
-# Nested: artist → albums → tracks in one query
-{ artists(search: "Aphex") { edges { node { name, albums { edges { node { title, tracks { edges { node { title } } } } } } } } } }
-
-# What's playing?
-{ nowPlaying { state, positionMs, track { title, artist, codec, sampleRate, bitDepth } } }
-
-# Queue management
-mutation { replaceQueue(trackIds: [42, 43, 44]) { ok, addedCount } }
-mutation { saveSnapshot(name: "techno friday") { ok } }
-mutation { enableRadio { ok } }
-```
-
-Every query supports rich filtering — albums by year/codec/label/genre, tracks by genre/codec/sample rate/bit depth/duration, artists by genre. All string filters are case-insensitive substrings. The MCP server's `graphql` tool uses the same schema in-process (no HTTP round-trip)
-
-**Available tools:**
-
-| Category | Tools |
-|----------|-------|
-| Playback | `play`, `pause`, `resume`, `stop`, `next`, `previous`, `seek` |
-| Queue | `add_to_queue`, `insert_in_queue`, `remove_from_queue`, `clear_queue`, `replace_queue`, `get_queue`, `reorder_queue` |
-| Library | `search`, `list_artists`, `list_albums`, `list_tracks`, `get_track`, `library_stats` |
-| State | `now_playing`, `list_devices`, `set_device` |
-| Favourites | `favourite`, `unfavourite`, `list_favourites` |
-
-The LLM can chain these together for complex operations — "find all my 90s electronic albums, pick one at random, and queue it up" becomes a search → filter → add_to_queue → play sequence that Claude handles naturally.
-
-### Playback TUI
-
-During playback, a full-screen Ratatui TUI shows the transport bar, queue, and key hints. The queue never goes blank during downloads — pending tracks appear immediately with animated spinners.
-
-| Key     | Action                 |
-| ------- | ---------------------- |
-| `space` | pause / resume         |
-| `< >`   | previous / next track  |
-| `, .`   | seek ±10s              |
-| `←` `→` | seek ±10s              |
-| `/`     | search queue (jump to track) |
-| `p`     | pick tracks            |
-| `a`     | pick album             |
-| `r`     | pick artist            |
-| `i`     | track info             |
-| `z`     | zoom album art         |
-| `f`     | favourite / unfavourite |
-| `Ctrl+Z` | undo last queue change |
-| `Ctrl+Y` / `Ctrl+Shift+Z` | redo last undone change |
-| `l`     | library browser        |
-| `L`     | lyrics panel           |
-| `f`     | filter library (in library mode) |
-| `e`     | edit queue             |
-| `g`     | jump to start          |
-| `G`     | jump to end            |
-| `PgUp` / `Ctrl+U` | page up     |
-| `PgDn` / `Ctrl+D` | page down   |
-| `q`     | quit                   |
-
-**Drag/drop:** Drag files or folders from Finder into the terminal window to add them to the queue.
-
-**Picker confirm actions** (track/album/artist picker):
-
-| Key          | Action                                 |
-| ------------ | -------------------------------------- |
-| `Enter`      | Append to queue (don't start playing)  |
-| `Ctrl+Enter` | Append and play first added track      |
-| `Ctrl+R`     | Replace entire queue and play          |
-
-**Mouse** (works in any mode — modality is keyboard-only): double-click a queue track to skip to it (forward or backward); double-click a downloading track to prioritize and play it as soon as it finishes. Click the seek bar to jump, scroll wheel in queue. Single-click selects, drag to reorder. Ctrl-click for range selection, Option-click to toggle individual tracks, drag selected group to move all together. Scrollbar is clickable and draggable. In the fuzzy picker, click items to select, double-click to confirm, click outside to dismiss. In the library browser, click to select, double-click to expand/enter/enqueue; click queue pane to switch focus.
-
-**Queue edit mode** (`e`):
-
-| Key           | Action                   |
-| ------------- | ------------------------ |
-| `↑` `↓`       | navigate                 |
-| `Shift+↑` `↓` | extend selection         |
-| `d`           | remove selected track(s) |
-| `j` / `k`     | move selected down/up    |
-| `Ctrl+Z` / `Ctrl+Y` | undo / redo      |
-| `Space`        | context menu (organize)  |
-| `g`           | jump to start            |
-| `G`           | jump to end (shift-extends) |
-| `PgUp` / `PgDn` | page up/down           |
-| `⌥-click`     | toggle select            |
-| `Ctrl-click`  | range select             |
-| `Esc`         | exit edit mode           |
-
-### Queue display
-
-Tracks are grouped by album with headers showing album artist, year, album title, and codec. Track artist is shown inline only when it differs from the album artist (compilations, VA albums). Downloading tracks show progress percentage, waiting tracks show braille spinners. Double-clicked priority tracks show `>` with progress.
-
-```
- Limewax — (2007) Therapy Session 4 [FLAC]
-   > 01 Agent Orange                              4:56
-     02 Pigeons and Marshmellows feat. The Panacea 2:53
-     03 SPL — Fade                                 1:52
-     04 Icicle                                     2:27
-```
-
-### File organization
-
-Rename and reorganize your music library using fb2k-compatible format strings, directly from the TUI.
-
-Select tracks in edit mode (`e`) → `Space` to open the context menu → Organize → pick a named pattern from your config → preview the file moves → execute. Playlist paths update automatically, playback continues uninterrupted (Unix rename preserves open file descriptors). Ancillary files (cover.jpg, .cue, .log) move with the music. Empty directories are cleaned up.
-
-Files are organized into the **first configured library folder** (from `[library] folders` in your config). If you have multiple library folders, the first one is always the destination. The format pattern generates the relative path within that folder — e.g. with the `standard` pattern, a track becomes `<library>/Artist/(Year) Album/01. Title.flac`.
-
-Define organize patterns in your config — see [Configuration](#configuration) below and [docs/format-strings.md](docs/format-strings.md) for the full syntax reference.
-
-## Configuration
-
-kōan uses [figment](https://docs.rs/figment) for layered configuration. Four sources are merged in order — each layer overrides the one before it:
-
-```
-Defaults → config.toml → config.local.toml → KOAN_* env vars
-(lowest)                                      (highest priority)
-```
-
-| Layer | Path | Purpose |
-|-------|------|---------|
-| Defaults | (built-in) | Hardcoded sane defaults for every field |
-| `config.toml` | `~/.config/koan/config.toml` | Shareable base config — safe to commit to dotfiles |
-| `config.local.toml` | `~/.config/koan/config.local.toml` | Machine-specific paths, credentials (gitignored) |
-| Environment | `KOAN_*` vars | 12-factor overrides — highest priority, ideal for Docker/CI |
-
-Run `koan config` to see all layers and the fully resolved result (including which `KOAN_*` env vars are active).
-
-### Environment variable overrides
-
-Any config field can be overridden via environment variables using `KOAN_` prefix with `__` (double underscore) as the section separator:
-
-```
-KOAN_<SECTION>__<FIELD>=<value>
-```
-
-Examples:
-
-```bash
-# Remote server password (avoids writing secrets to files)
-export KOAN_REMOTE__PASSWORD="hunter2"
-
-# Change GraphQL API port
-export KOAN_GRAPHQL__PORT=8080
-
-# Bind API to all interfaces
-export KOAN_GRAPHQL__BIND="0.0.0.0"
-
-# Override playback FPS
-export KOAN_PLAYBACK__TARGET_FPS=30
-
-# Enable the GraphiQL playground
-export KOAN_GRAPHQL__PLAYGROUND=true
-
-# Set ReplayGain mode
-export KOAN_PLAYBACK__REPLAYGAIN=track
-```
-
-Field names match the TOML key in SCREAMING_SNAKE_CASE. Nested sections use `__`:
-- `[remote] password` → `KOAN_REMOTE__PASSWORD`
-- `[graphql] subsonic_port` → `KOAN_GRAPHQL__SUBSONIC_PORT`
-- `[playback] pre_amp_db` → `KOAN_PLAYBACK__PRE_AMP_DB`
-
-### Docker / CI usage
-
-Env vars make kōan easy to configure in containers and CI without config files:
-
-```bash
-# Docker example — headless server with remote backend
-docker run -e KOAN_REMOTE__ENABLED=true \
-           -e KOAN_REMOTE__URL=https://music.example.com \
-           -e KOAN_REMOTE__USERNAME=admin \
-           -e KOAN_REMOTE__PASSWORD="$NAVIDROME_PASSWORD" \
-           -e KOAN_GRAPHQL__BIND=0.0.0.0 \
-           -e KOAN_GRAPHQL__PORT=4000 \
-           -p 4000:4000 \
-           koan --headless
-```
-
-```yaml
-# CI — run tests against a specific config
-env:
-  KOAN_REMOTE__URL: ${{ secrets.NAVIDROME_URL }}
-  KOAN_REMOTE__PASSWORD: ${{ secrets.NAVIDROME_PASSWORD }}
-  KOAN_GRAPHQL__PORT: 4001
-```
-
-### `koan init`
-
-Creates the config directory at `~/.config/koan/` with everything kōan needs to run:
-
-```bash
-koan init
-```
-
-What it creates:
-
-| File | Purpose |
-|------|---------|
-| `config.toml` | Base config with all defaults (new fields are merged in without overwriting your customizations) |
-| `config.local.toml` | Template for machine-specific settings (library folders, remote server) |
-| `.gitignore` | Ignores `*.log`, `*.db`, `config.local.toml`, `cache/` |
-| `koan.db` | SQLite database (created if missing) |
-| `cache/` | Download cache directory |
-
-Running `koan init` on an existing setup is safe — it merges new default fields into your `config.toml` without touching values you've already changed, and skips `config.local.toml` if it exists.
-
-`library.folders` is deliberately excluded from `config.toml` (it's machine-specific and belongs in `config.local.toml`). This means you can commit `~/.config/koan/` to your dotfiles repo and share playback/visualizer/organize settings across machines while keeping library paths and credentials local.
-
-### Playback
-
-```toml
-# config.toml
-[playback]
-software_volume = false   # volume control in software (vs hardware/DAC) — not yet wired in
-replaygain = "album"      # off | track | album — applies gain from ReplayGain tags with peak limiting
-pre_amp_db = 0.0          # pre-amp gain in dB applied on top of ReplayGain (default: 0.0)
-```
-
-ReplayGain normalizes volume levels across tracks so you don't reach for the volume knob between a whisper-quiet jazz track and a wall-of-sound metal album. kōan reads standard ReplayGain tags (embedded by tools like `loudgain`, `r128gain`, foobar2000, etc.) at decode time and applies gain with peak limiting to prevent clipping.
-
-| Mode | Description |
-|------|-------------|
-| `off` | No gain adjustment. Original signal untouched. |
-| `track` | Per-track normalization. Every track plays at the same perceived loudness. Best for shuffled playlists. |
-| `album` | Per-album normalization. Preserves the dynamic range and intentional volume differences within an album (quiet intros, loud climaxes) while normalizing between albums. **(recommended)** |
-
-`pre_amp_db` adds a fixed gain on top of the ReplayGain adjustment. Positive values make everything louder (risk of clipping on hot tracks), negative values quieter. Useful if your ReplayGain-tagged library feels too quiet at the target level.
-
-### Library
-
-```toml
-# config.local.toml
-[library]
-folders = ["/Volumes/Music/library"]
-```
-
-### Remote server
-
-```toml
-# config.local.toml
-[remote]
-enabled = true
-url = "https://music.example.com"
-username = "admin"
-```
-
-Password is prompted by `koan remote login` and saved to `config.local.toml` (gitignored).
-
-```toml
-# config.local.toml or config.toml
-[remote]
-transcode_quality = "original"   # original | opus-128 | mp3-320 (default: original)
-download_workers = 5             # parallel download threads (default: 5)
-cache_limit = "50GB"             # max cache size — LRU eviction on startup (default: unlimited)
-cache_dir = "/custom/path"       # explicit cache dir (default: ~/.config/koan/cache)
-```
-
-### Visualizer
-
-```toml
-# config.toml
-[visualizer]
-enabled = true                # show spectrum analyzer in transport area (default: true)
-fps = 60                      # analysis thread update rate in Hz (default: 60)
-scale = "bark"                # frequency scale (default: bark)
-amplitude_scale = "aweight"     # amplitude scale (default: aweight)
-bar_decay_ms = 50             # how fast bars drop — half-life in ms (default: 50)
-peak_decay_ms = 180           # how long peak markers linger — half-life in ms (default: 180)
-```
-
-The spectrum analyzer renders above the transport text when album art is present. 48-band FFT with sub-cell resolution using Unicode block characters (`▁▂▃▄▅▆▇█`), peak hold markers (`▔`), and smooth exponential decay. Bars are colored by signal level — green at safe headroom, yellow when getting hot, red only near clipping (0dBFS). FFT runs on a dedicated analysis thread so the 60fps UI is never blocked.
-
-**Frequency scales** (`scale`) — controls how FFT bins map to bars (the X axis):
-
-| Scale | Description |
-|-------|-------------|
-| `bark` | Bark psychoacoustic scale — 24 critical bands, matches how your ears group frequencies. Best for music. **(default)** |
-| `mel` | Mel perceptual pitch scale — similar to Bark, widely used in speech/music analysis |
-| `log` | Logarithmic — equal spacing per octave. Familiar if you read spectrograms |
-| `linear` | Linear — equal Hz per bar. Bass is cramped, treble dominates. Analytical use |
-
-**Amplitude scales** (`amplitude_scale`) — controls how magnitudes map to bar height (the Y axis):
-
-| Scale | Description |
-|-------|-------------|
-| `aweight` | A-weighted (IEC 61672). Bars reflect perceived loudness — bass and extreme treble are attenuated to match human hearing sensitivity (Fletcher-Munson). **(default)** |
-| `perceptual` | A-weighting + gentle gamma curve. Same frequency correction with a boost to quiet signals so more of the display stays active |
-| `sqrt` | Square root curve — gentle boost to quiet bands, no frequency correction |
-| `linear` | Raw dB-normalized magnitude. No correction. Quiet stuff barely visible, technically accurate |
-
-Set `enabled = false` to hide the visualizer entirely.
-
-### Organize patterns
-
-The TUI organize modal picks from named patterns defined in your config. Format strings use fb2k syntax — `%field%` for metadata, `$function()` for transforms, `[conditionals]` to omit blocks when fields are missing. See [docs/format-strings.md](docs/format-strings.md) for the full reference.
-
-```toml
-# config.toml
-[organize]
-default = "standard"      # which pattern the modal selects by default
-
-[organize.patterns]
-standard = "%album artist%/(%date%) %album%/%tracknumber%. %title%"
-va-aware = "%album artist%/$if($stricmp(%album artist%,Various Artists),,['('$left(%date%,4)')' ])%album% '['%codec%']'/[$num(%discnumber%,2)][%tracknumber%. ][%artist% - ]%title%"
-flat = "%artist% - %title%"
-```
-
-The `va-aware` pattern handles compilations: if the album artist is "Various Artists", it includes the per-track artist in the filename and omits the redundant year prefix. The `$stricmp`, `$if`, `$left`, `$num` functions work the same as in foobar2000.
-
-### GraphQL API
-
-```toml
-# config.toml
-[graphql]
-enabled = true                # run API alongside TUI (default: true, false = --no-api)
-port = 4000                   # API port (default: 4000)
-bind = "127.0.0.1"           # bind address (default: 127.0.0.1)
-playground = false            # enable GraphiQL IDE at GET /graphql (default: false)
-subsonic_port = 4040          # optional Subsonic REST API port (default: disabled)
-```
-
-Set `bind = "0.0.0.0"` to listen on all interfaces — there's no auth, so only do this on trusted networks.
-
-### Radio
-
-Radio mode (`R` in the TUI) queues similar tracks automatically. Scoring uses Subsonic getSimilarSongs2, cached artist relationships, and local genre/artist matching.
-
-```toml
-# config.toml
-[radio]
-lookahead = 5                 # tracks to keep queued ahead (default: 5)
-batch_size = 5                # tracks added per refill (default: 5)
-use_subsonic = true           # use Subsonic similarity when available (default: true)
-history_window = 200          # don't repeat last N tracks (default: 200)
-seed_window = 5               # recent tracks used as seed for similarity (default: 5)
-discovery_weight = 0.3        # 0.0 = familiar only, 1.0 = maximise discovery (default: 0.3)
-```
-
-### Discovery
-
-Acoustic analysis settings for radio mode's similarity scoring.
-
-```toml
-# config.toml
-[discovery]
-analysis_on_scan = false      # run acoustic analysis during library scan (default: false)
-acoustic_weight = 0.5         # weight of acoustic similarity in radio scoring 0.0..1.0 (default: 0.5)
-```
-
-Run `koan scan --analyze` to compute acoustic features for your library. Higher `acoustic_weight` gives radio mode more "sounds like" awareness vs. metadata-based matching.
-
-### All paths
-
-| File | Location |
-|------|----------|
-| Config (base) | `~/.config/koan/config.toml` |
-| Config (local) | `~/.config/koan/config.local.toml` |
-| Database | `~/.config/koan/koan.db` |
-| Download cache | `~/.config/koan/cache/` |
-| Log file | `~/.config/koan/koan.log` |
+- **Linux support** -- ALSA/PipeWire backends via trait-based audio abstraction ([plan](/.claude/plans/01-linux-and-audio-backends.md))
+- **DSP pipeline** -- EQ, headphone correction profiles, crossfeed ([plan](/.claude/plans/02-dsp-and-profiles.md))
+- **Tag editing** -- inline editing, bulk operations, vimv-style external editor ([plan](/.claude/plans/04-tagging.md))
+- **Artist metadata** -- bios, images, similar artists from MusicBrainz/Last.fm ([plan](/.claude/plans/09-artist-metadata.md))
 
 ## Dev
 
@@ -734,6 +176,8 @@ just check    # test + clippy
 just fmt      # cargo fmt
 just cli      # cargo run -p koan-music -- <args>
 ```
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 ## License
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,180 @@
+# Getting Started
+
+This guide walks you through installing koan, setting up your music library, and playing your first track.
+
+## Install
+
+### Homebrew (recommended)
+
+```bash
+brew install radiosilence/koan/koan
+```
+
+### mise
+
+```bash
+mise use -g github:radiosilence/koan@latest
+```
+
+### Cargo
+
+```bash
+cargo install koan-music
+```
+
+### Build from source
+
+```bash
+git clone https://github.com/radiosilence/koan.git && cd koan
+cargo install --path crates/koan-music
+```
+
+### Linux dependencies
+
+macOS works out of the box (CoreAudio). Linux needs ALSA and D-Bus dev headers:
+
+```bash
+# Debian/Ubuntu
+sudo apt install libasound2-dev libdbus-1-dev
+
+# Fedora
+sudo dnf install alsa-lib-devel dbus-devel
+
+# Arch
+sudo pacman -S alsa-lib dbus
+```
+
+## Create your config
+
+```bash
+koan init
+```
+
+This creates `~/.config/koan/` with:
+
+| File | Purpose |
+|------|---------|
+| `config.toml` | Base config with sane defaults -- safe to commit to dotfiles |
+| `config.local.toml` | Machine-specific settings (library paths, credentials) -- gitignored |
+| `.gitignore` | Ignores logs, database, local config, cache |
+| `koan.db` | SQLite database (created on first use) |
+| `cache/` | Download cache for remote tracks |
+
+Running `koan init` on an existing setup is safe -- it merges new default fields into `config.toml` without overwriting your customizations, and skips `config.local.toml` if it already exists.
+
+## Add your music
+
+koan needs at least one music source -- local files, a remote server, or both.
+
+### Option A: Local files
+
+Edit `~/.config/koan/config.local.toml`:
+
+```toml
+[library]
+folders = ["/path/to/your/music"]
+```
+
+Then scan your library:
+
+```bash
+koan scan
+```
+
+Scanning runs in parallel -- fast even for large collections (tens of thousands of tracks). koan reads metadata from FLAC, MP3, AAC, Vorbis, Opus, ALAC, WavPack, WAV, and AIFF files.
+
+### Option B: Remote server (Navidrome/Subsonic)
+
+If you run [Navidrome](https://www.navidrome.org/), Subsonic, or anything with a Subsonic-compatible API:
+
+```bash
+koan remote login https://music.example.com admin
+koan remote sync
+```
+
+The first sync fetches your entire library. Subsequent syncs are **incremental** -- only new albums since the last sync. Use `--full` to force a complete re-sync.
+
+See [Remote Servers](guide/remote-servers.md) for the full setup guide.
+
+### Option C: Both
+
+Use both together. Local and remote tracks merge seamlessly -- if the same track exists in both sources (matched by artist + album + title + track number), it becomes a single entry. Local files always take playback priority; remote tracks stream on demand and cache locally.
+
+Run `koan remote sync` periodically (or after adding music to your server) to pull new tracks.
+
+## Play something
+
+```bash
+# Launch the TUI
+koan
+
+# Play files or directories directly
+koan ~/Music/Aphex\ Twin/
+koan ~/Music/album/*.flac
+
+# Play by album or artist ID (use tab completion)
+koan --album 5
+koan --artist 3
+```
+
+The TUI launches immediately. If tracks need downloading (remote library), they appear in the queue with animated spinners while loading in the background.
+
+## Your first session
+
+The TUI has three areas: a **transport bar** at the top (album art, track info, seek bar, spectrum analyzer), a **content area** in the middle (queue, library, or picker), and a **hint bar** at the bottom showing available keys.
+
+### Finding music
+
+| Key | What it opens |
+|-----|--------------|
+| `p` | Track picker -- fuzzy search across all tracks |
+| `a` | Album picker -- fuzzy search by album name |
+| `r` | Artist picker -- fuzzy search by artist |
+| `l` | Library browser -- tree view (artist -> album -> track) |
+
+Type to filter. In any picker, press `Enter` to add to queue, `Ctrl+Enter` to add and start playing, or `Ctrl+R` to replace the entire queue.
+
+### Controlling playback
+
+| Key | Action |
+|-----|--------|
+| `space` | Pause / resume |
+| `<` `>` | Previous / next track |
+| `,` `.` or `<-` `->` | Seek +/-10 seconds |
+| `i` | Track info (codec, sample rate, bit depth, cover art) |
+| `L` | Toggle lyrics panel |
+| `f` | Favourite / unfavourite |
+| `R` | Toggle radio mode (infinite play) |
+
+### Managing the queue
+
+Press `e` to enter edit mode. Select tracks with shift-arrows, `d` to delete, `j`/`k` to reorder. `Ctrl+Z` undoes any queue change (100-deep stack). `Esc` to exit edit mode.
+
+Mouse works everywhere too -- click, drag, scroll wheel. Double-click a track to jump to it.
+
+See [Keybindings](reference/keybindings.md) for the complete key reference.
+
+## Shell completions
+
+Dynamic completions that know your library -- artist/album IDs tab-complete from the database.
+
+```bash
+# zsh (add to .zshrc)
+source <(COMPLETE=zsh koan)
+
+# bash
+source <(COMPLETE=bash koan)
+
+# fish
+COMPLETE=fish koan | source
+```
+
+Then `koan --album <TAB>` shows your actual albums with artist names.
+
+## What's next?
+
+- **[Configuration](reference/configuration.md)** -- customize playback, visualizer, organize patterns, and more
+- **[Radio Mode](guide/radio-mode.md)** -- let koan pick tracks for you
+- **[File Organization](guide/file-organization.md)** -- rename your library using format string patterns
+- **[Remote Servers](guide/remote-servers.md)** -- advanced Subsonic/Navidrome setup
+- **[GraphQL API](guide/graphql-api.md)** -- programmatic control and headless operation

--- a/docs/guide/file-organization.md
+++ b/docs/guide/file-organization.md
@@ -1,0 +1,76 @@
+# File Organization
+
+koan can rename and reorganize your music library using fb2k-compatible format strings, directly from the TUI. No external tools needed.
+
+## Quick start
+
+1. Open the TUI: `koan`
+2. Press `e` to enter queue edit mode
+3. Select tracks (shift-arrows for multi-select, or `Ctrl`-click)
+4. Press `space` to open the context menu
+5. Select **Organize**
+6. Pick a named pattern from your config
+7. Preview the file moves
+8. Execute
+
+Playlist paths update automatically. Playback continues uninterrupted (Unix rename preserves open file descriptors). Ancillary files (cover.jpg, .cue, .log) move with the music. Empty directories are cleaned up.
+
+## Destination
+
+Files are organized into the **first configured library folder** (from `[library] folders` in your config). If you have multiple library folders, the first one is always the destination. The format pattern generates the relative path within that folder.
+
+For example, with `folders = ["/Volumes/Music/library"]` and the `standard` pattern, a track becomes:
+
+```
+/Volumes/Music/library/Aphex Twin/(1999) Windowlicker EP/01. Windowlicker.flac
+```
+
+## Configuring patterns
+
+Define named patterns in your config:
+
+```toml
+[organize]
+default = "standard"      # pattern selected by default in the modal
+
+[organize.patterns]
+standard = "%album artist%/(%date%) %album%/%tracknumber%. %title%"
+va-aware = "%album artist%/$if($stricmp(%album artist%,Various Artists),,['('$left(%date%,4)')' ])%album% '['%codec%']'/[$num(%discnumber%,2)][%tracknumber%. ][%artist% - ]%title%"
+flat = "%artist% - %title%"
+```
+
+### Pattern breakdown
+
+**`standard`** -- simple artist/album/track hierarchy:
+```
+Aphex Twin/(1999) Windowlicker EP/01. Windowlicker.flac
+```
+
+**`va-aware`** -- handles compilations intelligently:
+- Normal album: `Aphex Twin/(1999) Windowlicker EP [FLAC]/01. Windowlicker.flac`
+- VA compilation: `Various Artists/Ministry of Sound [FLAC]/01. DJ Shadow - Building Steam.flac`
+
+When the album artist is "Various Artists", the per-track artist is included in the filename and the redundant year prefix is omitted.
+
+**`flat`** -- everything in one directory:
+```
+Aphex Twin - Windowlicker.flac
+```
+
+## Format string syntax
+
+Patterns use fb2k-compatible syntax:
+
+- `%field%` -- metadata value (artist, title, album, date, tracknumber, etc.)
+- `[...]` -- conditional block, only included if all fields inside have values
+- `$function()` -- transform functions ($if, $stricmp, $left, $num, etc.)
+- `/` -- directory separator
+
+See [Format Strings](../format-strings.md) for the complete syntax reference and all 55+ functions.
+
+## Safety
+
+- **Preview before execute.** The organize modal always shows you exactly what will be moved before doing anything.
+- **Path traversal protection.** Malicious metadata containing `..` or `.` path components is stripped. Destinations are validated to stay under the library base directory.
+- **Undo support.** Organize operations are tracked in the database (`organize_log` table) for potential reversal.
+- **Ancillary files move with music.** Cover art, cue sheets, and log files in the same directory are moved alongside the music files.

--- a/docs/guide/graphql-api.md
+++ b/docs/guide/graphql-api.md
@@ -1,0 +1,130 @@
+# GraphQL API
+
+koan exposes a GraphQL API for full programmatic control. The API runs alongside the TUI by default (port 4000, localhost only), or standalone in headless mode.
+
+## Quick start
+
+```bash
+# TUI + API (default)
+koan
+
+# Headless with GraphiQL web IDE
+koan --headless --playground
+
+# As a background daemon
+koan -d --playground
+```
+
+Then open `http://localhost:4000/graphql` for the GraphiQL IDE, or query directly:
+
+```bash
+curl -s http://localhost:4000/graphql \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "{ nowPlaying { state, track { title, artist } } }"}'
+```
+
+## Configuration
+
+```toml
+[graphql]
+enabled = true                # run alongside TUI (default: true, --no-api disables)
+port = 4000                   # API port (default: 4000)
+bind = "127.0.0.1"            # bind address (default: 127.0.0.1)
+playground = false             # GraphiQL IDE at GET /graphql (default: false)
+subsonic_port = 4040           # optional Subsonic REST API port (default: disabled)
+```
+
+The server binds to `127.0.0.1` by default. Use `--bind 0.0.0.0` or `bind = "0.0.0.0"` in config to expose on all interfaces. There's no authentication, so only do this on trusted networks.
+
+## Example queries
+
+### Library browsing
+
+```graphql
+# Find early FLAC albums
+{
+  albums(yearEnd: 1995, codec: "FLAC") {
+    edges { node { title, artistName, date } }
+  }
+}
+
+# Hi-res techno tracks
+{
+  tracks(genre: "techno", minSampleRate: 96000, minBitDepth: 24) {
+    edges { node { title, artist, codec, sampleRate } }
+  }
+}
+
+# Nested: artist -> albums -> tracks
+{
+  artists(search: "Aphex") {
+    edges {
+      node {
+        name
+        albums {
+          edges {
+            node {
+              title
+              tracks { edges { node { title } } }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Playback control
+
+```graphql
+# What's playing?
+{
+  nowPlaying {
+    state
+    positionMs
+    track { title, artist, codec, sampleRate, bitDepth }
+  }
+}
+
+# Queue management
+mutation { replaceQueue(trackIds: [42, 43, 44]) { ok, addedCount } }
+mutation { saveSnapshot(name: "techno friday") { ok } }
+mutation { enableRadio { ok } }
+```
+
+### Filtering
+
+Every query supports rich filtering:
+
+- **Albums**: year range, codec, label, genre
+- **Tracks**: genre, codec, sample rate, bit depth, duration
+- **Artists**: genre
+
+All string filters are case-insensitive substrings. Relay-style cursor pagination is available on all collection queries.
+
+## Available operations
+
+| Category | Operations |
+|----------|-----------|
+| **Playback** | `play`, `pause`, `resume`, `stop`, `next`, `previous`, `seek` |
+| **Queue** | `add_to_queue`, `insert_in_queue`, `remove_from_queue`, `clear_queue`, `replace_queue`, `get_queue`, `reorder_queue` |
+| **Library** | `search`, `list_artists`, `list_albums`, `list_tracks`, `get_track`, `library_stats` |
+| **State** | `now_playing`, `list_devices`, `set_device` |
+| **Favourites** | `favourite`, `unfavourite`, `list_favourites` |
+| **Snapshots** | `save_snapshot`, `restore_snapshot`, `list_snapshots`, `delete_snapshot` |
+| **Radio** | `enable_radio`, `disable_radio` |
+
+## Subsonic REST API
+
+koan can also expose a Subsonic-compatible REST API for clients that speak the Subsonic protocol:
+
+```bash
+koan --headless --subsonic 4040
+```
+
+This runs on a separate port from the GraphQL API. Useful for connecting Subsonic clients (DSub, Ultrasonic, play:Sub) to a headless koan instance.
+
+## MCP server
+
+The MCP server (`koan --mcp`) uses the same GraphQL schema in-process (no HTTP round-trip). See [MCP Integration](mcp-integration.md) for Claude Desktop setup.

--- a/docs/guide/headless-server.md
+++ b/docs/guide/headless-server.md
@@ -1,0 +1,86 @@
+# Headless Server
+
+Run koan as a background music server with no TUI -- controlled entirely via the GraphQL API, Subsonic REST API, or MCP.
+
+## Quick start
+
+```bash
+# Headless with GraphiQL IDE
+koan --headless --playground
+
+# Background daemon
+koan -d
+
+# Daemon with all APIs
+koan -d --playground --subsonic 4040
+```
+
+## Daemon mode
+
+The `-d` flag detaches koan from the terminal and runs it in the background:
+
+```bash
+koan -d
+```
+
+koan logs to `~/.config/koan/koan.log` in daemon mode. The GraphQL API is available on `http://localhost:4000/graphql` by default.
+
+## Server flags
+
+| Flag | Effect |
+|------|--------|
+| `--headless` | No TUI, API only |
+| `--playground` | Enable GraphiQL web IDE at `GET /graphql` |
+| `--subsonic PORT` | Enable Subsonic REST API on the given port |
+| `--port PORT` | Custom GraphQL port (default: 4000) |
+| `--bind ADDR` | Bind address (default: 127.0.0.1) |
+| `-d` | Detach and run as background daemon |
+
+## Configuration
+
+```toml
+[graphql]
+enabled = true            # redundant in headless mode, but controls TUI+API mode
+port = 4000               # GraphQL API port
+bind = "127.0.0.1"        # bind address
+playground = false         # GraphiQL IDE
+subsonic_port = 4040       # Subsonic REST API port (0 = disabled)
+```
+
+Or via environment variables:
+
+```bash
+export KOAN_GRAPHQL__PORT=8080
+export KOAN_GRAPHQL__BIND=0.0.0.0
+export KOAN_GRAPHQL__PLAYGROUND=true
+```
+
+## Docker
+
+```bash
+docker run -e KOAN_REMOTE__ENABLED=true \
+           -e KOAN_REMOTE__URL=https://music.example.com \
+           -e KOAN_REMOTE__USERNAME=admin \
+           -e KOAN_REMOTE__PASSWORD="$NAVIDROME_PASSWORD" \
+           -e KOAN_GRAPHQL__BIND=0.0.0.0 \
+           -e KOAN_GRAPHQL__PORT=4000 \
+           -p 4000:4000 \
+           koan --headless
+```
+
+All config fields are overridable via `KOAN_*` environment variables. See [Configuration](../reference/configuration.md) for the full list.
+
+## Remote TUI
+
+Connect a TUI from another machine to a running headless koan:
+
+```bash
+koan --server http://host:4000          # full TUI
+koan --server http://host:4000 --jukebox  # remote control only (no local playback)
+```
+
+## Security
+
+The GraphQL API has **no authentication**. By default it binds to `127.0.0.1` (localhost only). If you expose it on `0.0.0.0`, anyone on your network can control playback, browse your library, move files (via organize), and clear your queue.
+
+Only bind to all interfaces on trusted networks.

--- a/docs/guide/mcp-integration.md
+++ b/docs/guide/mcp-integration.md
@@ -1,0 +1,68 @@
+# MCP Integration
+
+`koan --mcp` runs koan as a headless player controllable by Claude Desktop (or any MCP client). No TUI, no terminal -- just the audio engine and 2 tools exposed over the Model Context Protocol on stdio. The LLM reads the GraphQL schema, then drives everything through one `graphql` tool.
+
+## Setup
+
+1. Make sure `koan` is on your PATH (or note the full path from `which koan`).
+
+2. Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "koan": {
+      "command": "koan",
+      "args": ["--mcp"]
+    }
+  }
+}
+```
+
+If koan isn't on Claude Desktop's PATH (common with Homebrew or mise), use the full path:
+
+```json
+{
+  "mcpServers": {
+    "koan": {
+      "command": "/opt/homebrew/bin/koan",
+      "args": ["--mcp"]
+    }
+  }
+}
+```
+
+3. Restart Claude Desktop. You should see koan in the MCP server list (plug icon).
+
+4. Make sure you've run `koan scan` at least once so your library is indexed.
+
+## Tools exposed
+
+| Tool | Purpose |
+|------|---------|
+| `schema_sdl` | Returns the full GraphQL schema so the LLM knows what queries and mutations are available |
+| `graphql` | Executes a GraphQL query or mutation against the running player |
+
+The LLM reads the schema first, then constructs whatever queries it needs. This 2-tool design means new features added to the GraphQL API are automatically available to the MCP server without any changes.
+
+## Example prompts
+
+Things you can ask Claude when koan is connected:
+
+- "Play me some ambient music"
+- "What albums do I have by Aphex Twin?"
+- "Queue up Tri Repetae but skip the interludes"
+- "Pause" / "Skip this" / "What's playing?"
+- "Play something like what's on now but more upbeat"
+- "Search my library for anything with 'rain' in the title"
+- "Switch audio output to my DAC"
+- "Save this queue as 'techno friday'" / "Restore my chill mix"
+- "Turn on radio mode" / "Star this track"
+
+Claude chains multiple GraphQL operations together naturally -- "find all my 90s electronic albums, pick one at random, and queue it up" becomes a search -> filter -> add_to_queue -> play sequence.
+
+## How it differs from the GraphQL API
+
+The MCP server executes GraphQL queries in-process (no HTTP round-trip). The schema and capabilities are identical to the [GraphQL API](graphql-api.md) -- same queries, same mutations, same filters.
+
+The main difference is the transport: MCP uses stdio (for Claude Desktop integration), while the GraphQL API uses HTTP (for scripts, web clients, and other tools).

--- a/docs/guide/radio-mode.md
+++ b/docs/guide/radio-mode.md
@@ -1,0 +1,81 @@
+# Radio Mode
+
+Radio mode turns koan into an infinite jukebox. When enabled, koan automatically queues similar tracks as you listen -- you never run out of music.
+
+## Quick start
+
+Press `R` in the TUI to toggle radio mode. That's it. koan starts adding tracks to your queue based on what's playing.
+
+## How it works
+
+Radio mode uses a multi-signal scoring system to find tracks similar to what you're currently listening to:
+
+1. **Subsonic similarity** (`use_subsonic`) -- if you have a remote server configured, koan queries `getSimilarSongs2` for server-side recommendations. This is the strongest signal when available.
+
+2. **Cached artist relationships** -- koan builds a local cache of "similar artist" relationships from your Subsonic server. Even when offline, these cached relationships inform radio selections.
+
+3. **Genre matching** -- tracks sharing genres with the current seed tracks get a relevance boost.
+
+4. **Artist matching** -- other tracks by the same artist (or similar artists) score higher.
+
+5. **Acoustic similarity** -- if you've run `koan scan --analyze`, radio mode factors in acoustic features (tempo, energy, spectral characteristics). Control the weight with `[discovery] acoustic_weight`.
+
+The scoring system blends these signals and avoids repeating recently-played tracks (controlled by `history_window`).
+
+## Configuration
+
+```toml
+[radio]
+lookahead = 5                 # tracks to keep queued ahead (default: 5)
+batch_size = 5                # tracks added per refill (default: 5)
+use_subsonic = true           # use Subsonic similarity when available (default: true)
+history_window = 200          # don't repeat last N tracks (default: 200)
+seed_window = 5               # recent tracks used as seed for similarity (default: 5)
+discovery_weight = 0.3        # 0.0 = familiar only, 1.0 = maximize discovery (default: 0.3)
+```
+
+### Tuning discovery
+
+`discovery_weight` is the most impactful setting:
+
+| Value | Behavior |
+|-------|----------|
+| `0.0` | Stick to what you know -- heavily favours familiar artists and genres |
+| `0.3` | **(default)** Balanced mix of familiar and new discoveries |
+| `0.7` | Adventurous -- actively seeks out less-played tracks and artists |
+| `1.0` | Maximum exploration -- prioritizes tracks you've never heard |
+
+### Seed window
+
+`seed_window` controls how many recent tracks inform the "similar to what?" query. With the default of 5, radio mode looks at the last 5 tracks to determine the musical direction. A smaller window (1-2) makes the radio more reactive to the single current track; a larger window (10+) gives a broader, more averaged vibe.
+
+### Lookahead and batch size
+
+`lookahead` is how many tracks radio mode tries to keep queued ahead of the current position. When the queue runs below this threshold, it adds `batch_size` more tracks. The default of 5 for both means you always have ~5 tracks ahead, refilled in batches of 5.
+
+## Acoustic analysis
+
+For the best radio experience, run acoustic analysis on your library:
+
+```bash
+koan scan --analyze
+```
+
+This computes acoustic features (spectral centroid, energy, tempo estimates) for each track. With acoustic analysis data available, radio mode can find tracks that genuinely *sound* similar, not just tracks that share metadata.
+
+Control how much weight acoustic similarity gets:
+
+```toml
+[discovery]
+analysis_on_scan = false      # run automatically during every scan (default: false)
+acoustic_weight = 0.5         # 0.0 = metadata only, 1.0 = acoustics only (default: 0.5)
+```
+
+Setting `analysis_on_scan = true` runs acoustic analysis on every `koan scan`, keeping features up to date as you add music. This makes scans slower, so it's off by default -- run `koan scan --analyze` manually when you want to update.
+
+## Tips
+
+- **Start with a track you like.** Radio mode uses whatever's playing as its seed. Queue up a track that sets the vibe you want, then press `R`.
+- **Queue some variety first.** If you queue tracks from different genres before enabling radio, the seed window will pick up on the mix and produce more varied results.
+- **Still edit the queue.** Radio mode only adds tracks -- you can still remove tracks you don't want (`e` to edit, `d` to delete). Radio will refill around your changes.
+- **Works offline.** Without a Subsonic server, radio falls back to local genre/artist matching and acoustic similarity. Less accurate but still functional.

--- a/docs/guide/remote-servers.md
+++ b/docs/guide/remote-servers.md
@@ -1,0 +1,122 @@
+# Remote Servers
+
+koan integrates with [Navidrome](https://www.navidrome.org/), Subsonic, and any server with a Subsonic-compatible API. Remote tracks merge seamlessly with your local library into a single unified collection.
+
+## Setup
+
+```bash
+koan remote login https://music.example.com admin
+```
+
+This prompts for your password and saves credentials to `config.local.toml` (gitignored). Then sync your library:
+
+```bash
+koan remote sync
+```
+
+The first sync fetches your entire remote library. This can take a while for large collections (tens of thousands of tracks), but progress is displayed throughout.
+
+## Incremental sync
+
+After the first full sync, subsequent runs are **incremental** -- only albums added since the last sync are fetched:
+
+```bash
+koan remote sync          # incremental (fast)
+koan remote sync --full   # force complete re-sync
+```
+
+Run `koan remote sync` periodically (or after adding music to your server) to pull new tracks.
+
+## How merging works
+
+When you have both local files and a remote server, koan deduplicates tracks using a 3-strategy match:
+
+1. **File path** -- exact local path match
+2. **Remote ID** -- Subsonic server ID
+3. **Content match** -- artist + album + title + track number
+
+If the same track exists in both sources, it becomes a single database entry. Playback priority:
+
+1. **Local file** -- always preferred (bit-perfect from disk)
+2. **Cached download** -- previously downloaded remote tracks
+3. **Remote stream** -- on-demand progressive download
+
+### Drive unplugged?
+
+If a local drive is disconnected, tracks with remote backing are demoted to remote-only (streaming fallback) instead of deleted. When the drive comes back, the next `koan scan` re-merges them automatically.
+
+## Streaming playback
+
+Remote tracks start playing after just **256KB** is buffered instead of waiting for the full download. In the TUI:
+
+- The seek bar dims the not-yet-downloaded portion
+- Seeking past the downloaded boundary is prevented
+- Duration always shows the full track length
+- When the download finishes, full metadata and cover art are re-read
+
+Downloads happen in the background with configurable parallelism:
+
+```toml
+[remote]
+download_workers = 5    # parallel download threads (default: 5)
+```
+
+## Transcoding
+
+By default, koan requests the original quality from the server. If bandwidth is a concern:
+
+```toml
+[remote]
+transcode_quality = "original"   # original | opus-128 | mp3-320
+```
+
+| Quality | Description |
+|---------|-------------|
+| `original` | **(default)** Bit-perfect, whatever the server has |
+| `opus-128` | Opus at 128kbps -- transparent quality, ~1/10th the bandwidth of FLAC |
+| `mp3-320` | MP3 at 320kbps -- maximum quality lossy, widest compatibility |
+
+Note: transcoding depends on the server supporting it. Navidrome and most Subsonic servers handle this natively.
+
+## Cache management
+
+Downloaded remote tracks are cached locally so subsequent plays are instant. See [Cache Management](../recipes/cache-management.md) for size limits, eviction, and cleanup.
+
+```toml
+[remote]
+cache_limit = "50GB"           # max cache size, LRU eviction on startup (default: unlimited)
+cache_dir = "/custom/path"     # explicit cache dir (default: ~/.config/koan/cache)
+```
+
+## Favourite sync
+
+Favourites sync bidirectionally with your remote server:
+
+- Star a track in koan (`f`) -> stars it on the server
+- Star a track on the server (via Navidrome web UI, DSub, etc.) -> next `koan remote sync` picks it up
+
+## Configuration reference
+
+```toml
+# config.local.toml
+[remote]
+enabled = true
+url = "https://music.example.com"
+username = "admin"
+# password saved by `koan remote login`
+
+# config.toml or config.local.toml
+[remote]
+transcode_quality = "original"   # original | opus-128 | mp3-320
+download_workers = 5             # parallel download threads
+cache_limit = "50GB"             # max cache size (LRU eviction)
+cache_dir = "/custom/path"       # cache directory
+```
+
+## Checking status
+
+```bash
+koan remote status
+```
+
+Shows the configured server URL, username, last sync time, and track counts.

--- a/docs/recipes/cache-management.md
+++ b/docs/recipes/cache-management.md
@@ -1,0 +1,67 @@
+# Cache Management
+
+When you play remote tracks, koan downloads them to a local cache so subsequent plays are instant. This guide covers monitoring and managing that cache.
+
+## Check cache status
+
+```bash
+koan cache status
+```
+
+Shows the total size, number of cached tracks, and the cache directory path.
+
+## Cache location
+
+Default: `~/.config/koan/cache/`
+
+Override with:
+```toml
+[remote]
+cache_dir = "/path/to/custom/cache"
+```
+
+Or: `KOAN_REMOTE__CACHE_DIR=/path/to/custom/cache`
+
+## Automatic LRU eviction
+
+Set a size limit and koan evicts the least-recently-played tracks on startup:
+
+```toml
+[remote]
+cache_limit = "50GB"
+```
+
+Eviction rules:
+- Evicts whole albums (not individual tracks), oldest last-played first
+- **Favourited tracks are never evicted** -- starring a track protects it from cache cleanup
+- Eviction runs automatically when koan starts, not during playback
+- Size is calculated from the database (fast), not by scanning the filesystem
+
+If no `cache_limit` is set, the cache grows without bound.
+
+## Manual eviction
+
+```bash
+koan cache evict          # run LRU eviction based on cache_limit
+```
+
+Useful if you want to trigger eviction without restarting koan.
+
+## Clear everything
+
+```bash
+koan cache clear          # delete all cached downloads
+```
+
+This removes all cached files. Remote tracks will need to re-download on next play.
+
+## How caching interacts with playback
+
+- Remote tracks start playing after **256KB** is buffered (progressive download)
+- Once fully downloaded, the file is cached and metadata/cover art are re-read
+- The seek bar dims the not-yet-downloaded portion during progressive playback
+- Double-clicking a downloading track in the queue prioritizes its download
+
+## Drive unplugged scenario
+
+If your local music drive is disconnected, tracks that also exist on your remote server are automatically demoted to remote-only (streaming with cache). When the drive comes back, `koan scan` re-merges them as local files. The cache for those tracks is then redundant and will eventually be evicted by LRU if you have a cache limit set.

--- a/docs/recipes/troubleshooting.md
+++ b/docs/recipes/troubleshooting.md
@@ -1,0 +1,134 @@
+# Troubleshooting
+
+Common issues and how to fix them.
+
+## Audio
+
+### No sound / wrong output device
+
+1. Check which devices koan sees:
+   ```bash
+   koan devices
+   ```
+2. Set the correct device in config:
+   ```toml
+   [playback]
+   output_device = "Your DAC Name"
+   ```
+   Or press `Shift+D` in the TUI to switch live.
+
+3. If the device name changed (e.g. after a macOS update), koan falls back to the system default. Update the config or re-select in the TUI.
+
+### Sample rate mismatch / clicks / pops
+
+koan switches the audio device's sample rate to match the source file. If you hear artifacts:
+
+- Check that your DAC supports the source sample rate (`koan probe <file>` to check)
+- Some USB DACs need a moment to lock onto a new sample rate -- this is normal for the first ~100ms of a rate-switched track
+- If using AirPlay or Bluetooth, sample rate switching isn't supported -- koan will play at whatever rate the device is already set to
+
+### Port already in use (GraphQL API)
+
+```
+WARN: Failed to bind to 127.0.0.1:4000
+```
+
+Another koan instance (or another process) is using port 4000. Either:
+- Kill the other process: `lsof -i :4000`
+- Use a different port: `koan --port 8080` or `KOAN_GRAPHQL__PORT=8080`
+
+## Library
+
+### Scan doesn't find my files
+
+- Check that `[library] folders` in `config.local.toml` points to the right directory
+- koan scans recursively -- you only need the top-level directory
+- Supported formats: FLAC, MP3, AAC, Vorbis, Opus, ALAC, WavPack, WAV, AIFF
+- Run `koan config` to verify the resolved config
+
+### Duplicate tracks after remote sync
+
+koan deduplicates using artist + album + title + track number. If you see duplicates:
+- Tags might differ between local files and the remote server (e.g. different artist spelling)
+- Run `koan scan` after `koan remote sync` to re-merge
+
+### Search returns nothing
+
+Make sure you've run `koan scan` at least once. The FTS5 index is built during scanning.
+
+## Remote
+
+### Connection refused / timeout
+
+```bash
+koan remote status    # check connection
+```
+
+- Verify the URL is correct (include `https://` or `http://`)
+- Check that the Subsonic API is enabled on your server (Navidrome: Settings -> Subsonic)
+- Try the URL in a browser to verify the server is reachable
+
+### Authentication failed
+
+```bash
+koan remote login https://music.example.com admin
+```
+
+Re-run login to update credentials. koan uses MD5+salt authentication (standard Subsonic protocol). Some servers require enabling "legacy authentication" in their settings.
+
+### Sync stalls or is very slow
+
+The first sync fetches all albums and tracks. For large libraries (50k+ tracks), this can take several minutes.
+
+- Progress is displayed during sync
+- Subsequent syncs are incremental (much faster)
+- Check your server's rate limits if sync seems throttled
+
+## TUI
+
+### Album art not showing
+
+Album art uses halfblock rendering (Unicode block characters). Requirements:
+- Terminal must support Unicode
+- Terminal must support 256 colors or truecolor
+- Art is extracted from embedded tags (FLAC, MP3, etc.) or downloaded from the remote server
+
+If art shows as garbled characters, your terminal may not support halfblock rendering. Try a different terminal (iTerm2, Ghostty, WezTerm, Kitty all work well).
+
+### Visualizer not showing
+
+The spectrum analyzer renders in the transport area when album art is present. If it's not visible:
+- Check that `[visualizer] enabled = true` (default)
+- The terminal window needs to be wide enough to fit both album art and the visualizer
+- Some terminals with limited Unicode support may not render the block characters correctly
+
+### Terminal not restored after crash
+
+If koan crashes and leaves your terminal in a bad state (no echo, wrong colors):
+
+```bash
+reset
+```
+
+koan installs a panic hook that attempts to restore the terminal on any thread, but some crash modes (SIGKILL, OOM) bypass the hook.
+
+## Config
+
+### Changes not taking effect
+
+Config is loaded at startup. Restart koan after editing config files.
+
+Check the resolved config to verify your changes are being picked up:
+```bash
+koan config
+```
+
+Environment variables (`KOAN_*`) override file config. If a value isn't what you expect, check for conflicting env vars.
+
+### Secrets appearing in config.toml
+
+If sensitive values from `config.local.toml` or environment variables appear in `config.toml`, something called `save()` on a merged config instead of using `Config::update_base()`. This is a bug -- please report it.
+
+## Logs
+
+koan logs to `~/.config/koan/koan.log`. Check this file for detailed error messages when something goes wrong. In daemon mode (`-d`), this is the primary debugging tool.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,0 +1,181 @@
+# CLI Reference
+
+koan is a single binary with subcommands. Running `koan` with no subcommand launches the TUI player.
+
+## Play (default)
+
+`koan` is the play command. All top-level flags are play flags.
+
+```bash
+koan                              # TUI + GraphQL API on :4000
+koan ~/Music/album/               # play a directory (recursive)
+koan ~/Music/*.flac               # play specific files
+koan --album 5                    # play album by ID (use tab completion)
+koan --artist 3                   # play artist by ID
+koan --library                    # TUI in library browse mode
+koan --clear                      # clear persisted queue
+koan --no-api                     # TUI only (no GraphQL server)
+```
+
+### Server flags
+
+```bash
+koan --headless                   # GraphQL API on 127.0.0.1:4000, no TUI
+koan --headless --playground      # with GraphiQL web IDE
+koan --headless --subsonic 4040   # + Subsonic REST on port 4040
+koan --port 8080                  # custom GraphQL port
+koan --bind 0.0.0.0              # listen on all interfaces (no auth)
+koan -d                           # background daemon
+koan -d --subsonic 4040           # daemon with Subsonic
+```
+
+### Remote TUI
+
+```bash
+koan --server http://host:4000          # TUI connected to remote koan
+koan --server http://host:4000 --jukebox  # remote control only
+```
+
+### MCP server
+
+```bash
+koan --mcp                        # MCP server on stdio (Claude Desktop)
+```
+
+See [MCP Integration](../guide/mcp-integration.md) for setup instructions.
+
+---
+
+## `koan init`
+
+Create the config directory with sensible defaults.
+
+```bash
+koan init
+```
+
+Safe to re-run -- merges new default fields without overwriting your customizations.
+
+See [Configuration](configuration.md) for details on what gets created.
+
+---
+
+## `koan scan`
+
+Scan configured library folders and index metadata.
+
+```bash
+koan scan                         # standard metadata scan
+koan scan --analyze               # scan + acoustic analysis in one pass
+```
+
+Scanning runs in parallel using rayon. Subsequent scans are incremental -- only new or modified files are re-indexed (based on mtime + size from the scan cache).
+
+The `--analyze` flag computes acoustic features for radio mode similarity scoring. This is slower than a plain scan.
+
+---
+
+## `koan search`
+
+Full-text search across your library (CLI output).
+
+```bash
+koan search "radiohead"
+koan search "kind of blue"
+```
+
+Uses SQLite FTS5 for fast, typo-tolerant search. Results display as a tree: artist -> album -> track.
+
+---
+
+## `koan library`
+
+Show library statistics.
+
+```bash
+koan library
+```
+
+---
+
+## `koan remote`
+
+Manage Subsonic/Navidrome remote servers.
+
+```bash
+koan remote login URL user        # authenticate (prompts for password)
+koan remote sync                  # incremental sync (new albums since last sync)
+koan remote sync --full           # full re-sync of entire library
+koan remote status                # show remote server info
+```
+
+See [Remote Servers](../guide/remote-servers.md) for the full guide.
+
+---
+
+## `koan config`
+
+Show the resolved configuration from all layers.
+
+```bash
+koan config
+```
+
+Displays defaults, config.toml values, config.local.toml overrides, and active `KOAN_*` environment variables with the final merged result.
+
+---
+
+## `koan devices`
+
+List available audio output devices.
+
+```bash
+koan devices
+```
+
+Shows device names as recognized by CoreAudio (macOS) or ALSA/cpal (Linux). Use these names for the `[playback] output_device` config field or the `Shift+D` device selector in the TUI.
+
+---
+
+## `koan cache`
+
+Manage the download cache for remote tracks.
+
+```bash
+koan cache status                 # show cache size and track count
+koan cache clear                  # clear all cached downloads
+koan cache evict                  # run LRU eviction based on cache_limit
+```
+
+See [Cache Management](../recipes/cache-management.md) for details.
+
+---
+
+## `koan probe`
+
+Show format and codec info for a file.
+
+```bash
+koan probe track.flac
+```
+
+Displays codec, sample rate, bit depth, channels, duration, and tag summary.
+
+---
+
+## Shell completions
+
+Dynamic completions that know your library -- artist/album IDs tab-complete from the database.
+
+```bash
+# zsh (add to .zshrc)
+source <(COMPLETE=zsh koan)
+
+# bash
+source <(COMPLETE=bash koan)
+
+# fish
+COMPLETE=fish koan | source
+```
+
+Then `koan --album <TAB>` shows your actual albums with artist names.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,0 +1,297 @@
+# Configuration Reference
+
+koan uses [figment](https://docs.rs/figment) for layered configuration. Four sources are merged in order -- each layer overrides the one before it:
+
+```
+Defaults -> config.toml -> config.local.toml -> KOAN_* env vars
+(lowest)                                       (highest priority)
+```
+
+| Layer | Path | Purpose |
+|-------|------|---------|
+| Defaults | (built-in) | Hardcoded sane defaults for every field |
+| `config.toml` | `~/.config/koan/config.toml` | Shareable base config -- safe to commit to dotfiles |
+| `config.local.toml` | `~/.config/koan/config.local.toml` | Machine-specific paths, credentials (gitignored) |
+| Environment | `KOAN_*` vars | 12-factor overrides -- highest priority, ideal for Docker/CI |
+
+Run `koan config` to see all layers and the fully resolved result (including which `KOAN_*` env vars are active).
+
+## Environment variable overrides
+
+Any config field can be overridden via environment variables using the `KOAN_` prefix with `__` (double underscore) as the section separator:
+
+```
+KOAN_<SECTION>__<FIELD>=<value>
+```
+
+Examples:
+
+```bash
+# Remote server password (avoids writing secrets to files)
+export KOAN_REMOTE__PASSWORD="hunter2"
+
+# Change GraphQL API port
+export KOAN_GRAPHQL__PORT=8080
+
+# Bind API to all interfaces
+export KOAN_GRAPHQL__BIND="0.0.0.0"
+
+# Override render FPS
+export KOAN_PLAYBACK__TARGET_FPS=30
+
+# Enable the GraphiQL playground
+export KOAN_GRAPHQL__PLAYGROUND=true
+
+# Set ReplayGain mode
+export KOAN_PLAYBACK__REPLAYGAIN=track
+```
+
+Field names match the TOML key in SCREAMING_SNAKE_CASE. Nested sections use `__`:
+- `[remote] password` -> `KOAN_REMOTE__PASSWORD`
+- `[graphql] subsonic_port` -> `KOAN_GRAPHQL__SUBSONIC_PORT`
+- `[playback] pre_amp_db` -> `KOAN_PLAYBACK__PRE_AMP_DB`
+
+## Docker / CI usage
+
+Env vars make koan easy to configure in containers and CI without config files:
+
+```bash
+# Docker -- headless server with remote backend
+docker run -e KOAN_REMOTE__ENABLED=true \
+           -e KOAN_REMOTE__URL=https://music.example.com \
+           -e KOAN_REMOTE__USERNAME=admin \
+           -e KOAN_REMOTE__PASSWORD="$NAVIDROME_PASSWORD" \
+           -e KOAN_GRAPHQL__BIND=0.0.0.0 \
+           -e KOAN_GRAPHQL__PORT=4000 \
+           -p 4000:4000 \
+           koan --headless
+```
+
+```yaml
+# CI -- run tests against a specific config
+env:
+  KOAN_REMOTE__URL: ${{ secrets.NAVIDROME_URL }}
+  KOAN_REMOTE__PASSWORD: ${{ secrets.NAVIDROME_PASSWORD }}
+  KOAN_GRAPHQL__PORT: 4001
+```
+
+## `koan init`
+
+Creates the config directory at `~/.config/koan/` with everything koan needs to run:
+
+```bash
+koan init
+```
+
+What it creates:
+
+| File | Purpose |
+|------|---------|
+| `config.toml` | Base config with all defaults (new fields are merged in without overwriting your customizations) |
+| `config.local.toml` | Template for machine-specific settings (library folders, remote server) |
+| `.gitignore` | Ignores `*.log`, `*.db`, `config.local.toml`, `cache/` |
+| `koan.db` | SQLite database (created if missing) |
+| `cache/` | Download cache directory |
+
+Running `koan init` on an existing setup is safe -- it merges new defaults without touching values you've changed, and skips `config.local.toml` if it exists.
+
+`library.folders` is deliberately excluded from `config.toml` (it's machine-specific and belongs in `config.local.toml`). This means you can commit `~/.config/koan/` to your dotfiles repo and share playback/visualizer/organize settings across machines while keeping library paths and credentials local.
+
+---
+
+## `[playback]`
+
+```toml
+[playback]
+software_volume = false     # volume control in software (vs hardware/DAC)
+replaygain = "album"        # off | track | album
+pre_amp_db = 0.0            # dB gain on top of ReplayGain (default: 0.0)
+target_fps = 60             # TUI render rate in Hz (default: 60)
+ticker_fps = 8              # title scroll speed in Hz (default: 8)
+show_fps = false            # FPS counter overlay in top-right corner (default: false)
+art_size = 24               # album art width in terminal columns (default: 24)
+output_device = "My DAC"    # audio output device name (default: system default)
+```
+
+### ReplayGain
+
+ReplayGain normalizes volume levels across tracks so you don't reach for the volume knob between a whisper-quiet jazz track and a wall-of-sound metal album. koan reads standard ReplayGain tags (embedded by tools like `loudgain`, `r128gain`, foobar2000) at decode time and applies gain with peak limiting to prevent clipping.
+
+| Mode | Description |
+|------|-------------|
+| `off` | No gain adjustment. Original signal untouched |
+| `track` | Per-track normalization. Every track plays at the same perceived loudness. Best for shuffled playlists |
+| `album` | Per-album normalization. Preserves dynamic range within an album (quiet intros, loud climaxes) while normalizing between albums. **(recommended)** |
+
+`pre_amp_db` adds a fixed gain on top of the ReplayGain adjustment. Positive values make everything louder (risk of clipping), negative values quieter. Useful if your ReplayGain-tagged library feels too quiet at the target level.
+
+### Render FPS
+
+`target_fps` controls how often the TUI redraws. 30, 60, or 120 are typical values. Higher values give smoother visualizer and seek bar updates but use more CPU. Most terminals cap at 60 anyway.
+
+### Ticker
+
+When the artist/title text overflows the available transport bar width, it scrolls horizontally like a ticker. `ticker_fps` controls the scroll speed -- one character per frame. Higher values scroll faster.
+
+### Album art size
+
+`art_size` sets the width in terminal columns. Height is always `art_size / 2` (square via halfblock rendering, where each cell is 2 pixels tall). The default of 24 columns = 24x12 cells = a 24x24 pixel-equivalent square.
+
+### Output device
+
+`output_device` selects an audio output by name. Press `Shift+D` in the TUI to browse available devices and switch live. The choice is persisted to config. If the named device isn't available at startup, koan falls back to the system default.
+
+Run `koan devices` to list available audio outputs.
+
+---
+
+## `[library]`
+
+```toml
+# config.local.toml (machine-specific)
+[library]
+folders = ["/Volumes/Music/library", "/Users/me/Music"]
+```
+
+One or more directories to scan for music. Subdirectories are scanned recursively.
+
+---
+
+## `[remote]`
+
+```toml
+# config.local.toml (credentials should stay local)
+[remote]
+enabled = true
+url = "https://music.example.com"
+username = "admin"
+# password is prompted by `koan remote login` and saved here
+
+# config.toml or config.local.toml
+[remote]
+transcode_quality = "original"   # original | opus-128 | mp3-320 (default: original)
+download_workers = 5             # parallel download threads (default: 5)
+cache_limit = "50GB"             # max cache size, LRU eviction on startup (default: unlimited)
+cache_dir = "/custom/path"       # explicit cache dir (default: ~/.config/koan/cache)
+```
+
+See [Remote Servers](../guide/remote-servers.md) for the full setup guide.
+
+---
+
+## `[visualizer]`
+
+```toml
+[visualizer]
+enabled = true                # show spectrum analyzer in transport area (default: true)
+fps = 60                      # analysis thread update rate in Hz (default: 60)
+scale = "bark"                # frequency scale (default: bark)
+amplitude_scale = "aweight"   # amplitude scale (default: aweight)
+bar_decay_ms = 50             # bar drop half-life in ms (default: 50)
+peak_decay_ms = 180           # peak marker linger half-life in ms (default: 180)
+```
+
+Also accepts `[visualiser]` spelling.
+
+The spectrum analyzer renders above the transport text when album art is present. 48-band FFT with sub-cell resolution using Unicode block characters, peak hold markers, and smooth exponential decay. Bars are colored by signal level -- green at safe headroom, yellow when getting hot, red near clipping (0dBFS). The FFT runs on a dedicated thread so the UI is never blocked.
+
+### Frequency scales (`scale`)
+
+Controls how FFT bins map to bars (the X axis):
+
+| Scale | Description |
+|-------|-------------|
+| `bark` | Bark psychoacoustic scale -- 24 critical bands, matches how your ears group frequencies. Best for music. **(default)** |
+| `mel` | Mel perceptual pitch scale -- similar to Bark, widely used in speech/music analysis |
+| `log` | Logarithmic -- equal spacing per octave. Familiar if you read spectrograms |
+| `linear` | Linear -- equal Hz per bar. Bass is cramped, treble dominates. Analytical use |
+
+### Amplitude scales (`amplitude_scale`)
+
+Controls how magnitudes map to bar height (the Y axis):
+
+| Scale | Description |
+|-------|-------------|
+| `aweight` | A-weighted (IEC 61672). Reflects perceived loudness -- bass and extreme treble attenuated to match human hearing. **(default)** |
+| `perceptual` | A-weighting + gentle gamma curve. Same frequency correction with a boost to quiet signals |
+| `sqrt` | Square root curve -- gentle boost to quiet bands, no frequency correction |
+| `linear` | Raw dB-normalized magnitude. No correction. Technically accurate |
+
+---
+
+## `[organize]`
+
+```toml
+[organize]
+default = "standard"      # pattern selected by default in the TUI modal
+
+[organize.patterns]
+standard = "%album artist%/(%date%) %album%/%tracknumber%. %title%"
+va-aware = "%album artist%/$if($stricmp(%album artist%,Various Artists),,['('$left(%date%,4)')' ])%album% '['%codec%']'/[$num(%discnumber%,2)][%tracknumber%. ][%artist% - ]%title%"
+flat = "%artist% - %title%"
+```
+
+Named patterns used by the TUI organize modal. Format strings use fb2k syntax -- `%field%` for metadata, `$function()` for transforms, `[conditionals]` to omit blocks when fields are missing. See [Format Strings](../format-strings.md) for the full reference.
+
+The `va-aware` pattern handles compilations: if the album artist is "Various Artists", it includes the per-track artist in the filename and omits the redundant year prefix.
+
+Files are organized into the **first configured library folder** (from `[library] folders`). The format pattern generates the relative path within that folder.
+
+See [File Organization](../guide/file-organization.md) for a walkthrough.
+
+---
+
+## `[graphql]`
+
+```toml
+[graphql]
+enabled = true                # run API alongside TUI (default: true, false = --no-api)
+port = 4000                   # API port (default: 4000)
+bind = "127.0.0.1"            # bind address (default: 127.0.0.1)
+playground = false             # enable GraphiQL IDE at GET /graphql (default: false)
+subsonic_port = 4040           # optional Subsonic REST API port (default: disabled)
+```
+
+Set `bind = "0.0.0.0"` to listen on all interfaces. There's no authentication, so only do this on trusted networks.
+
+See [GraphQL API](../guide/graphql-api.md) and [Headless Server](../guide/headless-server.md) for usage guides.
+
+---
+
+## `[radio]`
+
+```toml
+[radio]
+lookahead = 5                 # tracks to keep queued ahead (default: 5)
+batch_size = 5                # tracks added per refill (default: 5)
+use_subsonic = true           # use Subsonic similarity when available (default: true)
+history_window = 200          # don't repeat last N tracks (default: 200)
+seed_window = 5               # recent tracks used as seed for similarity (default: 5)
+discovery_weight = 0.3        # 0.0 = familiar only, 1.0 = maximize discovery (default: 0.3)
+```
+
+See [Radio Mode](../guide/radio-mode.md) for a full guide.
+
+---
+
+## `[discovery]`
+
+```toml
+[discovery]
+analysis_on_scan = false      # run acoustic analysis during library scan (default: false)
+acoustic_weight = 0.5         # weight of acoustic similarity in radio scoring 0.0..1.0 (default: 0.5)
+```
+
+Run `koan scan --analyze` to compute acoustic features for your library. Higher `acoustic_weight` gives radio mode more "sounds like" awareness vs. metadata-based matching.
+
+---
+
+## File paths
+
+| File | Default location |
+|------|-----------------|
+| Config (base) | `~/.config/koan/config.toml` |
+| Config (local) | `~/.config/koan/config.local.toml` |
+| Database | `~/.config/koan/koan.db` |
+| Download cache | `~/.config/koan/cache/` |
+| Log file | `~/.config/koan/koan.log` |

--- a/docs/reference/keybindings.md
+++ b/docs/reference/keybindings.md
@@ -1,0 +1,147 @@
+# Keybindings
+
+Every key in every mode. The hint bar at the bottom of the TUI shows available keys for the current mode.
+
+## Normal mode (default)
+
+### Playback
+
+| Key | Action |
+|-----|--------|
+| `space` | Pause / resume |
+| `<` | Previous track |
+| `>` | Next track |
+| `,` or `<-` | Seek -10 seconds |
+| `.` or `->` | Seek +10 seconds |
+| `Shift+D` | Device selector (switch audio output) |
+
+### Navigation
+
+| Key | Action |
+|-----|--------|
+| `p` | Track picker (fuzzy search) |
+| `a` | Album picker |
+| `r` | Artist picker |
+| `l` | Library browser |
+| `/` | Search queue (jump to matching track) |
+| `g` | Jump to start of queue |
+| `G` | Jump to end of queue |
+| `PgUp` or `Ctrl+U` | Page up |
+| `PgDn` or `Ctrl+D` | Page down |
+
+### Modes & panels
+
+| Key | Action |
+|-----|--------|
+| `e` | Enter queue edit mode |
+| `i` | Track info modal (codec, sample rate, cover art) |
+| `z` | Zoom album art |
+| `L` | Toggle lyrics panel |
+| `R` | Toggle radio mode |
+| `f` | Favourite / unfavourite current track |
+| `q` | Quit |
+
+### Queue changes
+
+| Key | Action |
+|-----|--------|
+| `Ctrl+Z` | Undo last queue change |
+| `Ctrl+Y` or `Ctrl+Shift+Z` | Redo last undone change |
+
+---
+
+## Picker mode (track/album/artist)
+
+Active when a fuzzy picker overlay is open (`p`, `a`, or `r`).
+
+| Key | Action |
+|-----|--------|
+| Type | Filter results (fuzzy matching) |
+| `Up` / `Down` | Navigate results |
+| `Enter` | Append selected to queue |
+| `Ctrl+Enter` | Append and start playing |
+| `Ctrl+R` | Replace entire queue and play |
+| `Esc` | Close picker |
+
+### Mouse in pickers
+
+- Click items to select
+- Double-click to confirm (same as `Enter`)
+- Click outside the picker to dismiss
+
+---
+
+## Library browser (`l`)
+
+Tree view: artist -> album -> track.
+
+| Key | Action |
+|-----|--------|
+| `Up` / `Down` | Navigate |
+| `Enter` | Expand/collapse node, or enqueue track |
+| `f` | Filter library (type to search) |
+| `Esc` | Exit library browser |
+
+---
+
+## Queue edit mode (`e`)
+
+| Key | Action |
+|-----|--------|
+| `Up` / `Down` | Navigate |
+| `Shift+Up` / `Shift+Down` | Extend selection |
+| `d` | Remove selected track(s) |
+| `j` | Move selected down |
+| `k` | Move selected up |
+| `Ctrl+Z` | Undo |
+| `Ctrl+Y` | Redo |
+| `space` | Context menu (organize) |
+| `g` | Jump to start |
+| `G` | Jump to end (shift-extends selection) |
+| `PgUp` / `PgDn` | Page up / page down |
+| `Esc` | Exit edit mode |
+
+### Mouse in edit mode
+
+| Action | Effect |
+|--------|--------|
+| Click | Select track |
+| `Option`-click | Toggle individual selection |
+| `Ctrl`-click | Range select |
+| Drag | Reorder selected tracks |
+| Drag group | Move all selected together |
+
+---
+
+## Mouse (works in any mode)
+
+Mouse controls are always available -- keyboard modality only affects keyboard shortcuts.
+
+| Action | Effect |
+|--------|--------|
+| Double-click queue track | Skip to that track (forward or backward) |
+| Double-click downloading track | Prioritize download and play when ready |
+| Click seek bar | Jump to position |
+| Scroll wheel in queue | Scroll queue |
+| Click scrollbar | Jump scroll position |
+| Drag scrollbar | Drag scroll position |
+| Single-click in queue | Select track |
+| Drag in queue | Reorder |
+
+### Finder drag & drop
+
+Drag files or folders from macOS Finder into the terminal window to add them to the queue.
+
+---
+
+## Queue display reference
+
+Tracks are grouped by album with headers showing album artist, year, album title, and codec. Track artist is shown inline only when it differs from the album artist (compilations, VA albums). Downloading tracks show progress percentage, waiting tracks show braille spinners.
+
+```
+ Limewax -- (2007) Therapy Session 4 [FLAC]
+   > 01 Agent Orange                              4:56
+     02 Pigeons and Marshmellows feat. The Panacea 2:53
+     03 SPL -- Fade                                1:52
+     04 Icicle                                     2:27
+```


### PR DESCRIPTION
## Summary

- Slimmed README from 740 to 184 lines: hook, install, 30-sec quickstart, feature list, comparison tables, doc index
- Created 12 new doc pages under `docs/`: getting-started tutorial, 6 guides (radio, remote, file-org, GraphQL, MCP, headless), 3 references (config, keybindings, CLI), 2 recipes (troubleshooting, cache)
- Documented 5 previously undocumented config fields: `ticker_fps`, `target_fps`, `show_fps`, `art_size`, `output_device`

## Test plan

- [ ] All cross-document links resolve correctly
- [ ] README renders correctly on GitHub
- [ ] No content lost from the original README (everything moved to appropriate doc pages)
- [ ] Config reference covers all fields in `PlaybackConfig` struct

🤖 Generated with [Claude Code](https://claude.com/claude-code)