### PR TITLE
#137 feat(visualizer): braille-mode visualizer modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- **Braille visualizer modes** — five rendering modes for the visualizer, switchable with `M` key: `bars` (existing LED spectrum), `oscilloscope` (raw PCM waveform as braille line), `radial` (polar-coordinate spectrum starburst), `particles` (frequency-driven particle system with physics), `lissajous` (stereo phase scope with afterglow trail). All modes use a braille character grid (U+2800..U+28FF) for 2x4 subpixel resolution per terminal cell. Beat-reactive, palette-colored, existing color palettes and drift effects apply to all modes. Config: `[visualizer] mode = "bars"` (default). ([#137](https://github.com/radiosilence/koan/issues/137))
+
 ## v0.19.0 (2026-04-06)
 
 ### Added

--- a/crates/koan-core/src/audio/analyzer.rs
+++ b/crates/koan-core/src/audio/analyzer.rs
@@ -633,11 +633,22 @@ fn analysis_loop(
 
         // ── Phase 3b: publish to VizSnapshot (RwLock write, <1us) ────────────
         if let Some(ref snap_out) = snapshot {
+            // Stash the most recent waveform samples for oscilloscope/lissajous.
+            // Take the tail of the raw snapshot (already in chronological order).
+            use super::viz::WAVEFORM_SAMPLES;
+            let waveform = if snap.channels >= 1 && !snap.samples.is_empty() {
+                let interleaved_len = WAVEFORM_SAMPLES * snap.channels.max(1) as usize;
+                let start = snap.samples.len().saturating_sub(interleaved_len);
+                snap.samples[start..].to_vec()
+            } else {
+                Vec::new()
+            };
             snap_out.write(VizFrame {
                 spectrum: state.spectrum,
                 vu_levels: state.vu_levels,
                 beat_energy: state.beat_energy,
                 timestamp: Instant::now(),
+                waveform,
             });
         }
 

--- a/crates/koan-core/src/audio/viz.rs
+++ b/crates/koan-core/src/audio/viz.rs
@@ -39,10 +39,14 @@ pub type SharedAnalysisOutput = Arc<Mutex<AnalysisOutput>>;
 
 // ── VizFrame / VizSnapshot (high-level UI-facing snapshot API) ────────────────
 
+/// Number of waveform samples carried in each VizFrame for oscilloscope/lissajous modes.
+/// 2048 samples (~46ms at 44.1kHz) matches the FFT window size — enough for smooth waveform display.
+pub const WAVEFORM_SAMPLES: usize = 2048;
+
 /// A single frame of analysis output, ready for the UI thread.
 ///
 /// Held inside `VizSnapshot` under an RwLock. The UI thread clones this in
-/// <1us (memcpy of 48 floats + 2 floats + 1 float + Instant) while holding the read lock.
+/// <1us (memcpy of 48 floats + 2 floats + 1 float + waveform + Instant) while holding the read lock.
 #[derive(Clone)]
 pub struct VizFrame {
     /// Spectrum bar heights (0.0..1.0), one per bar.
@@ -54,6 +58,10 @@ pub struct VizFrame {
     pub beat_energy: f32,
     /// When this frame was computed.
     pub timestamp: std::time::Instant,
+    /// Raw waveform samples for oscilloscope/lissajous rendering.
+    /// Interleaved stereo (L, R, L, R...) — `WAVEFORM_SAMPLES` frames = `WAVEFORM_SAMPLES * 2` values.
+    /// Empty when no audio is playing.
+    pub waveform: Vec<f32>,
 }
 
 impl Default for VizFrame {
@@ -63,6 +71,7 @@ impl Default for VizFrame {
             vu_levels: [0.0; 2],
             beat_energy: 0.0,
             timestamp: std::time::Instant::now(),
+            waveform: Vec::new(),
         }
     }
 }
@@ -342,6 +351,7 @@ mod tests {
             vu_levels: [0.5, 0.5],
             beat_energy: 0.0,
             timestamp: std::time::Instant::now(),
+            waveform: Vec::new(),
         });
 
         let frame2 = snap.read();

--- a/crates/koan-core/src/config.rs
+++ b/crates/koan-core/src/config.rs
@@ -126,6 +126,8 @@ impl Default for PlaybackConfig {
 pub struct VisualizerConfig {
     pub enabled: bool,
     pub fps: u8,
+    /// Visualizer mode: "bars" (default), "oscilloscope", "radial", "particles", "lissajous".
+    pub mode: String,
     /// Frequency scale: "bark" (default), "mel", "log", "linear".
     pub scale: String,
     /// Amplitude scale: "aweight" (default, A-weighted), "perceptual" (A-weighted + gamma), "sqrt", "linear".
@@ -144,6 +146,7 @@ impl Default for VisualizerConfig {
         Self {
             enabled: true,
             fps: 60,
+            mode: "bars".into(),
             scale: "bark".into(),
             amplitude_scale: "aweight".into(),
             bar_decay_ms: 50,

--- a/crates/koan-music/src/tui/app.rs
+++ b/crates/koan-music/src/tui/app.rs
@@ -990,6 +990,20 @@ impl App {
                     cfg.visualizer.enabled = viz_enabled;
                 });
             }
+            KeyCode::Char('M') => {
+                let next_mode = self.visualizer.mode.next();
+                self.visualizer.mode = next_mode;
+                self.viz_config.mode = next_mode.as_str().to_string();
+                self.status_message = Some((
+                    format!("visualiser: {}", next_mode.label()),
+                    std::time::Instant::now(),
+                ));
+                // Persist to config.toml.
+                let mode_str = next_mode.as_str().to_string();
+                let _ = koan_core::config::Config::update_base(|cfg| {
+                    cfg.visualizer.mode = mode_str.clone();
+                });
+            }
             KeyCode::Up => {
                 let visible = self.visible_queue();
                 if !visible.is_empty() {

--- a/crates/koan-music/src/tui/help_modal.rs
+++ b/crates/koan-music/src/tui/help_modal.rs
@@ -75,7 +75,8 @@ const SECTIONS: &[Section] = &[
         bindings: &[
             ("L", "Lyrics panel"),
             ("R", "Radio mode (auto-queue)"),
-            ("V", "Visualiser"),
+            ("V", "Visualiser on/off"),
+            ("M", "Visualiser mode cycle"),
             ("f", "Favourite track"),
         ],
     },

--- a/crates/koan-music/src/tui/ui.rs
+++ b/crates/koan-music/src/tui/ui.rs
@@ -15,7 +15,7 @@ use super::picker::{PickerOverlay, picker_popup_rect};
 use super::queue::QueueView;
 use super::track_info::TrackInfoOverlay;
 use super::transport::TransportBar;
-use super::visualizer::SpectrumWidget;
+use super::visualizer::VisualizerWidget;
 
 /// Height of the transport bar without album art.
 const TRANSPORT_HEIGHT_DEFAULT: u16 = 3;
@@ -106,7 +106,8 @@ pub fn render(frame: &mut Frame, app: &mut App) {
     .with_download_fraction(dl_fraction);
     frame.render_widget(transport, text_area);
 
-    // Spectrum visualizer — renders in the space above the transport text.
+    // Visualizer — renders in the space above the transport text.
+    // Dispatches to the active mode (bars, oscilloscope, radial, particles, lissajous).
     if transport_height > TRANSPORT_HEIGHT_DEFAULT {
         let spectrum_height = transport_height - TRANSPORT_HEIGHT_DEFAULT;
         let spectrum_area = Rect::new(
@@ -115,8 +116,8 @@ pub fn render(frame: &mut Frame, app: &mut App) {
             chunks[0].width.saturating_sub(art_width + 1),
             spectrum_height,
         );
-        let spectrum = SpectrumWidget::new(&app.visualizer, &app.theme);
-        frame.render_widget(spectrum, spectrum_area);
+        let viz = VisualizerWidget::new(&mut app.visualizer, &app.theme);
+        viz.render(spectrum_area, frame.buffer_mut());
     }
 
     // Content area: library + queue side-by-side, or just queue, with optional lyrics panel.

--- a/crates/koan-music/src/tui/visualizer.rs
+++ b/crates/koan-music/src/tui/visualizer.rs
@@ -14,6 +14,69 @@ const NUM_BARS: usize = 48;
 /// Eighth-block characters for sub-cell vertical resolution (8 levels per cell).
 const EIGHTH_BLOCKS: &[char] = &[' ', '▁', '▂', '▃', '▄', '▅', '▆', '▇', '█'];
 
+// ── Visualizer Mode ────────────────────────────────────────────────────────
+
+/// Active visualizer rendering mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VisualizerMode {
+    /// Classic LED-segment spectrum bars (default).
+    Bars,
+    /// Raw PCM waveform drawn as a continuous braille line.
+    Oscilloscope,
+    /// Spectrum bars mapped to polar coordinates — radial starburst.
+    Radial,
+    /// Frequency-driven particle system with physics sim.
+    Particles,
+    /// Stereo phase scope — L channel vs R channel as X/Y coordinates.
+    Lissajous,
+}
+
+impl VisualizerMode {
+    pub fn parse(s: &str) -> Self {
+        match s.to_lowercase().as_str() {
+            "bars" | "spectrum" => Self::Bars,
+            "oscilloscope" | "scope" => Self::Oscilloscope,
+            "radial" => Self::Radial,
+            "particles" | "particle" => Self::Particles,
+            "lissajous" | "phase" => Self::Lissajous,
+            _ => Self::Bars,
+        }
+    }
+
+    /// Cycle to the next mode.
+    pub fn next(self) -> Self {
+        match self {
+            Self::Bars => Self::Oscilloscope,
+            Self::Oscilloscope => Self::Radial,
+            Self::Radial => Self::Particles,
+            Self::Particles => Self::Lissajous,
+            Self::Lissajous => Self::Bars,
+        }
+    }
+
+    /// Config string for persistence.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Bars => "bars",
+            Self::Oscilloscope => "oscilloscope",
+            Self::Radial => "radial",
+            Self::Particles => "particles",
+            Self::Lissajous => "lissajous",
+        }
+    }
+
+    /// Human-readable label for status messages.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Bars => "bars",
+            Self::Oscilloscope => "oscilloscope",
+            Self::Radial => "radial",
+            Self::Particles => "particles",
+            Self::Lissajous => "lissajous",
+        }
+    }
+}
+
 // ── Palette ─────────────────────────────────────────────────────────────────
 
 /// Color palette for the spectrum analyzer.
@@ -45,7 +108,7 @@ impl VisualizerPalette {
 
     /// Map a normalised frequency position (0.0..1.0) to an RGB color.
     /// For `Mono`, this is unused — the renderer uses height-based coloring instead.
-    fn freq_color(self, t: f32) -> Color {
+    pub fn freq_color(self, t: f32) -> Color {
         match self {
             Self::Mono => Color::Green, // fallback; actual mono uses height-based
             Self::Spectrum => {
@@ -112,6 +175,287 @@ fn brighten(color: Color, amount: f32) -> Color {
     }
 }
 
+/// Dim an RGB color toward black by a factor (0.0 = unchanged, 1.0 = pure black).
+fn dim(color: Color, amount: f32) -> Color {
+    if let Color::Rgb(r, g, b) = color {
+        let a = amount.clamp(0.0, 1.0);
+        Color::Rgb(
+            (r as f32 * (1.0 - a)) as u8,
+            (g as f32 * (1.0 - a)) as u8,
+            (b as f32 * (1.0 - a)) as u8,
+        )
+    } else {
+        color
+    }
+}
+
+// ── BrailleGrid ─────────────────────────────────────────────────────────────
+
+/// Braille character subpixel grid.
+///
+/// Each terminal cell maps to one Unicode braille character (U+2800..U+28FF)
+/// giving 2x4 subpixel resolution per cell. Color is per-cell (terminal limitation).
+///
+/// Braille dot layout per cell:
+/// ```text
+///   0 3
+///   1 4
+///   2 5
+///   6 7
+/// ```
+/// Bit 0 = dot 1 (top-left), bit 3 = dot 4 (top-right), etc.
+pub struct BrailleGrid {
+    /// Terminal cell dimensions.
+    width: usize,
+    height: usize,
+    /// 8 bits per cell — braille dot pattern.
+    dots: Vec<u8>,
+    /// One color per cell. Last write wins (per-cell limitation).
+    colors: Vec<Color>,
+}
+
+impl BrailleGrid {
+    /// Create a new grid sized for the given terminal area.
+    pub fn new(width: usize, height: usize) -> Self {
+        let cells = width * height;
+        Self {
+            width,
+            height,
+            dots: vec![0; cells],
+            colors: vec![Color::Reset; cells],
+        }
+    }
+
+    /// Pixel dimensions (subpixel resolution).
+    pub fn px_width(&self) -> usize {
+        self.width * 2
+    }
+
+    pub fn px_height(&self) -> usize {
+        self.height * 4
+    }
+
+    /// Set a single subpixel dot at pixel coordinates (px, py).
+    /// Returns false if out of bounds.
+    pub fn set_dot(&mut self, px: usize, py: usize, color: Color) -> bool {
+        if px >= self.px_width() || py >= self.px_height() {
+            return false;
+        }
+        let cell_x = px / 2;
+        let cell_y = py / 4;
+        let sub_x = px % 2;
+        let sub_y = py % 4;
+        let bit = braille_bit(sub_x, sub_y);
+        let idx = cell_y * self.width + cell_x;
+        self.dots[idx] |= bit;
+        self.colors[idx] = color;
+        true
+    }
+
+    /// Draw a line between two subpixel points using Bresenham's algorithm.
+    pub fn draw_line(&mut self, x0: f32, y0: f32, x1: f32, y1: f32, color: Color) {
+        let mut x = x0;
+        let mut y = y0;
+        let dx = (x1 - x0).abs();
+        let dy = (y1 - y0).abs();
+        let sx = if x0 < x1 { 1.0 } else { -1.0 };
+        let sy = if y0 < y1 { 1.0 } else { -1.0 };
+        let steps = dx.max(dy).ceil() as usize;
+        if steps == 0 {
+            self.set_dot(x0 as usize, y0 as usize, color);
+            return;
+        }
+        let step_x = (x1 - x0) / steps as f32;
+        let step_y = (y1 - y0) / steps as f32;
+        for _ in 0..=steps {
+            let ix = x.round() as usize;
+            let iy = y.round() as usize;
+            self.set_dot(ix, iy, color);
+            x += step_x;
+            y += step_y;
+        }
+        // Ignore sx/sy warnings — they're used conceptually but the step-based
+        // approach handles direction via step_x/step_y.
+        let _ = (sx, sy);
+    }
+
+    /// Render the braille grid into a ratatui Buffer at the given area.
+    pub fn render_to(&self, area: Rect, buf: &mut Buffer) {
+        for cy in 0..self.height.min(area.height as usize) {
+            for cx in 0..self.width.min(area.width as usize) {
+                let idx = cy * self.width + cx;
+                let pattern = self.dots[idx];
+                if pattern == 0 {
+                    continue;
+                }
+                let ch = char::from_u32(0x2800 + pattern as u32).unwrap_or(' ');
+                let x = area.x + cx as u16;
+                let y = area.y + cy as u16;
+                buf[(x, y)]
+                    .set_char(ch)
+                    .set_style(Style::new().fg(self.colors[idx]));
+            }
+        }
+    }
+}
+
+/// Map subpixel position within a cell to the braille bit index.
+/// Layout: col 0 = bits 0,1,2,6 (top to bottom), col 1 = bits 3,4,5,7.
+fn braille_bit(sub_x: usize, sub_y: usize) -> u8 {
+    match (sub_x, sub_y) {
+        (0, 0) => 1 << 0,
+        (0, 1) => 1 << 1,
+        (0, 2) => 1 << 2,
+        (0, 3) => 1 << 6,
+        (1, 0) => 1 << 3,
+        (1, 1) => 1 << 4,
+        (1, 2) => 1 << 5,
+        (1, 3) => 1 << 7,
+        _ => 0,
+    }
+}
+
+// ── Particle System ─────────────────────────────────────────────────────────
+
+/// Maximum active particles at any time.
+const MAX_PARTICLES: usize = 2000;
+
+/// A single particle in the frequency-driven particle system.
+#[derive(Clone)]
+struct Particle {
+    x: f32,
+    y: f32,
+    vx: f32,
+    vy: f32,
+    /// Remaining lifetime (0.0..1.0). Particle dies at 0.
+    life: f32,
+    /// Normalized frequency of the source band (0.0..1.0) — for coloring.
+    freq_t: f32,
+}
+
+/// Particle system state. Persists across frames.
+pub struct ParticleSystem {
+    particles: Vec<Particle>,
+}
+
+impl ParticleSystem {
+    pub fn new() -> Self {
+        Self {
+            particles: Vec::with_capacity(MAX_PARTICLES),
+        }
+    }
+
+    /// Emit new particles from spectrum bands and step physics.
+    pub fn update(
+        &mut self,
+        spectrum: &[f32; NUM_BARS],
+        beat_energy: f32,
+        px_width: f32,
+        px_height: f32,
+        dt: f32,
+    ) {
+        // Physics step for existing particles.
+        let gravity = px_height * 0.3; // Gentle downward pull.
+        for p in self.particles.iter_mut() {
+            p.x += p.vx * dt;
+            p.y += p.vy * dt;
+            p.vy += gravity * dt;
+            p.life -= dt * 1.5; // ~0.67s lifetime.
+        }
+        // Remove dead particles.
+        self.particles.retain(|p| p.life > 0.0);
+
+        // Emit new particles from high-energy bands.
+        let emit_center_x = px_width / 2.0;
+        let emit_y = px_height * 0.85; // Emit from bottom area.
+        let beat_boost = 1.0 + beat_energy * 3.0;
+
+        for (i, &energy) in spectrum.iter().enumerate() {
+            if energy < 0.15 {
+                continue;
+            }
+            let freq_t = i as f32 / (NUM_BARS - 1) as f32;
+            // Higher energy = more particles per frame.
+            let emit_count = ((energy * beat_boost * 2.0) as usize).min(3);
+            for _ in 0..emit_count {
+                if self.particles.len() >= MAX_PARTICLES {
+                    break;
+                }
+                // Spread across X based on frequency position.
+                let spread = (freq_t - 0.5) * px_width * 0.6;
+                let angle_spread = (freq_t - 0.5) * 0.8;
+                // Velocity: upward with some horizontal scatter.
+                let speed = px_height * (0.4 + energy * 0.6) * beat_boost;
+                let vx = speed * angle_spread + spread * 0.1;
+                let vy = -speed * (0.6 + energy * 0.4);
+                self.particles.push(Particle {
+                    x: emit_center_x + spread,
+                    y: emit_y,
+                    vx,
+                    vy,
+                    life: 1.0,
+                    freq_t,
+                });
+            }
+        }
+    }
+
+    /// Render particles onto a braille grid.
+    pub fn render(&self, grid: &mut BrailleGrid, palette: VisualizerPalette, beat: f32) {
+        for p in &self.particles {
+            let ix = p.x as usize;
+            let iy = p.y as usize;
+            if ix < grid.px_width() && iy < grid.px_height() {
+                let base = palette.freq_color(p.freq_t);
+                let color = dim(brighten(base, beat * 0.5), 1.0 - p.life);
+                grid.set_dot(ix, iy, color);
+            }
+        }
+    }
+}
+
+// ── Lissajous Trail ─────────────────────────────────────────────────────────
+
+/// Number of trail frames for the afterglow effect.
+const LISSAJOUS_TRAIL_FRAMES: usize = 4;
+
+/// Stored trail of previous lissajous point sets for afterglow.
+pub struct LissajousTrail {
+    /// Ring buffer of past frames' point sets (newest last).
+    frames: Vec<Vec<(usize, usize)>>,
+    write_idx: usize,
+}
+
+impl LissajousTrail {
+    pub fn new() -> Self {
+        Self {
+            frames: (0..LISSAJOUS_TRAIL_FRAMES).map(|_| Vec::new()).collect(),
+            write_idx: 0,
+        }
+    }
+
+    /// Push a new set of points. Old frames dim as afterglow.
+    pub fn push(&mut self, points: Vec<(usize, usize)>) {
+        self.frames[self.write_idx] = points;
+        self.write_idx = (self.write_idx + 1) % LISSAJOUS_TRAIL_FRAMES;
+    }
+
+    /// Render all trail frames onto a braille grid with fading.
+    pub fn render(&self, grid: &mut BrailleGrid, palette: VisualizerPalette, beat: f32) {
+        for age in 0..LISSAJOUS_TRAIL_FRAMES {
+            // Oldest frame = highest dim, newest = brightest.
+            let frame_idx = (self.write_idx + age) % LISSAJOUS_TRAIL_FRAMES;
+            let brightness = (age + 1) as f32 / LISSAJOUS_TRAIL_FRAMES as f32;
+            let color_t = 0.3 + brightness * 0.7;
+            let base = palette.freq_color(color_t);
+            let color = dim(brighten(base, beat * 0.3), 1.0 - brightness);
+            for &(px, py) in &self.frames[frame_idx] {
+                grid.set_dot(px, py, color);
+            }
+        }
+    }
+}
+
 // ── VisualizerState ─────────────────────────────────────────────────────────
 
 /// Processed visualizer data, ready for rendering.
@@ -144,6 +488,16 @@ pub struct VisualizerState {
     peak_half_life: f32,
     /// Color palette for rendering.
     pub palette: VisualizerPalette,
+    /// Active visualizer mode.
+    pub mode: VisualizerMode,
+    /// Latest raw waveform samples (interleaved stereo) from VizFrame.
+    pub waveform: Vec<f32>,
+    /// Particle system state (persists across frames).
+    pub particles: ParticleSystem,
+    /// Lissajous afterglow trail.
+    pub lissajous_trail: LissajousTrail,
+    /// Radial rotation angle (radians), slowly drifts.
+    pub radial_angle: f32,
 }
 
 impl VisualizerState {
@@ -151,13 +505,15 @@ impl VisualizerState {
         let bar_half_life = cfg.bar_decay_ms as f32 / 1000.0;
         let peak_half_life = cfg.peak_decay_ms as f32 / 1000.0;
         let palette = VisualizerPalette::parse(&cfg.palette);
-        Self::with_config(bar_half_life, peak_half_life, palette)
+        let mode = VisualizerMode::parse(&cfg.mode);
+        Self::with_config(bar_half_life, peak_half_life, palette, mode)
     }
 
     pub fn with_config(
         bar_half_life: f32,
         peak_half_life: f32,
         palette: VisualizerPalette,
+        mode: VisualizerMode,
     ) -> Self {
         Self {
             spectrum: [0.0; NUM_BARS],
@@ -171,6 +527,11 @@ impl VisualizerState {
             bar_half_life,
             peak_half_life,
             palette,
+            mode,
+            waveform: Vec::new(),
+            particles: ParticleSystem::new(),
+            lissajous_trail: LissajousTrail::new(),
+            radial_angle: 0.0,
         }
     }
 
@@ -187,7 +548,7 @@ impl VisualizerState {
 
     /// Read the latest analysis frame from VizSnapshot and apply decay/smoothing.
     ///
-    /// The snapshot read is <1us (RwLock clone of ~200 bytes).
+    /// The snapshot read is <1us (RwLock clone of ~200 bytes + waveform vec).
     /// All decay/smoothing runs on local copies — no locks held during computation.
     /// Called once per frame (~60fps) from `handle_tick()`.
     pub fn update_from_snapshot(&mut self, snapshot: &VizSnapshot) {
@@ -231,6 +592,16 @@ impl VisualizerState {
             // Decay back toward 0 — slower than bar decay for lingering color shift.
             self.beat_hue_offset *= 0.95;
         }
+
+        // Stash waveform for oscilloscope/lissajous modes.
+        self.waveform = frame.waveform;
+
+        // Advance radial rotation — slow drift + beat burst.
+        let dt = 1.0 / 60.0; // Approximate frame time.
+        self.radial_angle += dt * 0.3 + self.beat_energy * 0.1;
+        if self.radial_angle > std::f32::consts::TAU {
+            self.radial_angle -= std::f32::consts::TAU;
+        }
     }
 
     /// Apply decay smoothing without new analysis input (called when paused/stopped).
@@ -249,6 +620,226 @@ impl VisualizerState {
         self.beat_hue_offset *= 0.95;
     }
 }
+
+// ── VisualizerWidget (mode-dispatching wrapper) ─────────────────────────────
+
+/// Top-level visualizer widget that dispatches to the active mode's renderer.
+pub struct VisualizerWidget<'a> {
+    state: &'a mut VisualizerState,
+    theme: &'a Theme,
+}
+
+impl<'a> VisualizerWidget<'a> {
+    pub fn new(state: &'a mut VisualizerState, theme: &'a Theme) -> Self {
+        Self { state, theme }
+    }
+
+    pub fn render(self, area: Rect, buf: &mut Buffer) {
+        if area.width == 0 || area.height == 0 {
+            return;
+        }
+
+        match self.state.mode {
+            VisualizerMode::Bars => {
+                // Delegate to the existing spectrum bar renderer.
+                let widget = SpectrumWidget::new(self.state, self.theme);
+                Widget::render(widget, area, buf);
+            }
+            VisualizerMode::Oscilloscope => {
+                render_oscilloscope(self.state, area, buf);
+            }
+            VisualizerMode::Radial => {
+                render_radial(self.state, area, buf);
+            }
+            VisualizerMode::Particles => {
+                render_particles(self.state, area, buf);
+            }
+            VisualizerMode::Lissajous => {
+                render_lissajous(self.state, area, buf);
+            }
+        }
+    }
+}
+
+// ── Oscilloscope Renderer ──────────────────────────────────────────────────
+
+fn render_oscilloscope(state: &VisualizerState, area: Rect, buf: &mut Buffer) {
+    let mut grid = BrailleGrid::new(area.width as usize, area.height as usize);
+    let px_w = grid.px_width();
+    let px_h = grid.px_height();
+
+    if state.waveform.is_empty() || px_w == 0 || px_h == 0 {
+        return;
+    }
+
+    // Mix to mono from interleaved stereo.
+    let channels = if state.waveform.len() > 2 { 2 } else { 1 };
+    let num_frames = state.waveform.len() / channels;
+    if num_frames < 2 {
+        return;
+    }
+
+    let center_y = px_h as f32 / 2.0;
+    let amplitude = px_h as f32 * 0.4; // ±40% of height.
+
+    let mut prev_x = 0.0f32;
+    let mut prev_y = center_y;
+
+    for i in 0..px_w {
+        // Map pixel X to waveform frame index.
+        let frame_idx = i * num_frames / px_w;
+        let sample = if channels == 2 {
+            (state.waveform[frame_idx * 2] + state.waveform[frame_idx * 2 + 1]) * 0.5
+        } else {
+            state.waveform[frame_idx]
+        };
+
+        let x = i as f32;
+        let y = center_y - sample * amplitude;
+        let y = y.clamp(0.0, (px_h - 1) as f32);
+
+        if i > 0 {
+            // Color by amplitude — palette mapped.
+            let amp_t = sample.abs().clamp(0.0, 1.0);
+            let base = state.palette.freq_color(amp_t);
+            let color = brighten(base, state.beat_energy * 0.5);
+            grid.draw_line(prev_x, prev_y, x, y, color);
+        }
+
+        prev_x = x;
+        prev_y = y;
+    }
+
+    grid.render_to(area, buf);
+}
+
+// ── Radial Spectrum Renderer ───────────────────────────────────────────────
+
+fn render_radial(state: &VisualizerState, area: Rect, buf: &mut Buffer) {
+    let mut grid = BrailleGrid::new(area.width as usize, area.height as usize);
+    let px_w = grid.px_width() as f32;
+    let px_h = grid.px_height() as f32;
+
+    if px_w < 4.0 || px_h < 4.0 {
+        return;
+    }
+
+    let cx = px_w / 2.0;
+    let cy = px_h / 2.0;
+    let max_radius = cx.min(cy) * 0.9;
+    let inner_radius = max_radius * 0.15;
+    let rotation = state.radial_angle;
+    let beat_pulse = 1.0 + state.beat_energy * 0.3;
+
+    let elapsed = state.created_at.elapsed().as_secs_f32();
+    let drift = (elapsed * std::f32::consts::TAU / 8.0).sin() * 0.15;
+
+    for i in 0..NUM_BARS {
+        let freq_t = i as f32 / (NUM_BARS - 1) as f32;
+        let angle = freq_t * std::f32::consts::TAU + rotation;
+        let magnitude = state.spectrum[i] * beat_pulse;
+        let bar_len = magnitude * (max_radius - inner_radius);
+
+        if bar_len < 0.5 {
+            continue;
+        }
+
+        let cos_a = angle.cos();
+        let sin_a = angle.sin();
+
+        let x0 = cx + inner_radius * cos_a;
+        let y0 = cy + inner_radius * sin_a;
+        let x1 = cx + (inner_radius + bar_len) * cos_a;
+        let y1 = cy + (inner_radius + bar_len) * sin_a;
+
+        let warped = (freq_t + drift + state.beat_hue_offset).rem_euclid(1.0);
+        let base = state.palette.freq_color(warped);
+        let color = brighten(base, state.beat_energy * 0.5);
+
+        grid.draw_line(x0, y0, x1, y1, color);
+    }
+
+    grid.render_to(area, buf);
+}
+
+// ── Particle Renderer ──────────────────────────────────────────────────────
+
+fn render_particles(state: &mut VisualizerState, area: Rect, buf: &mut Buffer) {
+    let mut grid = BrailleGrid::new(area.width as usize, area.height as usize);
+    let px_w = grid.px_width() as f32;
+    let px_h = grid.px_height() as f32;
+
+    // Step physics and emit new particles.
+    let dt = 1.0 / 60.0;
+    state
+        .particles
+        .update(&state.spectrum, state.beat_energy, px_w, px_h, dt);
+
+    // Render particles to the grid.
+    state
+        .particles
+        .render(&mut grid, state.palette, state.beat_energy);
+
+    grid.render_to(area, buf);
+}
+
+// ── Lissajous Renderer ─────────────────────────────────────────────────────
+
+fn render_lissajous(state: &mut VisualizerState, area: Rect, buf: &mut Buffer) {
+    let mut grid = BrailleGrid::new(area.width as usize, area.height as usize);
+    let px_w = grid.px_width();
+    let px_h = grid.px_height();
+
+    if state.waveform.is_empty() || px_w == 0 || px_h == 0 {
+        // Still render the trail for afterglow.
+        state.lissajous_trail.push(Vec::new());
+        state
+            .lissajous_trail
+            .render(&mut grid, state.palette, state.beat_energy);
+        grid.render_to(area, buf);
+        return;
+    }
+
+    let channels = if state.waveform.len() > 2 { 2 } else { 1 };
+    let num_frames = state.waveform.len() / channels;
+
+    let cx = px_w as f32 / 2.0;
+    let cy = px_h as f32 / 2.0;
+    let scale_x = cx * 0.85;
+    let scale_y = cy * 0.85;
+
+    let mut points = Vec::with_capacity(num_frames.min(1024));
+
+    // Downsample to ~1024 points for performance.
+    let step = (num_frames / 1024).max(1);
+    for i in (0..num_frames).step_by(step) {
+        let (left, right) = if channels == 2 {
+            (state.waveform[i * 2], state.waveform[i * 2 + 1])
+        } else {
+            (state.waveform[i], state.waveform[i])
+        };
+
+        let px = (cx + left * scale_x).clamp(0.0, (px_w - 1) as f32) as usize;
+        let py = (cy - right * scale_y).clamp(0.0, (px_h - 1) as f32) as usize;
+        points.push((px, py));
+
+        // Draw the current frame's points brightly.
+        let amp = ((left * left + right * right) * 0.5).sqrt().clamp(0.0, 1.0);
+        let base = state.palette.freq_color(amp);
+        let color = brighten(base, state.beat_energy * 0.4);
+        grid.set_dot(px, py, color);
+    }
+
+    // Push to trail and render afterglow.
+    state.lissajous_trail.push(points);
+    state
+        .lissajous_trail
+        .render(&mut grid, state.palette, state.beat_energy);
+
+    grid.render_to(area, buf);
+}
+
+// ── SpectrumWidget (original bars mode) ─────────────────────────────────────
 
 /// 80s hi-fi LED-segment spectrum analyzer widget.
 ///
@@ -434,7 +1025,12 @@ mod tests {
 
     #[test]
     fn visualizer_state_initializes() {
-        let state = VisualizerState::with_config(0.045, 0.18, VisualizerPalette::Spectrum);
+        let state = VisualizerState::with_config(
+            0.045,
+            0.18,
+            VisualizerPalette::Spectrum,
+            VisualizerMode::Bars,
+        );
         assert_eq!(state.spectrum.len(), NUM_BARS);
         assert_eq!(state.peaks.len(), NUM_BARS);
         assert_eq!(state.vu_levels, [0.0, 0.0]);
@@ -443,7 +1039,12 @@ mod tests {
 
     #[test]
     fn update_from_snapshot_with_silence() {
-        let mut state = VisualizerState::with_config(0.045, 0.18, VisualizerPalette::Spectrum);
+        let mut state = VisualizerState::with_config(
+            0.045,
+            0.18,
+            VisualizerPalette::Spectrum,
+            VisualizerMode::Bars,
+        );
         let snapshot = VizSnapshot::new();
 
         // Default snapshot has all zeros (silence).
@@ -456,7 +1057,12 @@ mod tests {
 
     #[test]
     fn update_from_snapshot_with_signal() {
-        let mut state = VisualizerState::with_config(0.045, 0.18, VisualizerPalette::Spectrum);
+        let mut state = VisualizerState::with_config(
+            0.045,
+            0.18,
+            VisualizerPalette::Spectrum,
+            VisualizerMode::Bars,
+        );
         let snapshot = VizSnapshot::new();
 
         // Write a frame with some energy.
@@ -468,6 +1074,7 @@ mod tests {
             vu_levels: [0.6, 0.6],
             beat_energy: 0.3,
             timestamp: Instant::now(),
+            waveform: Vec::new(),
         });
 
         state.update_from_snapshot(&snapshot);
@@ -479,7 +1086,12 @@ mod tests {
 
     #[test]
     fn decay_to_zero_reduces_bars() {
-        let mut state = VisualizerState::with_config(0.045, 0.18, VisualizerPalette::Spectrum);
+        let mut state = VisualizerState::with_config(
+            0.045,
+            0.18,
+            VisualizerPalette::Spectrum,
+            VisualizerMode::Bars,
+        );
         let snapshot = VizSnapshot::new();
 
         // Seed some energy.
@@ -489,6 +1101,7 @@ mod tests {
             vu_levels: [1.0, 1.0],
             beat_energy: 0.8,
             timestamp: Instant::now(),
+            waveform: Vec::new(),
         });
         state.update_from_snapshot(&snapshot);
 
@@ -516,7 +1129,12 @@ mod tests {
 
     #[test]
     fn peak_hold_rises_and_falls() {
-        let mut state = VisualizerState::with_config(0.045, 0.18, VisualizerPalette::Spectrum);
+        let mut state = VisualizerState::with_config(
+            0.045,
+            0.18,
+            VisualizerPalette::Spectrum,
+            VisualizerMode::Bars,
+        );
         let snapshot = VizSnapshot::new();
 
         // Push a loud frame.
@@ -527,6 +1145,7 @@ mod tests {
             vu_levels: [0.0; 2],
             beat_energy: 0.0,
             timestamp: Instant::now(),
+            waveform: Vec::new(),
         });
         state.update_from_snapshot(&snapshot);
         let peak_after_signal = state.peaks[5];
@@ -538,6 +1157,7 @@ mod tests {
             vu_levels: [0.0; 2],
             beat_energy: 0.0,
             timestamp: Instant::now(),
+            waveform: Vec::new(),
         });
         state.last_update = Instant::now() - std::time::Duration::from_millis(16);
         state.update_from_snapshot(&snapshot);
@@ -601,5 +1221,102 @@ mod tests {
     fn brighten_at_one_is_white() {
         let c = Color::Rgb(100, 150, 200);
         assert_eq!(brighten(c, 1.0), Color::Rgb(255, 255, 255));
+    }
+
+    #[test]
+    fn mode_parse_variants() {
+        assert_eq!(VisualizerMode::parse("bars"), VisualizerMode::Bars);
+        assert_eq!(VisualizerMode::parse("spectrum"), VisualizerMode::Bars);
+        assert_eq!(
+            VisualizerMode::parse("oscilloscope"),
+            VisualizerMode::Oscilloscope
+        );
+        assert_eq!(VisualizerMode::parse("scope"), VisualizerMode::Oscilloscope);
+        assert_eq!(VisualizerMode::parse("radial"), VisualizerMode::Radial);
+        assert_eq!(
+            VisualizerMode::parse("particles"),
+            VisualizerMode::Particles
+        );
+        assert_eq!(
+            VisualizerMode::parse("lissajous"),
+            VisualizerMode::Lissajous
+        );
+        assert_eq!(VisualizerMode::parse("phase"), VisualizerMode::Lissajous);
+        assert_eq!(VisualizerMode::parse("garbage"), VisualizerMode::Bars);
+    }
+
+    #[test]
+    fn mode_cycles_through_all() {
+        let mode = VisualizerMode::Bars;
+        let mode = mode.next();
+        assert_eq!(mode, VisualizerMode::Oscilloscope);
+        let mode = mode.next();
+        assert_eq!(mode, VisualizerMode::Radial);
+        let mode = mode.next();
+        assert_eq!(mode, VisualizerMode::Particles);
+        let mode = mode.next();
+        assert_eq!(mode, VisualizerMode::Lissajous);
+        let mode = mode.next();
+        assert_eq!(mode, VisualizerMode::Bars);
+    }
+
+    #[test]
+    fn braille_grid_basic() {
+        let mut grid = BrailleGrid::new(10, 5);
+        assert_eq!(grid.px_width(), 20);
+        assert_eq!(grid.px_height(), 20);
+
+        // Set a dot and verify it sticks.
+        assert!(grid.set_dot(0, 0, Color::White));
+        assert_eq!(grid.dots[0], 1 << 0); // top-left dot of cell (0,0).
+
+        // Out of bounds returns false.
+        assert!(!grid.set_dot(20, 0, Color::White));
+        assert!(!grid.set_dot(0, 20, Color::White));
+    }
+
+    #[test]
+    fn braille_grid_line_drawing() {
+        let mut grid = BrailleGrid::new(10, 5);
+        grid.draw_line(0.0, 0.0, 19.0, 19.0, Color::Cyan);
+
+        // At least some dots should be set along the diagonal.
+        let any_set = grid.dots.iter().any(|&d| d != 0);
+        assert!(any_set, "diagonal line should set some dots");
+    }
+
+    #[test]
+    fn particle_system_emits_and_decays() {
+        let mut ps = ParticleSystem::new();
+        let mut spectrum = [0.0f32; NUM_BARS];
+        spectrum[10] = 0.8;
+        spectrum[20] = 0.6;
+
+        // Emit.
+        ps.update(&spectrum, 0.5, 100.0, 100.0, 1.0 / 60.0);
+        assert!(!ps.particles.is_empty(), "should have emitted particles");
+
+        // Decay to death with large dt.
+        for _ in 0..100 {
+            let silence = [0.0f32; NUM_BARS];
+            ps.update(&silence, 0.0, 100.0, 100.0, 0.1);
+        }
+        assert!(
+            ps.particles.is_empty(),
+            "particles should die after enough time"
+        );
+    }
+
+    #[test]
+    fn dim_produces_darker_color() {
+        let bright = Color::Rgb(200, 150, 100);
+        let dark = dim(bright, 0.5);
+        if let (Color::Rgb(r1, g1, b1), Color::Rgb(r2, g2, b2)) = (bright, dark) {
+            assert!(r2 < r1, "red should decrease");
+            assert!(g2 < g1, "green should decrease");
+            assert!(b2 < b1, "blue should decrease");
+        } else {
+            panic!("expected Rgb colors");
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Five visualizer rendering modes using braille characters (U+2800..U+28FF) for 2x4 subpixel resolution per terminal cell
- `M` key cycles: bars -> oscilloscope -> radial -> particles -> lissajous -> bars
- `V` still toggles visualizer on/off
- Mode persisted in `[visualizer] mode` config field
- VizFrame extended with raw waveform samples so oscilloscope/lissajous can render without touching VizBuffer directly (clean lock discipline maintained)
- BrailleGrid abstraction with `set_dot`, `draw_line`, per-cell coloring
- Particle system with Euler physics, ~2000 budget, frequency-band emission
- Lissajous with 4-frame afterglow trail
- All existing palettes (spectrum/fire/neon/mono) and beat-reactive effects apply to all modes

## Test plan

- [x] `cargo test --workspace` -- 107 tests pass
- [x] `cargo clippy --workspace -- -D warnings` -- zero warnings
- [x] `cargo fmt --all` -- formatted
- [ ] Manual: run `koan`, press `M` to cycle through all 5 modes while music plays
- [ ] Manual: verify mode persists across restarts (`config.toml` updated)
- [ ] Manual: verify `V` toggle still works independently of mode

Closes #137

Generated with [Claude Code](https://claude.com/claude-code)