### PR TITLE
release: v0.18.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # Changelog
 
-## Unreleased
+## v0.18.6 (2026-04-05)
 
 ### Fixed
 
-- **`koan play /dir` with large libraries** — for >1000 files, uses a single `all_tracks_by_path` DB query instead of hundreds of batched `WHERE IN` queries. Directory walk + metadata resolution now runs on a background thread so the TUI starts immediately
-- **Organize preview takes minutes on large libraries** — `preview_for_paths` now loads metadata from the DB (single query) instead of re-reading every file's tags from disk. Falls back to parallel disk reads (rayon) for files not in the DB. 48k-track library: ~5 minutes → ~3 seconds
+- **`koan play /dir` with large libraries** — for >1000 files, uses a single `all_tracks_by_path` DB query instead of hundreds of batched `WHERE IN` queries. Directory walk + metadata resolution now runs on a background thread so the TUI starts immediately ([#128](https://github.com/radiosilence/koan/pull/128))
+- **Organize preview takes minutes on large libraries** — `preview_for_paths` now loads metadata from the DB (single query) instead of re-reading every file's tags from disk. Falls back to parallel disk reads (rayon) for files not in the DB. 48k-track library: ~5 minutes → ~3 seconds ([#128](https://github.com/radiosilence/koan/pull/128))
 
 ## v0.18.5 (2026-04-05)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2002,7 +2002,7 @@ dependencies = [
 
 [[package]]
 name = "koan-core"
-version = "0.18.5"
+version = "0.18.6"
 dependencies = [
  "bliss-audio",
  "bliss-audio-aubio-rs",
@@ -2037,7 +2037,7 @@ dependencies = [
 
 [[package]]
 name = "koan-music"
-version = "0.18.5"
+version = "0.18.6"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/koan-core", "crates/koan-music"]
 
 [workspace.package]
-version = "0.18.5"
+version = "0.18.6"
 edition = "2024"
 homepage = "https://github.com/radiosilence/koan"
 repository = "https://github.com/radiosilence/koan"


### PR DESCRIPTION
## v0.18.6

### Fixed
- `koan play /dir` — single DB query + background thread for large libraries
- Organize preview — DB metadata first, parallel rayon fallback. 48k tracks: ~5min → ~3sec

🤖 Generated with [Claude Code](https://claude.com/claude-code)