### PR TITLE
release: v0.19.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.19.3 (2026-04-09)
+
+### Fixed
+
+- **Incomplete downloads can't corrupt the cache** — downloads now write to a `.part` file and atomically rename on completion. Interrupted downloads are cleaned up, never mistaken for complete files. Size verification against Content-Length catches server-side truncation. Streaming playback reads from RAM (StreamBuffer) so the rename is invisible to the decoder. ([#143](https://github.com/radiosilence/koan/pull/143))
+
 ## v0.19.2 (2026-04-09)
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2002,7 +2002,7 @@ dependencies = [
 
 [[package]]
 name = "koan-core"
-version = "0.19.2"
+version = "0.19.3"
 dependencies = [
  "bliss-audio",
  "bliss-audio-aubio-rs",
@@ -2037,7 +2037,7 @@ dependencies = [
 
 [[package]]
 name = "koan-music"
-version = "0.19.2"
+version = "0.19.3"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/koan-core", "crates/koan-music"]
 
 [workspace.package]
-version = "0.19.2"
+version = "0.19.3"
 edition = "2024"
 homepage = "https://github.com/radiosilence/koan"
 repository = "https://github.com/radiosilence/koan"

--- a/crates/koan-music/Cargo.toml
+++ b/crates/koan-music/Cargo.toml
@@ -20,7 +20,7 @@ ctrlc = "3"
 crossbeam-channel = "0.5"
 crossterm = "0.28"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "webp"] }
-koan-core = { path = "../koan-core", version = "0.19.2" }
+koan-core = { path = "../koan-core", version = "0.19.3" }
 log = "0.4"
 nucleo = "0.5"
 owo-colors = "4"


### PR DESCRIPTION
Atomic .part downloads, size verification, no more truncated cache files.