### PR TITLE
fix(db): clean FK references before deleting stale tracks

### DIFF
--- a/crates/koan-core/src/db/queries/tracks.rs
+++ b/crates/koan-core/src/db/queries/tracks.rs
@@ -313,8 +313,11 @@ pub fn remove_stale_tracks(conn: &Connection, folder: &Path) -> Result<usize, Db
                 params![id],
             )?;
         } else {
-            // Pure local — delete entirely.
+            // Pure local — delete entirely. Clean up all FK references first.
             conn.execute("DELETE FROM tracks_fts WHERE rowid = ?1", params![id])?;
+            conn.execute("DELETE FROM lyrics_cache WHERE track_id = ?1", params![id])?;
+            conn.execute("DELETE FROM play_history WHERE track_id = ?1", params![id])?;
+            conn.execute("DELETE FROM track_vectors WHERE track_id = ?1", params![id])?;
             conn.execute("DELETE FROM tracks WHERE id = ?1", params![id])?;
         }
     }


### PR DESCRIPTION
## Summary

`koan scan` failed with `FOREIGN KEY constraint failed` when removing stale tracks that had rows in `lyrics_cache`, `play_history`, or `track_vectors`. Now deletes from all referencing tables before removing the track row.

## Test plan

- [ ] `koan scan` after moving/deleting files completes without FK errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)