### PR TITLE
feat(tui): fullscreen visualizer toggle (F key)

### DIFF
--- a/crates/koan-music/src/tui/app.rs
+++ b/crates/koan-music/src/tui/app.rs
@@ -277,6 +277,8 @@ pub struct App {
 
     /// Whether to show FPS overlay (from config).
     pub show_fps: bool,
+    /// Fullscreen visualizer mode — hides transport, queue, hints.
+    pub viz_fullscreen: bool,
     /// Timestamp of last FPS sample for computing display FPS.
     fps_sample_time: std::time::Instant,
     /// Frame counter since last FPS sample.
@@ -361,6 +363,7 @@ impl App {
             status_message: None,
             pending_share_status: None,
             show_fps: cfg.playback.show_fps,
+            viz_fullscreen: false,
             viz_config,
             fps_sample_time: std::time::Instant::now(),
             fps_sample_count: 0,
@@ -989,6 +992,13 @@ impl App {
                 let _ = koan_core::config::Config::update_base(|cfg| {
                     cfg.visualizer.enabled = viz_enabled;
                 });
+            }
+            KeyCode::Char('F') => {
+                self.viz_fullscreen = !self.viz_fullscreen;
+                // Enable visualizer if it wasn't already.
+                if self.viz_fullscreen {
+                    self.viz_config.enabled = true;
+                }
             }
             KeyCode::Char('M') => {
                 let next_mode = self.visualizer.mode.next();

--- a/crates/koan-music/src/tui/help_modal.rs
+++ b/crates/koan-music/src/tui/help_modal.rs
@@ -77,6 +77,7 @@ const SECTIONS: &[Section] = &[
             ("R", "Radio mode (auto-queue)"),
             ("V", "Visualiser on/off"),
             ("M", "Visualiser mode cycle"),
+            ("F", "Visualiser fullscreen"),
             ("f", "Favourite track"),
         ],
     },

--- a/crates/koan-music/src/tui/ui.rs
+++ b/crates/koan-music/src/tui/ui.rs
@@ -27,6 +27,24 @@ pub fn render(frame: &mut Frame, app: &mut App) {
 
     let area = frame.area();
 
+    // Fullscreen visualizer — take the entire frame, skip everything else.
+    if app.viz_fullscreen && app.viz_config.enabled {
+        let viz = VisualizerWidget::new(&mut app.visualizer, &app.theme);
+        viz.render(area, frame.buffer_mut());
+
+        // FPS overlay in fullscreen too.
+        if app.show_fps && area.width >= 8 {
+            let beat = app.visualizer.beat_energy;
+            let beat_tag = if beat > 0.3 { " BEAT" } else { "" };
+            let fps_text = format!(" {}fps b:{:.2}{} ", app.display_fps, beat, beat_tag);
+            let w = fps_text.len() as u16;
+            let fps_area = Rect::new(area.x + area.width - w, area.y, w, 1);
+            let fps_line = Line::from(Span::styled(fps_text, app.theme.hint_desc));
+            frame.render_widget(Paragraph::new(fps_line), fps_area);
+        }
+        return;
+    }
+
     let has_art = app.art.now_playing_art.cached().is_some();
     let art_width = app.art_size;
     let art_height = art_width / 2; // square via halfblock rendering


### PR DESCRIPTION
## Summary

- Press `F` to toggle fullscreen visualizer — takes the entire terminal, hides transport/queue/hints
- Press `F` again to return to normal view
- Auto-enables the visualizer if it was off
- FPS/beat overlay works in fullscreen too

🤖 Generated with [Claude Code](https://claude.com/claude-code)