### PR TITLE
chore: bump version to 0.18.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/koan-core", "crates/koan-music"]
 
 [workspace.package]
-version = "0.18.6"
+version = "0.18.7"
 edition = "2024"
 homepage = "https://github.com/radiosilence/koan"
 repository = "https://github.com/radiosilence/koan"


### PR DESCRIPTION
## Summary
- Bump workspace version to 0.18.7 to trigger CI release with binaries

Includes changes from #131 (CoreAudio property listener refactor).