### PR TITLE
chore: fix changelog heading for v0.18.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.18.7 (2026-04-05)
 
 ### Changed
 


### PR DESCRIPTION
Replaces `## Unreleased` with `## v0.18.7 (2026-04-05)`.