### PR TITLE
fix(audio): decode thread exit detection, session restore double-start, skip debounce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- **Audio seize-up at album transitions** — when the gapless decode loop exhausted the playlist, the Player had no way to know playback finished. Audio engine kept running, outputting silence. Now the decode thread signals `DecodeFinished` and the Player auto-advances or stops cleanly
+- **Double engine restart at session restore** — startup sent Play+Pause+Seek, causing three engine teardown/rebuild cycles. Now sets cursor without playback; the deferred seek is the single start point
+- **Key repeat rapid-skipping** — terminal key repeat on `>`/`<` could fire dozens of NextTrack/PrevTrack commands. Added 150ms debounce in the Player command loop
+
+### Changed
+
+- **Now-playing queue indicator** — playing track now shows ▶ instead of `>`, with bold title text for visibility
+
 ## v0.18.3 (2026-04-01)
 
 ### Changed

--- a/crates/koan-core/src/audio/buffer.rs
+++ b/crates/koan-core/src/audio/buffer.rs
@@ -310,7 +310,7 @@ fn probe_mss(mss: MediaSourceStream, hint: &Hint) -> Result<StreamInfo, DecodeEr
 /// `next_track` — closure returning the next `SourceEntry` for gapless playback.
 ///                Called on EOF. Returns None when the playlist is exhausted.
 #[allow(clippy::too_many_arguments)]
-pub fn start_decode<N>(
+pub fn start_decode<N, F>(
     first: SourceEntry,
     producer: rtrb::Producer<f32>,
     seek_ms: u64,
@@ -319,9 +319,11 @@ pub fn start_decode<N>(
     viz_buffer: Option<Arc<VizBuffer>>,
     rg_mode: ReplayGainMode,
     pre_amp_db: f64,
+    on_finished: F,
 ) -> Result<(StreamInfo, DecodeHandle), DecodeError>
 where
     N: Fn() -> Option<SourceEntry> + Send + 'static,
+    F: FnOnce() + Send + 'static,
 {
     let stop = Arc::new(AtomicBool::new(false));
     let stop_clone = stop.clone();
@@ -340,6 +342,12 @@ where
                 rg_mode,
                 pre_amp_db,
             );
+            // Notify the player that the decode loop finished (playlist
+            // exhausted or error). Only fire if we weren't explicitly stopped
+            // (i.e. this is a natural end, not a seek/skip teardown).
+            if !stop_clone.load(Ordering::Relaxed) {
+                on_finished();
+            }
         })
         .map_err(DecodeError::Io)?;
 
@@ -372,7 +380,7 @@ where
 /// `seek_ms` — if > 0, seek to this position before decoding the first track.
 /// `next_track` — closure returning the next (id, path) for gapless playback.
 #[allow(clippy::too_many_arguments)]
-pub fn start_decode_file<N>(
+pub fn start_decode_file<N, F>(
     initial_id: QueueItemId,
     path: &Path,
     producer: rtrb::Producer<f32>,
@@ -382,9 +390,11 @@ pub fn start_decode_file<N>(
     viz_buffer: Option<Arc<VizBuffer>>,
     rg_mode: ReplayGainMode,
     pre_amp_db: f64,
+    on_finished: F,
 ) -> Result<(StreamInfo, DecodeHandle), DecodeError>
 where
     N: Fn() -> Option<(QueueItemId, PathBuf)> + Send + 'static,
+    F: FnOnce() + Send + 'static,
 {
     let info = probe_file(path)?;
     let first = SourceEntry::from_file(initial_id, path.to_path_buf());
@@ -400,6 +410,7 @@ where
         viz_buffer,
         rg_mode,
         pre_amp_db,
+        on_finished,
     )?;
     Ok((info, handle))
 }

--- a/crates/koan-core/src/player/commands.rs
+++ b/crates/koan-core/src/player/commands.rs
@@ -44,6 +44,8 @@ pub enum PlayerCommand {
     TrackReady(QueueItemId),
     /// Enough data buffered for streaming playback — check if cursor is waiting.
     TrackStreamReady(QueueItemId),
+    /// Decode thread exhausted the playlist — auto-advance or stop.
+    DecodeFinished,
     /// Undo the last reversible playlist operation.
     Undo,
     /// Redo the last undone operation.

--- a/crates/koan-core/src/player/mod.rs
+++ b/crates/koan-core/src/player/mod.rs
@@ -49,6 +49,8 @@ pub struct Player {
     output_device_name: Option<String>,
     /// Platform audio backend (CoreAudio on macOS, cpal on Linux).
     backend: Box<dyn AudioBackend>,
+    /// Debounce: timestamp of last NextTrack/PrevTrack to suppress key repeat.
+    last_skip: std::time::Instant,
 }
 
 /// Holds the resources for an active playback session.
@@ -86,6 +88,7 @@ impl Player {
             batch_buffer: None,
             output_device_name: cfg.playback.output_device.clone(),
             backend: crate::audio::platform_backend(),
+            last_skip: std::time::Instant::now(),
         }
     }
 
@@ -311,6 +314,7 @@ impl Player {
         let rg_mode = cfg.playback.replaygain;
         let pre_amp_db = cfg.playback.pre_amp_db;
 
+        let finish_tx = self.commands.tx.clone();
         let (_stream_info, decode_handle) = buffer::start_decode_file(
             id,
             path,
@@ -321,6 +325,9 @@ impl Player {
             Some(self.viz_buffer.clone()),
             rg_mode,
             pre_amp_db,
+            move || {
+                finish_tx.send(PlayerCommand::DecodeFinished).ok();
+            },
         )?;
 
         // Create and start audio engine with the timeline's sample counter.
@@ -528,6 +535,7 @@ impl Player {
         let rg_mode = cfg.playback.replaygain;
         let pre_amp_db = cfg.playback.pre_amp_db;
 
+        let finish_tx = self.commands.tx.clone();
         let (_stream_info, decode_handle) = buffer::start_decode(
             first,
             producer,
@@ -540,6 +548,9 @@ impl Player {
             Some(self.viz_buffer.clone()),
             rg_mode,
             pre_amp_db,
+            move || {
+                finish_tx.send(PlayerCommand::DecodeFinished).ok();
+            },
         )?;
 
         let actual_rate = self
@@ -871,6 +882,24 @@ impl Player {
         }
     }
 
+    /// Decode thread naturally finished (playlist exhausted or error).
+    /// Try to advance to the next Ready track; otherwise stop cleanly.
+    fn on_decode_finished(&mut self) {
+        log::info!("decode finished, checking for next track");
+        match self.shared_state.advance_cursor() {
+            Some((id, path)) => {
+                if let Err(e) = self.start_playback(id, &path, 0) {
+                    log::error!("auto-advance after decode finished failed: {}", e);
+                    self.stop_playback_and_clear_state();
+                }
+            }
+            None => {
+                log::info!("no more tracks — stopping");
+                self.stop_playback_and_clear_state();
+            }
+        }
+    }
+
     /// Route an undo entry to the batch buffer (if batching) or the undo stack.
     fn push_undo(&mut self, entry: UndoEntry) {
         if let Some(ref mut batch) = self.batch_buffer {
@@ -888,8 +917,21 @@ impl Player {
             PlayerCommand::Resume => self.resume(),
             PlayerCommand::Stop => self.stop(),
             PlayerCommand::Seek(pos) => self.seek(pos),
-            PlayerCommand::NextTrack => self.next_track(),
-            PlayerCommand::PrevTrack => self.prev_track(),
+            PlayerCommand::NextTrack => {
+                // Debounce: suppress key repeat from terminal (150ms window).
+                let now = std::time::Instant::now();
+                if now.duration_since(self.last_skip).as_millis() >= 150 {
+                    self.last_skip = now;
+                    self.next_track();
+                }
+            }
+            PlayerCommand::PrevTrack => {
+                let now = std::time::Instant::now();
+                if now.duration_since(self.last_skip).as_millis() >= 150 {
+                    self.last_skip = now;
+                    self.prev_track();
+                }
+            }
             PlayerCommand::AddToPlaylist(items) => {
                 let ids: Vec<QueueItemId> = items.iter().map(|i| i.id).collect();
                 self.shared_state.add_items(items);
@@ -960,6 +1002,7 @@ impl Player {
                 self.push_undo(UndoEntry::MovedBatch { entries });
             }
             PlayerCommand::TrackReady(id) => self.track_ready(id),
+            PlayerCommand::DecodeFinished => self.on_decode_finished(),
             PlayerCommand::TrackStreamReady(id) => self.track_stream_ready(id),
             PlayerCommand::Undo => self.execute_undo(),
             PlayerCommand::Redo => self.execute_redo(),

--- a/crates/koan-music/src/commands/play.rs
+++ b/crates/koan-music/src/commands/play.rs
@@ -217,11 +217,12 @@ pub fn cmd_play(
             });
             tx.send(PlayerCommand::AddToPlaylist(items))
                 .expect("player thread died");
-            // Set cursor without starting playback (paused restore).
+            // Set cursor without starting playback — the TUI's deferred seek
+            // will start the engine at the saved position. This avoids the
+            // double-start bug where Play+Pause+Seek caused three engine
+            // restarts at startup.
             if let Some(cid) = cursor_id {
-                tx.send(PlayerCommand::Play(cid))
-                    .expect("player thread died");
-                tx.send(PlayerCommand::Pause).expect("player thread died");
+                state.set_cursor(Some(cid));
                 restored_position_ms = Some(persisted.position_ms);
             }
             expects_playback = true;
@@ -499,12 +500,20 @@ fn run_tui(
         // 4. Always tick.
         app.handle_tick();
 
-        // Deferred seek: once the player has track_info (i.e. audio is loaded), seek to
-        // the persisted position. This must wait for the decode thread to start.
+        // Deferred restore: once the cursor item is Ready (file exists or downloaded),
+        // start playback at the saved position then immediately pause.
+        // This is a single Play+Seek+Pause instead of the old Play+Pause+Seek
+        // which caused a double-start bug (three engine restarts at startup).
         if let Some(pos) = pending_seek
-            && app.state.track_info().is_some()
+            && let Some(cid) = app.state.cursor()
+            && app
+                .state
+                .item_load_state(cid)
+                .is_some_and(|s| matches!(s, LoadState::Ready))
         {
+            tx.send(PlayerCommand::Play(cid)).ok();
             tx.send(PlayerCommand::Seek(pos)).ok();
+            tx.send(PlayerCommand::Pause).ok();
             pending_seek = None;
         }
 

--- a/crates/koan-music/src/remote_bridge.rs
+++ b/crates/koan-music/src/remote_bridge.rs
@@ -402,7 +402,8 @@ fn command_loop(
             | PlayerCommand::MoveInPlaylist { .. }
             | PlayerCommand::MoveItemsInPlaylist { .. }
             | PlayerCommand::InsertInPlaylist { .. }
-            | PlayerCommand::AddToPlaylist(_) => {
+            | PlayerCommand::AddToPlaylist(_)
+            | PlayerCommand::DecodeFinished => {
                 log::debug!("ignoring {:?} in remote mode", cmd);
             }
         }

--- a/crates/koan-music/src/tui/queue.rs
+++ b/crates/koan-music/src/tui/queue.rs
@@ -374,7 +374,7 @@ fn render_track_line<'a>(
 
     let status_icon = match entry.status {
         QueueEntryStatus::Queued => Span::raw(" "),
-        QueueEntryStatus::Playing => Span::styled(">", theme.track_playing),
+        QueueEntryStatus::Playing => Span::styled("\u{25b6}", theme.track_playing),
         QueueEntryStatus::Played => {
             if is_selected {
                 Span::styled(" ", theme.track_selected)
@@ -458,12 +458,17 @@ fn render_track_line<'a>(
         Span::raw(" ")
     };
 
+    let is_playing = matches!(entry.status, QueueEntryStatus::Playing);
     let title_style = if is_cursor {
         theme.track_cursor
     } else if is_selected {
         theme.track_selected
     } else if is_hovered {
         theme.track_hover
+    } else if is_playing {
+        theme
+            .track_playing
+            .add_modifier(ratatui::style::Modifier::BOLD)
     } else {
         theme.track_normal
     };


### PR DESCRIPTION
## Summary

- **Decode thread signals completion** — when `decode_queue_loop` exhausts the playlist, it sends `DecodeFinished` to the Player. Player auto-advances to next Ready track or stops cleanly. Previously, the Player had no idea the decode thread exited — audio engine kept running, outputting silence forever (the "seize up" bug)
- **Session restore single-start** — startup no longer sends Play+Pause+Seek (three engine teardown/rebuild cycles). Sets cursor directly via shared state; the TUI's deferred seek is the single playback start point
- **NextTrack/PrevTrack 150ms debounce** — prevents terminal key repeat from rapid-fire skipping through the queue
- **Now-playing indicator** — ▶ instead of `>`, bold title text

## Test plan

- [x] `cargo test --workspace` — 96 passed
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [ ] Start koan with persisted queue near end of track — verify single "playing:" log, clean transition
- [ ] Hold `>` key — verify tracks skip at ~150ms intervals, not 80ms bursts
- [ ] Let an album finish naturally — verify auto-advance to next queue item or clean stop

🤖 Generated with [Claude Code](https://claude.com/claude-code)