### PR TITLE
release: v0.19.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.19.4 (2026-04-11)
+
+### Fixed
+
+- **Braille visualizer modes running at ~11fps instead of 60fps** — the decode thread pushed entire packets to the visualization buffer in one shot, then blocked waiting for the audio ring buffer to drain. For FLAC (4096 frames/packet at 44.1kHz), VizBuffer only got fresh data every ~93ms (~11fps). Spectrum bars hid this with decay smoothing, but waveform-based modes (oscilloscope, lissajous, radial, particles) rendered the same frozen samples 5-6 frames in a row before jumping. VizBuffer writes now happen incrementally inside the ring buffer push loop, paced by the audio callback's real-time consumption rate. All visualizer modes now update at true 60fps.
+
 ## v0.19.3 (2026-04-09)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - **Braille visualizer modes running at ~11fps instead of 60fps** — the decode thread pushed entire packets to the visualization buffer in one shot, then blocked waiting for the audio ring buffer to drain. For FLAC (4096 frames/packet at 44.1kHz), VizBuffer only got fresh data every ~93ms (~11fps). Spectrum bars hid this with decay smoothing, but waveform-based modes (oscilloscope, lissajous, radial, particles) rendered the same frozen samples 5-6 frames in a row before jumping. VizBuffer writes now happen incrementally inside the ring buffer push loop, paced by the audio callback's real-time consumption rate. All visualizer modes now update at true 60fps.
+- **Double-smoothed spectrum bars** — the TUI applied its own decay smoothing on top of the analyzer's, making transients mushier than intended. Spectrum, peaks, and VU levels now pass through directly from the analyzer thread (single layer of smoothing). Beat energy retains local decay for the hue-shift effect.
 
 ## v0.19.3 (2026-04-09)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2002,7 +2002,7 @@ dependencies = [
 
 [[package]]
 name = "koan-core"
-version = "0.19.3"
+version = "0.19.4"
 dependencies = [
  "bliss-audio",
  "bliss-audio-aubio-rs",
@@ -2037,7 +2037,7 @@ dependencies = [
 
 [[package]]
 name = "koan-music"
-version = "0.19.3"
+version = "0.19.4"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/koan-core", "crates/koan-music"]
 
 [workspace.package]
-version = "0.19.3"
+version = "0.19.4"
 edition = "2024"
 homepage = "https://github.com/radiosilence/koan"
 repository = "https://github.com/radiosilence/koan"

--- a/crates/koan-core/src/audio/analyzer.rs
+++ b/crates/koan-core/src/audio/analyzer.rs
@@ -645,6 +645,7 @@ fn analysis_loop(
             };
             snap_out.write(VizFrame {
                 spectrum: state.spectrum,
+                peaks: state.peaks,
                 vu_levels: state.vu_levels,
                 beat_energy: state.beat_energy,
                 timestamp: Instant::now(),

--- a/crates/koan-core/src/audio/buffer.rs
+++ b/crates/koan-core/src/audio/buffer.rs
@@ -657,12 +657,12 @@ fn decode_single(
             sbuf.samples()
         };
 
-        // Copy decoded samples to the visualization buffer (if attached).
-        if let Some(viz) = viz_buffer {
-            viz.push_samples(samples, channels, sample_rate);
-        }
-
         // Push samples into ring buffer, blocking if full.
+        // VizBuffer is updated incrementally inside this loop so it receives
+        // samples at the real-time audio consumption rate (paced by the audio
+        // callback draining the rtrb consumer), not in packet-sized bursts.
+        // Without this, FLAC packets (~93ms each at 44.1kHz) would update the
+        // viz buffer only ~11 times/sec, making waveform modes visibly choppy.
         let mut offset = 0;
         while offset < samples.len() {
             if stop.load(Ordering::Relaxed) {
@@ -692,6 +692,12 @@ fn decode_single(
                 // two loops above — first.len() + second.len() == chunk_size,
                 // and every slot is written via MaybeUninit::write().
                 unsafe { chunk.commit_all() };
+
+                // Feed viz buffer at the same rate as rtrb consumption.
+                if let Some(viz) = viz_buffer {
+                    viz.push_samples(to_write, channels, sample_rate);
+                }
+
                 offset += chunk_size;
             }
         }

--- a/crates/koan-core/src/audio/viz.rs
+++ b/crates/koan-core/src/audio/viz.rs
@@ -49,8 +49,10 @@ pub const WAVEFORM_SAMPLES: usize = 2048;
 /// <1us (memcpy of 48 floats + 2 floats + 1 float + waveform + Instant) while holding the read lock.
 #[derive(Clone)]
 pub struct VizFrame {
-    /// Spectrum bar heights (0.0..1.0), one per bar.
+    /// Spectrum bar heights (0.0..1.0), one per bar. Already smoothed by the analyzer.
     pub spectrum: [f32; NUM_BARS],
+    /// Peak hold values (slowly decaying maxima), one per bar. Managed by the analyzer.
+    pub peaks: [f32; NUM_BARS],
     /// RMS VU levels: [left, right], each 0.0..1.0.
     pub vu_levels: [f32; 2],
     /// Beat energy (0.0..1.0). Spikes on transients in the low bands,
@@ -68,6 +70,7 @@ impl Default for VizFrame {
     fn default() -> Self {
         Self {
             spectrum: [0.0; NUM_BARS],
+            peaks: [0.0; NUM_BARS],
             vu_levels: [0.0; 2],
             beat_energy: 0.0,
             timestamp: std::time::Instant::now(),
@@ -348,6 +351,7 @@ mod tests {
         new_spectrum[5] = 0.9;
         snap.write(VizFrame {
             spectrum: new_spectrum,
+            peaks: [0.0; NUM_BARS],
             vu_levels: [0.5, 0.5],
             beat_energy: 0.0,
             timestamp: std::time::Instant::now(),

--- a/crates/koan-music/src/tui/visualizer.rs
+++ b/crates/koan-music/src/tui/visualizer.rs
@@ -461,15 +461,15 @@ impl LissajousTrail {
 /// Processed visualizer data, ready for rendering.
 ///
 /// All FFT/analysis work is done on a dedicated thread in koan-core (VizAnalyzer).
-/// This struct handles only decay smoothing, peak hold, and rendering on the UI thread.
+/// Spectrum, peaks, and VU levels are passed through directly from the analyzer
+/// (single layer of smoothing). Only beat energy has local decay for the hue-shift effect.
+/// `decay_to_zero` provides graceful falloff when paused/stopped.
 ///
 /// Lock discipline: `update_from_snapshot` acquires the VizSnapshot RwLock for <1us
-/// (clone of ~200 bytes), then does all decay/smoothing on local copies with no locks held.
+/// (clone of ~200 bytes). No further computation on spectrum/peaks.
 pub struct VisualizerState {
     /// Current spectrum bar values (0.0..1.0), one per bar.
     pub spectrum: [f32; NUM_BARS],
-    /// Previous frame's spectrum for decay smoothing.
-    prev_spectrum: [f32; NUM_BARS],
     /// Peak hold values (slowly decaying maxima).
     pub peaks: [f32; NUM_BARS],
     /// RMS levels for VU meters: [left, right].
@@ -517,7 +517,6 @@ impl VisualizerState {
     ) -> Self {
         Self {
             spectrum: [0.0; NUM_BARS],
-            prev_spectrum: [0.0; NUM_BARS],
             peaks: [0.0; NUM_BARS],
             vu_levels: [0.0; 2],
             beat_energy: 0.0,
@@ -546,50 +545,33 @@ impl VisualizerState {
         (bar_decay, peak_decay)
     }
 
-    /// Read the latest analysis frame from VizSnapshot and apply decay/smoothing.
+    /// Read the latest analysis frame from VizSnapshot.
+    ///
+    /// Spectrum, peaks, and VU levels come directly from the analyzer thread
+    /// (which already applies decay smoothing and peak hold). No double-smoothing.
+    /// Only beat energy gets local decay for the hue-shift effect.
     ///
     /// The snapshot read is <1us (RwLock clone of ~200 bytes + waveform vec).
-    /// All decay/smoothing runs on local copies — no locks held during computation.
     /// Called once per frame (~60fps) from `handle_tick()`.
     pub fn update_from_snapshot(&mut self, snapshot: &VizSnapshot) {
-        // Acquire RwLock read, clone frame, release — total <1us.
         let frame = snapshot.read();
 
-        // Save current spectrum as previous for smoothing.
-        std::mem::swap(&mut self.spectrum, &mut self.prev_spectrum);
-
-        // Compute time-based decay factors (no lock held).
-        let (bar_decay, peak_decay) = self.decay_factors();
-
-        let bars = self.spectrum.len().min(frame.spectrum.len());
-        for i in 0..bars {
-            let new_val = frame.spectrum[i];
-            let decayed = self.prev_spectrum[i] * bar_decay;
-            // Take the max of the fresh analysis value and the decayed previous value.
-            self.spectrum[i] = new_val.max(decayed);
-
-            // Peak hold: rise instantly, fall slowly with peak_decay.
-            if self.spectrum[i] > self.peaks[i] {
-                self.peaks[i] = self.spectrum[i];
-            } else {
-                self.peaks[i] *= peak_decay;
-            }
-        }
-
-        // VU levels come directly from the analysis thread — copy as-is.
+        // Spectrum + peaks: pass through directly from analyzer (already smoothed).
+        self.spectrum = frame.spectrum;
+        self.peaks = frame.peaks;
         self.vu_levels = frame.vu_levels;
 
         // Beat energy: rise instantly from analyzer, decay locally for smooth falloff.
+        // Local decay gives the hue-shift a longer tail than the analyzer's own decay.
+        let (bar_decay, _) = self.decay_factors();
         let prev_beat = self.beat_energy;
         self.beat_energy = frame.beat_energy.max(self.beat_energy * bar_decay);
 
         // Beat hue shift: on a fresh beat (energy rising), jump the hue offset forward.
         // Decays back toward 0 between beats for a "snap then relax" feel.
         if self.beat_energy > prev_beat + 0.05 {
-            // Jump: 15-30% hue rotation proportional to beat strength.
             self.beat_hue_offset = (self.beat_hue_offset + self.beat_energy * 0.3) % 1.0;
         } else {
-            // Decay back toward 0 — slower than bar decay for lingering color shift.
             self.beat_hue_offset *= 0.95;
         }
 
@@ -597,7 +579,7 @@ impl VisualizerState {
         self.waveform = frame.waveform;
 
         // Advance radial rotation — slow drift + beat burst.
-        let dt = 1.0 / 60.0; // Approximate frame time.
+        let dt = 1.0 / 60.0;
         self.radial_angle += dt * 0.3 + self.beat_energy * 0.1;
         if self.radial_angle > std::f32::consts::TAU {
             self.radial_angle -= std::f32::consts::TAU;
@@ -1071,6 +1053,7 @@ mod tests {
         spectrum[20] = 0.5;
         snapshot.write(VizFrame {
             spectrum,
+            peaks: [0.0; NUM_BARS],
             vu_levels: [0.6, 0.6],
             beat_energy: 0.3,
             timestamp: Instant::now(),
@@ -1098,6 +1081,7 @@ mod tests {
         let spectrum = [1.0f32; NUM_BARS];
         snapshot.write(VizFrame {
             spectrum,
+            peaks: [1.0; NUM_BARS],
             vu_levels: [1.0, 1.0],
             beat_energy: 0.8,
             timestamp: Instant::now(),
@@ -1137,37 +1121,37 @@ mod tests {
         );
         let snapshot = VizSnapshot::new();
 
-        // Push a loud frame.
+        // Push a loud frame — peaks come from the analyzer via VizFrame.
         let mut spectrum = [0.0f32; NUM_BARS];
         spectrum[5] = 0.9;
+        let mut peaks = [0.0f32; NUM_BARS];
+        peaks[5] = 0.9;
         snapshot.write(VizFrame {
             spectrum,
+            peaks,
             vu_levels: [0.0; 2],
             beat_energy: 0.0,
             timestamp: Instant::now(),
             waveform: Vec::new(),
         });
         state.update_from_snapshot(&snapshot);
-        let peak_after_signal = state.peaks[5];
-        assert!(peak_after_signal > 0.5, "peak should rise with signal");
+        assert!(state.peaks[5] > 0.5, "peak should match analyzer value");
 
-        // Push silence — peak should hold or slowly decay, not jump to zero.
+        // Push silence with decayed peak — simulates analyzer's own peak decay.
+        let mut decayed_peaks = [0.0f32; NUM_BARS];
+        decayed_peaks[5] = 0.7; // Analyzer decayed it a bit.
         snapshot.write(VizFrame {
             spectrum: [0.0; NUM_BARS],
+            peaks: decayed_peaks,
             vu_levels: [0.0; 2],
             beat_energy: 0.0,
             timestamp: Instant::now(),
             waveform: Vec::new(),
         });
-        state.last_update = Instant::now() - std::time::Duration::from_millis(16);
         state.update_from_snapshot(&snapshot);
         assert!(
-            state.peaks[5] <= peak_after_signal,
-            "peak should not grow after silence"
-        );
-        assert!(
             state.peaks[5] > 0.0,
-            "peak should not instantly zero after one frame"
+            "peak should not instantly zero — analyzer provides gradual decay"
         );
     }
 


### PR DESCRIPTION
## Summary

- **fix(visualizer):** braille visualizer modes (oscilloscope, lissajous, radial, particles) were effectively running at ~11fps for FLAC playback. VizBuffer was fed entire decoded packets in one burst, then starved until the next packet. Moved VizBuffer writes inside the rtrb push loop so samples flow at real-time audio consumption rate. All modes now update at true 60fps.
- Version bump 0.19.3 → 0.19.4, changelog updated.

## Changelog

### Fixed

- **Braille visualizer modes running at ~11fps instead of 60fps** — the decode thread pushed entire packets to the visualization buffer in one shot, then blocked waiting for the audio ring buffer to drain. For FLAC (4096 frames/packet at 44.1kHz), VizBuffer only got fresh data every ~93ms (~11fps). Spectrum bars hid this with decay smoothing, but waveform-based modes (oscilloscope, lissajous, radial, particles) rendered the same frozen samples 5-6 frames in a row before jumping. VizBuffer writes now happen incrementally inside the ring buffer push loop, paced by the audio callback's real-time consumption rate. All visualizer modes now update at true 60fps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)