### PR TITLE
release: v0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,10 @@
 # Changelog
 
-## Unreleased
+## v0.19.0 (2026-04-06)
 
 ### Added
 
-- **Colorful spectrum analyzer palettes** — frequency-mapped color gradients replace the old monochrome green. Four palettes available via `[visualizer] palette = "..."`: `spectrum` (default, bass red/orange through cyan mids to purple highs), `fire` (deep red to white-hot), `neon` (synthwave pink through electric blue), `mono` (classic LED green/yellow/red). ([#134](https://github.com/radiosilence/koan/issues/134))
-- **Beat-reactive color shifts** — low-frequency transient detection drives a brightness pulse across the entire palette on beats. Zero overhead on the audio thread (detection runs in the existing analyzer thread, color math in the render path)
-- **Peak hold glow** — peak markers now render in a brightened version of the palette color instead of flat white, fading as they decay
+- **Colorful spectrum analyzer** — frequency-mapped rainbow replaces monochrome green. Four palettes via `[visualizer] palette`: `spectrum` (default), `fire`, `neon`, `mono`. Dreamy 8-second color drift breathes the rainbow back and forth across the bars. Beat-reactive hue shifts snap the palette forward on kicks/transients. Brightness pulses on top. Peak markers glow in brightened palette colors. All color math in the render path — zero impact on audio threads. ([#134](https://github.com/radiosilence/koan/issues/134), [#135](https://github.com/radiosilence/koan/pull/135))
 
 ## v0.18.7 (2026-04-05)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2002,7 +2002,7 @@ dependencies = [
 
 [[package]]
 name = "koan-core"
-version = "0.18.6"
+version = "0.19.0"
 dependencies = [
  "bliss-audio",
  "bliss-audio-aubio-rs",
@@ -2037,7 +2037,7 @@ dependencies = [
 
 [[package]]
 name = "koan-music"
-version = "0.18.6"
+version = "0.19.0"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/koan-core", "crates/koan-music"]
 
 [workspace.package]
-version = "0.18.7"
+version = "0.19.0"
 edition = "2024"
 homepage = "https://github.com/radiosilence/koan"
 repository = "https://github.com/radiosilence/koan"

--- a/crates/koan-music/Cargo.toml
+++ b/crates/koan-music/Cargo.toml
@@ -20,7 +20,7 @@ ctrlc = "3"
 crossbeam-channel = "0.5"
 crossterm = "0.28"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "webp"] }
-koan-core = { path = "../koan-core", version = "0.18.2" }
+koan-core = { path = "../koan-core", version = "0.19.0" }
 log = "0.4"
 nucleo = "0.5"
 owo-colors = "4"


### PR DESCRIPTION
## v0.19.0 — Colorful spectrum analyzer

Rainbow frequency-mapped visualizer with 4 palettes, dreamy 8-second color drift, beat-reactive hue shifts, and brightness pulses. All render-side math, zero audio thread impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)