### PR TITLE
release: v0.18.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.18.5 (2026-04-05)
+
+### Fixed
+
+- **Hi-res audio playing at wrong speed** — CoreAudio sample rate switches are asynchronous, but the player read back the device rate immediately after requesting the change and got the *old* rate. A fallback (`unwrap_or(source_rate)`) then masked the mismatch by lying to the ASBD. Result: 96kHz files played at quarter speed (device still clocked at the old rate, draining the ring buffer too slowly). `set_device_sample_rate` now polls until CoreAudio confirms the switch (10ms intervals, 2s timeout) and returns the verified rate. Both file and streaming playback paths fixed. ([#124](https://github.com/radiosilence/koan/pull/124))
+
 ## v0.18.4 (2026-04-01)
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2002,7 +2002,7 @@ dependencies = [
 
 [[package]]
 name = "koan-core"
-version = "0.18.4"
+version = "0.18.5"
 dependencies = [
  "bliss-audio",
  "bliss-audio-aubio-rs",
@@ -2037,7 +2037,7 @@ dependencies = [
 
 [[package]]
 name = "koan-music"
-version = "0.18.4"
+version = "0.18.5"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/koan-core", "crates/koan-music"]
 
 [workspace.package]
-version = "0.18.4"
+version = "0.18.5"
 edition = "2024"
 homepage = "https://github.com/radiosilence/koan"
 repository = "https://github.com/radiosilence/koan"

--- a/crates/koan-core/src/audio/backend.rs
+++ b/crates/koan-core/src/audio/backend.rs
@@ -45,8 +45,9 @@ pub trait AudioBackend: Send + Sync {
     fn get_device_sample_rate(&self, device: &DeviceInfo) -> Result<f64, BackendError>;
 
     /// Set the nominal sample rate of a device (for bit-perfect matching).
+    /// Returns the actual device rate after the switch (may differ if unsupported).
     /// On Linux/cpal this is a no-op — the rate is set at stream creation.
-    fn set_device_sample_rate(&self, device: &DeviceInfo, rate: f64) -> Result<(), BackendError>;
+    fn set_device_sample_rate(&self, device: &DeviceInfo, rate: f64) -> Result<f64, BackendError>;
 
     /// Create an audio engine targeting a device at a specific format.
     /// Takes ownership of the rtrb consumer.

--- a/crates/koan-core/src/audio/coreaudio_backend.rs
+++ b/crates/koan-core/src/audio/coreaudio_backend.rs
@@ -50,7 +50,7 @@ impl AudioBackend for CoreAudioBackend {
         device::get_device_sample_rate(id).map_err(|e| BackendError::Platform(e.to_string()))
     }
 
-    fn set_device_sample_rate(&self, device: &DeviceInfo, rate: f64) -> Result<(), BackendError> {
+    fn set_device_sample_rate(&self, device: &DeviceInfo, rate: f64) -> Result<f64, BackendError> {
         let id = device.platform_id as u32;
         device::set_device_sample_rate(id, rate).map_err(|e| BackendError::Platform(e.to_string()))
     }

--- a/crates/koan-core/src/audio/cpal_backend.rs
+++ b/crates/koan-core/src/audio/cpal_backend.rs
@@ -160,10 +160,12 @@ impl AudioBackend for CpalBackend {
         Ok(config.sample_rate().0 as f64)
     }
 
-    fn set_device_sample_rate(&self, _device: &DeviceInfo, _rate: f64) -> Result<(), BackendError> {
+    fn set_device_sample_rate(&self, device: &DeviceInfo, rate: f64) -> Result<f64, BackendError> {
         // On Linux, sample rate is set at stream creation time.
         // This is a no-op — the rate will be applied in `create_engine`.
-        Ok(())
+        // Return the requested rate since cpal handles it at stream creation.
+        let _ = device;
+        Ok(rate)
     }
 
     fn create_engine(
@@ -304,7 +306,9 @@ mod tests {
             sample_rates: vec![44100.0],
             platform_id: 0,
         };
-        assert!(backend.set_device_sample_rate(&dummy, 96000.0).is_ok());
+        let result = backend.set_device_sample_rate(&dummy, 96000.0);
+        assert!(result.is_ok());
+        assert!((result.unwrap() - 96000.0).abs() < 0.1);
     }
 
     #[test]

--- a/crates/koan-core/src/audio/device.rs
+++ b/crates/koan-core/src/audio/device.rs
@@ -255,7 +255,11 @@ pub fn find_output_device_by_name(name: &str) -> Result<AudioDeviceID> {
 }
 
 /// Set the nominal sample rate of a device (for bit-perfect matching).
-pub fn set_device_sample_rate(device_id: AudioDeviceID, rate: f64) -> Result<()> {
+///
+/// CoreAudio rate changes are asynchronous — the device needs time to physically
+/// reclock. This function polls until the device confirms the new rate or a
+/// timeout expires. Returns the actual device rate after the attempt.
+pub fn set_device_sample_rate(device_id: AudioDeviceID, rate: f64) -> Result<f64> {
     let property = AudioObjectPropertyAddress {
         mSelector: kAudioDevicePropertyNominalSampleRate,
         mScope: kAudioObjectPropertyScopeGlobal,
@@ -272,5 +276,25 @@ pub fn set_device_sample_rate(device_id: AudioDeviceID, rate: f64) -> Result<()>
             mem::size_of::<f64>() as u32,
             &rate as *const _ as *const _,
         )
-    })
+    })?;
+
+    // Poll until the device confirms the rate switch or we time out.
+    // Most DACs complete the switch in 10–50ms; USB devices can take longer.
+    const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(10);
+    const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+    let start = std::time::Instant::now();
+
+    loop {
+        let actual = get_device_sample_rate(device_id)?;
+        if (actual - rate).abs() < 0.1 {
+            return Ok(actual);
+        }
+        if start.elapsed() >= TIMEOUT {
+            log::warn!(
+                "device sample rate switch timed out: requested {rate}Hz, device reports {actual}Hz"
+            );
+            return Ok(actual);
+        }
+        std::thread::sleep(POLL_INTERVAL);
+    }
 }

--- a/crates/koan-core/src/player/mod.rs
+++ b/crates/koan-core/src/player/mod.rs
@@ -272,19 +272,34 @@ impl Player {
         let device_rate = self.backend.get_device_sample_rate(&device)?;
         let source_rate = info.sample_rate as f64;
 
-        if (device_rate - source_rate).abs() > 0.1 {
+        let actual_rate = if (device_rate - source_rate).abs() > 0.1 {
             log::info!(
                 "switching device sample rate: {}Hz → {}Hz",
                 device_rate,
                 source_rate
             );
-            if let Err(e) = self.backend.set_device_sample_rate(&device, source_rate) {
-                log::warn!(
-                    "failed to set sample rate (continuing at device rate): {}",
-                    e
-                );
+            match self.backend.set_device_sample_rate(&device, source_rate) {
+                Ok(confirmed_rate) => {
+                    if (confirmed_rate - source_rate).abs() > 0.1 {
+                        log::warn!(
+                            "device stayed at {}Hz (wanted {}Hz) — playback will use device rate",
+                            confirmed_rate,
+                            source_rate
+                        );
+                    }
+                    confirmed_rate
+                }
+                Err(e) => {
+                    log::warn!(
+                        "failed to set sample rate (continuing at device rate): {}",
+                        e
+                    );
+                    device_rate
+                }
             }
-        }
+        } else {
+            device_rate
+        };
 
         let (producer, consumer) = rtrb::RingBuffer::new(RING_BUFFER_SIZE);
 
@@ -330,11 +345,7 @@ impl Player {
             },
         )?;
 
-        // Create and start audio engine with the timeline's sample counter.
-        let actual_rate = self
-            .backend
-            .get_device_sample_rate(&device)
-            .unwrap_or(source_rate);
+        // Create and start audio engine with the confirmed device rate.
         let engine = self.backend.create_engine(
             &device,
             actual_rate,
@@ -470,19 +481,34 @@ impl Player {
         let device_rate = self.backend.get_device_sample_rate(&device)?;
         let source_rate = info.sample_rate as f64;
 
-        if (device_rate - source_rate).abs() > 0.1 {
+        let actual_rate = if (device_rate - source_rate).abs() > 0.1 {
             log::info!(
                 "switching device sample rate: {}Hz → {}Hz",
                 device_rate,
                 source_rate
             );
-            if let Err(e) = self.backend.set_device_sample_rate(&device, source_rate) {
-                log::warn!(
-                    "failed to set sample rate (continuing at device rate): {}",
-                    e
-                );
+            match self.backend.set_device_sample_rate(&device, source_rate) {
+                Ok(confirmed_rate) => {
+                    if (confirmed_rate - source_rate).abs() > 0.1 {
+                        log::warn!(
+                            "device stayed at {}Hz (wanted {}Hz) — playback will use device rate",
+                            confirmed_rate,
+                            source_rate
+                        );
+                    }
+                    confirmed_rate
+                }
+                Err(e) => {
+                    log::warn!(
+                        "failed to set sample rate (continuing at device rate): {}",
+                        e
+                    );
+                    device_rate
+                }
             }
-        }
+        } else {
+            device_rate
+        };
 
         let (producer, consumer) = rtrb::RingBuffer::new(RING_BUFFER_SIZE);
 
@@ -553,10 +579,7 @@ impl Player {
             },
         )?;
 
-        let actual_rate = self
-            .backend
-            .get_device_sample_rate(&device)
-            .unwrap_or(source_rate);
+        // Create and start audio engine with the confirmed device rate.
         let engine = self.backend.create_engine(
             &device,
             actual_rate,


### PR DESCRIPTION
## Summary

- **fix(audio): hi-res sample rate switching** — CoreAudio rate changes are async; the player was reading back the old rate immediately and masking the mismatch with `unwrap_or`. 96kHz files played at quarter speed. `set_device_sample_rate` now polls until confirmed (2s timeout). Both file and streaming paths fixed.

## v0.18.5 Changelog

### Fixed

- **Hi-res audio playing at wrong speed** — CoreAudio sample rate switches are asynchronous, but the player read back the device rate immediately after requesting the change and got the *old* rate. A fallback (`unwrap_or(source_rate)`) then masked the mismatch by lying to the ASBD. Result: 96kHz files played at quarter speed (device still clocked at the old rate, draining the ring buffer too slowly). `set_device_sample_rate` now polls until CoreAudio confirms the switch (10ms intervals, 2s timeout) and returns the verified rate. Both file and streaming playback paths fixed.

## Test plan

- [ ] Play a 96kHz FLAC file — should play at correct speed
- [ ] Play a 44.1kHz file after a 96kHz file — rate should switch back cleanly
- [ ] Stream a hi-res track from Navidrome — same fix applies to streaming path
- [ ] Check logs for "switching device sample rate" confirmation messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)