### PR TITLE
fix(docs): remove hallucinated content, fix inaccuracies in PR #112

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v0.18.3 (2026-03-28)
+
+### Fixed
+
+- **Docs: `koan --mcp` → `koan mcp`** — MCP is a subcommand, not a flag. Fixed in CLI reference, GraphQL API, MCP integration guide, and README
+- **Docs: removed hallucinated Docker sections** — no Docker image exists. Removed from headless server guide and configuration reference
+- **Docs: GraphQL operations table** — fixed snake_case names to match actual camelCase schema, added missing queries (track, randomTracks, fuzzySearch, lyrics, similarTracks, coverArt, radioStatus, similarArtists, playHistory) and mutations (organizePreview/Execute/Undo, triggerScan, triggerRemoteSync, createShare, toggleFavourite, undo/redo, moveInQueue, clearDevice)
+- **Docs: radio mode scoring signals** — replaced inaccurate "cached Subsonic artist relationships" with the actual implementation: live ListenBrainz ML similarity + MusicBrainz relationship lookups (both with local caching), plus Subsonic, genre/era, acoustic, and random fallback signals
+- **Docs: missing CLI commands** — added `koan analyze`, `koan completions`, `scan --force`, `scan [PATH]`
+- **Docs: missing V keybinding** — added visualizer toggle (`V`) to keybindings reference
+
 ## v0.18.2 (2026-03-28)
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -68,12 +68,12 @@ Local and remote tracks merge into one library. Local files take playback priori
 - **Format support** -- FLAC, MP3, AAC, Vorbis, Opus, ALAC, WavPack, WAV/AIFF (via Symphonia)
 - **Full-screen TUI** -- transport bar with album art, album-grouped queue, fuzzy picker, library browser, track info modal, spectrum analyzer, lyrics panel, mouse support
 - **Subsonic/Navidrome** -- incremental sync, unified local+remote browsing, streaming playback, favourite sync
-- **Radio mode** -- infinite play using Subsonic similarity, cached artist relationships, and genre matching
+- **Radio mode** -- infinite play using ListenBrainz/MusicBrainz similarity, Subsonic recommendations, genre matching, and acoustic analysis
 - **ReplayGain** -- track and album modes with peak limiting and configurable pre-amp
 - **Format strings** -- fb2k-compatible `%field%`, `[conditionals]`, `$functions()` for display and file organization
 - **File organization** -- rename/reorganize your library from inside the TUI using format string patterns
 - **GraphQL API** -- full programmatic control alongside the TUI, or headless. Relay pagination, rich filters, mutations for everything
-- **MCP server** -- `koan --mcp` exposes the player to Claude Desktop via Model Context Protocol
+- **MCP server** -- `koan mcp` exposes the player to Claude Desktop via Model Context Protocol
 - **Queue management** -- undo/redo (100-deep), multi-select, drag-reorder, Finder drag & drop, session persistence
 - **SQLite FTS5 search** -- full-text search across your entire library
 - **Media keys** -- macOS Control Center integration (play/pause, next/prev, now playing info)

--- a/docs/guide/graphql-api.md
+++ b/docs/guide/graphql-api.md
@@ -105,15 +105,31 @@ All string filters are case-insensitive substrings. Relay-style cursor paginatio
 
 ## Available operations
 
+### Queries
+
+| Category | Operations |
+|----------|-----------|
+| **Library** | `artists`, `albums`, `tracks`, `track`, `randomTracks`, `fuzzySearch`, `libraryStats` |
+| **Playback** | `nowPlaying`, `queue`, `devices`, `lyrics`, `coverArt` |
+| **Favourites** | `favourites` |
+| **Snapshots** | `snapshots` |
+| **Radio** | `radioStatus`, `similarTracks`, `similarArtists` |
+| **History** | `playHistory` |
+
+### Mutations
+
 | Category | Operations |
 |----------|-----------|
 | **Playback** | `play`, `pause`, `resume`, `stop`, `next`, `previous`, `seek` |
-| **Queue** | `add_to_queue`, `insert_in_queue`, `remove_from_queue`, `clear_queue`, `replace_queue`, `get_queue`, `reorder_queue` |
-| **Library** | `search`, `list_artists`, `list_albums`, `list_tracks`, `get_track`, `library_stats` |
-| **State** | `now_playing`, `list_devices`, `set_device` |
-| **Favourites** | `favourite`, `unfavourite`, `list_favourites` |
-| **Snapshots** | `save_snapshot`, `restore_snapshot`, `list_snapshots`, `delete_snapshot` |
-| **Radio** | `enable_radio`, `disable_radio` |
+| **Queue** | `addToQueue`, `replaceQueue`, `removeFromQueue`, `moveInQueue`, `clearQueue` |
+| **Device** | `setDevice`, `clearDevice` |
+| **Favourites** | `favourite`, `unfavourite`, `toggleFavourite` |
+| **Snapshots** | `saveSnapshot`, `restoreSnapshot`, `deleteSnapshot` |
+| **Radio** | `enableRadio`, `disableRadio` |
+| **Organize** | `organizePreview`, `organizeExecute`, `organizeUndo` |
+| **Library** | `triggerScan`, `triggerRemoteSync` |
+| **Sharing** | `createShare` |
+| **Undo** | `undo`, `redo` |
 
 ## Subsonic REST API
 
@@ -127,4 +143,4 @@ This runs on a separate port from the GraphQL API. Useful for connecting Subsoni
 
 ## MCP server
 
-The MCP server (`koan --mcp`) uses the same GraphQL schema in-process (no HTTP round-trip). See [MCP Integration](mcp-integration.md) for Claude Desktop setup.
+The MCP server (`koan mcp`) uses the same GraphQL schema in-process (no HTTP round-trip). See [MCP Integration](mcp-integration.md) for Claude Desktop setup.

--- a/docs/guide/headless-server.md
+++ b/docs/guide/headless-server.md
@@ -55,21 +55,6 @@ export KOAN_GRAPHQL__BIND=0.0.0.0
 export KOAN_GRAPHQL__PLAYGROUND=true
 ```
 
-## Docker
-
-```bash
-docker run -e KOAN_REMOTE__ENABLED=true \
-           -e KOAN_REMOTE__URL=https://music.example.com \
-           -e KOAN_REMOTE__USERNAME=admin \
-           -e KOAN_REMOTE__PASSWORD="$NAVIDROME_PASSWORD" \
-           -e KOAN_GRAPHQL__BIND=0.0.0.0 \
-           -e KOAN_GRAPHQL__PORT=4000 \
-           -p 4000:4000 \
-           koan --headless
-```
-
-All config fields are overridable via `KOAN_*` environment variables. See [Configuration](../reference/configuration.md) for the full list.
-
 ## Remote TUI
 
 Connect a TUI from another machine to a running headless koan:

--- a/docs/guide/mcp-integration.md
+++ b/docs/guide/mcp-integration.md
@@ -1,6 +1,6 @@
 # MCP Integration
 
-`koan --mcp` runs koan as a headless player controllable by Claude Desktop (or any MCP client). No TUI, no terminal -- just the audio engine and 2 tools exposed over the Model Context Protocol on stdio. The LLM reads the GraphQL schema, then drives everything through one `graphql` tool.
+`koan mcp` runs koan as a headless player controllable by Claude Desktop (or any MCP client). No TUI, no terminal -- just the audio engine and 2 tools exposed over the Model Context Protocol on stdio. The LLM reads the GraphQL schema, then drives everything through one `graphql` tool.
 
 ## Setup
 
@@ -13,7 +13,7 @@
   "mcpServers": {
     "koan": {
       "command": "koan",
-      "args": ["--mcp"]
+      "args": ["mcp"]
     }
   }
 }
@@ -26,7 +26,7 @@ If koan isn't on Claude Desktop's PATH (common with Homebrew or mise), use the f
   "mcpServers": {
     "koan": {
       "command": "/opt/homebrew/bin/koan",
-      "args": ["--mcp"]
+      "args": ["mcp"]
     }
   }
 }

--- a/docs/guide/radio-mode.md
+++ b/docs/guide/radio-mode.md
@@ -10,15 +10,19 @@ Press `R` in the TUI to toggle radio mode. That's it. koan starts adding tracks 
 
 Radio mode uses a multi-signal scoring system to find tracks similar to what you're currently listening to:
 
-1. **Subsonic similarity** (`use_subsonic`) -- if you have a remote server configured, koan queries `getSimilarSongs2` for server-side recommendations. This is the strongest signal when available.
+1. **ListenBrainz similar artists** -- ML-based artist similarity fetched live from the ListenBrainz API. Results are cached locally so subsequent lookups are instant.
 
-2. **Cached artist relationships** -- koan builds a local cache of "similar artist" relationships from your Subsonic server. Even when offline, these cached relationships inform radio selections.
+2. **MusicBrainz relationships** -- fetches artist relationships (collaborators, band members, associated acts) from the MusicBrainz API via MBID lookups. Also cached locally. Rate-limited per MusicBrainz terms of service.
 
-3. **Genre matching** -- tracks sharing genres with the current seed tracks get a relevance boost.
+3. **Subsonic similarity** (`use_subsonic`) -- if you have a remote server configured, koan queries `getSimilarSongs2` for server-side recommendations and caches the results.
 
-4. **Artist matching** -- other tracks by the same artist (or similar artists) score higher.
+4. **Genre and era matching** -- tracks sharing genres and release era with the current seed tracks get a relevance boost.
 
-5. **Acoustic similarity** -- if you've run `koan scan --analyze`, radio mode factors in acoustic features (tempo, energy, spectral characteristics). Control the weight with `[discovery] acoustic_weight`.
+5. **Same-artist tracks** -- other tracks by the same artist or related artists score higher. Local library fallback when external APIs aren't available.
+
+6. **Acoustic similarity** -- if you've run `koan scan --analyze`, radio mode factors in acoustic features (spectral centroid, energy, tempo) via vector KNN. Control the weight with `[discovery] acoustic_weight`.
+
+7. **Random library tracks** -- final fallback when other signals don't produce enough candidates.
 
 The scoring system blends these signals and avoids repeating recently-played tracks (controlled by `history_window`).
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -39,7 +39,7 @@ koan --server http://host:4000 --jukebox  # remote control only
 ### MCP server
 
 ```bash
-koan --mcp                        # MCP server on stdio (Claude Desktop)
+koan mcp                          # MCP server on stdio (Claude Desktop)
 ```
 
 See [MCP Integration](../guide/mcp-integration.md) for setup instructions.
@@ -66,10 +66,12 @@ Scan configured library folders and index metadata.
 
 ```bash
 koan scan                         # standard metadata scan
+koan scan /path/to/music          # scan a specific directory
+koan scan --force                 # force re-scan of all files (ignore cache)
 koan scan --analyze               # scan + acoustic analysis in one pass
 ```
 
-Scanning runs in parallel using rayon. Subsequent scans are incremental -- only new or modified files are re-indexed (based on mtime + size from the scan cache).
+Scanning runs in parallel using rayon. Subsequent scans are incremental -- only new or modified files are re-indexed (based on mtime + size from the scan cache). Use `--force` to bypass the cache and re-index everything.
 
 The `--analyze` flag computes acoustic features for radio mode similarity scoring. This is slower than a plain scan.
 
@@ -163,19 +165,39 @@ Displays codec, sample rate, bit depth, channels, duration, and tag summary.
 
 ---
 
-## Shell completions
+## `koan analyze`
 
-Dynamic completions that know your library -- artist/album IDs tab-complete from the database.
+Run acoustic analysis on the library for similarity features (used by radio mode).
+
+```bash
+koan analyze
+```
+
+This computes spectral centroid, energy, and tempo estimates for each track. Equivalent to running `koan scan --analyze` but without re-scanning metadata -- useful when your library is already indexed and you just want to add acoustic data.
+
+---
+
+## `koan completions`
+
+Generate static shell completion scripts for the CLI structure.
+
+```bash
+koan completions zsh              # zsh completions
+koan completions bash             # bash completions
+koan completions fish             # fish completions
+```
+
+Add to your shell config:
 
 ```bash
 # zsh (add to .zshrc)
-source <(COMPLETE=zsh koan)
+source <(koan completions zsh)
 
 # bash
-source <(COMPLETE=bash koan)
+source <(koan completions bash)
 
 # fish
-COMPLETE=fish koan | source
+koan completions fish | source
 ```
 
-Then `koan --album <TAB>` shows your actual albums with artist names.
+koan also supports dynamic completions that know your library -- artist/album IDs tab-complete from the database. These are activated automatically via the `COMPLETE` env var when using a compatible shell.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -51,21 +51,9 @@ Field names match the TOML key in SCREAMING_SNAKE_CASE. Nested sections use `__`
 - `[graphql] subsonic_port` -> `KOAN_GRAPHQL__SUBSONIC_PORT`
 - `[playback] pre_amp_db` -> `KOAN_PLAYBACK__PRE_AMP_DB`
 
-## Docker / CI usage
+## CI usage
 
-Env vars make koan easy to configure in containers and CI without config files:
-
-```bash
-# Docker -- headless server with remote backend
-docker run -e KOAN_REMOTE__ENABLED=true \
-           -e KOAN_REMOTE__URL=https://music.example.com \
-           -e KOAN_REMOTE__USERNAME=admin \
-           -e KOAN_REMOTE__PASSWORD="$NAVIDROME_PASSWORD" \
-           -e KOAN_GRAPHQL__BIND=0.0.0.0 \
-           -e KOAN_GRAPHQL__PORT=4000 \
-           -p 4000:4000 \
-           koan --headless
-```
+Env vars make koan easy to configure in CI without config files:
 
 ```yaml
 # CI -- run tests against a specific config

--- a/docs/reference/keybindings.md
+++ b/docs/reference/keybindings.md
@@ -37,6 +37,7 @@ Every key in every mode. The hint bar at the bottom of the TUI shows available k
 | `i` | Track info modal (codec, sample rate, cover art) |
 | `z` | Zoom album art |
 | `L` | Toggle lyrics panel |
+| `V` | Toggle visualizer |
 | `R` | Toggle radio mode |
 | `f` | Favourite / unfavourite current track |
 | `q` | Quit |


### PR DESCRIPTION
## Summary

- **`koan --mcp` → `koan mcp`** — MCP is a subcommand, not a flag. Fixed across CLI ref, GraphQL API, MCP integration guide, Claude Desktop JSON examples, and README
- **Removed hallucinated Docker sections** — no Docker image exists. Removed from headless-server.md and configuration.md
- **Fixed GraphQL operations table** — snake_case → camelCase to match actual schema, added 18 missing queries/mutations (track, randomTracks, fuzzySearch, lyrics, similarTracks, coverArt, organizePreview/Execute/Undo, triggerScan, triggerRemoteSync, createShare, etc.)
- **Fixed radio mode scoring signals** — replaced inaccurate "cached Subsonic artist relationships" with actual implementation: live ListenBrainz ML similarity + MusicBrainz relationship lookups (both with local caching), 7 signals total
- **Added missing CLI commands** — `koan analyze`, `koan completions`, `scan --force`, `scan [PATH]`
- **Added missing V keybinding** — visualizer toggle to keybindings reference

## Test plan

- [ ] Verify all `koan mcp` references match actual CLI (`koan mcp` subcommand exists)
- [ ] Verify no remaining `koan --mcp` in docs
- [ ] Verify no remaining Docker references in headless-server.md or configuration.md
- [ ] Verify GraphQL operations match actual schema in `crates/koan-music/src/commands/graphql/`
- [ ] Verify radio scoring signals match `crates/koan-core/src/` radio implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)