### PR TITLE
feat: bitrate display + human-readable quality labels

### DIFF
--- a/crates/koan-core/src/audio/buffer.rs
+++ b/crates/koan-core/src/audio/buffer.rs
@@ -41,6 +41,8 @@ pub struct StreamInfo {
     pub sample_rate: u32,
     pub channels: u16,
     pub bit_depth: Option<u16>,
+    /// Bitrate in kbps. Meaningful for lossy codecs, None for lossless.
+    pub bitrate_kbps: Option<u32>,
     pub duration_ms: u64,
 }
 
@@ -258,13 +260,24 @@ pub fn probe_source(mss: MediaSourceStream, hint: &Hint) -> Result<StreamInfo, D
 
 /// Probe a file and return stream info without decoding.
 pub fn probe_file(path: &Path) -> Result<StreamInfo, DecodeError> {
+    let file_size = std::fs::metadata(path).ok().map(|m| m.len());
     let file = File::open(path)?;
     let mss = MediaSourceStream::new(Box::new(file), Default::default());
     let mut hint = Hint::new();
     if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
         hint.with_extension(ext);
     }
-    probe_mss(mss, &hint)
+    let mut info = probe_mss(mss, &hint)?;
+    // For Opus (and other lossy codecs where symphonia couldn't give us a
+    // bitrate), estimate from file size / duration when both are available.
+    if info.bitrate_kbps.is_none()
+        && info.bit_depth.is_none()
+        && let Some(size) = file_size
+        && info.duration_ms > 0
+    {
+        info.bitrate_kbps = Some((size * 8 / info.duration_ms) as u32);
+    }
+    Ok(info)
 }
 
 /// Internal: probe a `MediaSourceStream` with a hint.
@@ -301,11 +314,18 @@ fn probe_mss(mss: MediaSourceStream, hint: &Hint) -> Result<StreamInfo, DecodeEr
         .unwrap_or(0);
     let codec = codec_name(codec_params.codec);
 
+    // Symphonia doesn't expose bitrate directly. For lossy codecs we can
+    // estimate from bits_per_coded_sample when the demuxer provides it.
+    // Opus estimation from file size is handled in probe_file() where we
+    // have the path; here we only have a MediaSourceStream.
+    let bitrate_kbps = estimate_bitrate_from_codec_params(codec_params);
+
     Ok(StreamInfo {
         codec,
         sample_rate,
         channels,
         bit_depth,
+        bitrate_kbps,
         duration_ms,
     })
 }
@@ -369,6 +389,7 @@ where
         sample_rate: 44100,
         channels: 2,
         bit_depth: Some(16),
+        bitrate_kbps: None,
         duration_ms: 0,
     };
 
@@ -558,6 +579,21 @@ fn decode_single(
     };
     let channels = codec_params.channels.map(|c| c.count() as u16).unwrap_or(2);
 
+    let duration_ms = codec_params
+        .n_frames
+        .map(|f| f * 1000 / sample_rate as u64)
+        .unwrap_or(0);
+
+    // Try codec_params first; fall back to file-size estimation for Opus/lossy.
+    let mut bitrate_kbps = estimate_bitrate_from_codec_params(codec_params);
+    if bitrate_kbps.is_none()
+        && is_opus_codec
+        && let Ok(meta) = std::fs::metadata(path)
+        && duration_ms > 0
+    {
+        bitrate_kbps = Some((meta.len() * 8 / duration_ms) as u32);
+    }
+
     let info = StreamInfo {
         codec: codec_name(codec_params.codec),
         sample_rate,
@@ -567,10 +603,8 @@ fn decode_single(
         } else {
             Some(codec_params.bits_per_sample.unwrap_or(16) as u16)
         },
-        duration_ms: codec_params
-            .n_frames
-            .map(|f| f * 1000 / sample_rate as u64)
-            .unwrap_or(0),
+        bitrate_kbps,
+        duration_ms,
     };
 
     let seek_samples = seek_ms * sample_rate as u64 * channels as u64 / 1000;
@@ -760,6 +794,30 @@ fn decode_single(
     }
 }
 
+/// Estimate bitrate (kbps) from Symphonia codec parameters.
+///
+/// Symphonia doesn't expose a `bit_rate` field. For lossy codecs like MP3/AAC
+/// we can derive it from `bits_per_coded_sample` when the demuxer populates it.
+/// Returns `None` for lossless codecs or when the info isn't available.
+fn estimate_bitrate_from_codec_params(
+    params: &symphonia::core::codecs::CodecParameters,
+) -> Option<u32> {
+    let is_lossy = matches!(
+        params.codec,
+        CODEC_TYPE_MP3 | CODEC_TYPE_AAC | CODEC_TYPE_VORBIS | CODEC_TYPE_OPUS
+    );
+    if !is_lossy {
+        return None;
+    }
+
+    // bits_per_coded_sample * sample_rate / 1000 gives kbps for CBR streams.
+    // Few demuxers fill this in, but it's our best shot without file size.
+    let bpcs = params.bits_per_coded_sample?;
+    let sr = params.sample_rate?;
+    let channels = params.channels.map(|c| c.count() as u32).unwrap_or(2);
+    Some(bpcs * sr * channels / 1000)
+}
+
 pub fn codec_name(codec: CodecType) -> String {
     match codec {
         CODEC_TYPE_FLAC => "FLAC",
@@ -792,6 +850,7 @@ mod tests {
             sample_rate,
             channels,
             bit_depth: Some(16),
+            bitrate_kbps: None,
             duration_ms: 10_000,
         }
     }

--- a/crates/koan-core/src/graphql_client.rs
+++ b/crates/koan-core/src/graphql_client.rs
@@ -66,7 +66,7 @@ impl GraphQLClient {
     pub fn now_playing(&self) -> Result<NowPlaying, GraphQLError> {
         let data = self.execute(
             "{ nowPlaying { state positionMs durationMs queueItemId \
-             track { title artist album codec sampleRate bitDepth channels durationMs } } }",
+             track { title artist album codec sampleRate bitDepth bitrateKbps channels durationMs } } }",
             None,
         )?;
         let np = &data["nowPlaying"];
@@ -86,6 +86,7 @@ impl GraphQLClient {
                     codec: t["codec"].as_str().unwrap_or("").to_string(),
                     sample_rate: t["sampleRate"].as_u64().unwrap_or(0) as u32,
                     bit_depth: t["bitDepth"].as_u64().map(|v| v as u16),
+                    bitrate_kbps: t["bitrateKbps"].as_u64().map(|v| v as u32),
                     channels: t["channels"].as_u64().unwrap_or(0) as u16,
                     duration_ms: t["durationMs"].as_u64().unwrap_or(0),
                 })
@@ -347,6 +348,7 @@ pub struct NowPlayingTrack {
     pub codec: String,
     pub sample_rate: u32,
     pub bit_depth: Option<u16>,
+    pub bitrate_kbps: Option<u32>,
     pub channels: u16,
     pub duration_ms: u64,
 }

--- a/crates/koan-core/src/player/mod.rs
+++ b/crates/koan-core/src/player/mod.rs
@@ -248,6 +248,7 @@ impl Player {
             codec: info.codec.clone(),
             sample_rate: info.sample_rate,
             bit_depth: info.bit_depth,
+            bitrate_kbps: info.bitrate_kbps,
             channels: info.channels,
             duration_ms: info.duration_ms,
         }));
@@ -465,6 +466,7 @@ impl Player {
             codec: info.codec.clone(),
             sample_rate: info.sample_rate,
             bit_depth: info.bit_depth,
+            bitrate_kbps: info.bitrate_kbps,
             channels: info.channels,
             duration_ms: info.duration_ms,
         }));
@@ -899,6 +901,7 @@ impl Player {
                     codec: info.codec,
                     sample_rate: info.sample_rate,
                     bit_depth: info.bit_depth,
+                    bitrate_kbps: info.bitrate_kbps,
                     channels: info.channels,
                     duration_ms: info.duration_ms,
                 }));

--- a/crates/koan-core/src/player/state.rs
+++ b/crates/koan-core/src/player/state.rs
@@ -55,6 +55,7 @@ pub struct TrackInfo {
     pub codec: String,
     pub sample_rate: u32,
     pub bit_depth: Option<u16>,
+    pub bitrate_kbps: Option<u32>,
     pub channels: u16,
     pub duration_ms: u64,
 }

--- a/crates/koan-music/src/commands/graphql/queries.rs
+++ b/crates/koan-music/src/commands/graphql/queries.rs
@@ -382,6 +382,7 @@ impl QueryRoot {
                 codec: info.codec.clone(),
                 sample_rate: info.sample_rate,
                 bit_depth: info.bit_depth,
+                bitrate_kbps: info.bitrate_kbps,
                 channels: info.channels,
                 duration_ms: info.duration_ms,
             };

--- a/crates/koan-music/src/commands/graphql/types.rs
+++ b/crates/koan-music/src/commands/graphql/types.rs
@@ -318,6 +318,7 @@ pub(super) struct GqlNowPlayingTrack {
     pub codec: String,
     pub sample_rate: u32,
     pub bit_depth: Option<u16>,
+    pub bitrate_kbps: Option<u32>,
     pub channels: u16,
     pub duration_ms: u64,
 }

--- a/crates/koan-music/src/commands/probe.rs
+++ b/crates/koan-music/src/commands/probe.rs
@@ -20,6 +20,9 @@ pub fn cmd_probe(path: &Path) {
             if let Some(bd) = info.bit_depth {
                 println!("{} {}", "bit depth:".cyan(), bd);
             }
+            if let Some(kbps) = info.bitrate_kbps {
+                println!("{} {} kbps", "bitrate:".cyan(), kbps);
+            }
             println!("{} {}", "channels:".cyan(), info.channels);
             println!(
                 "{} {} {}",

--- a/crates/koan-music/src/remote_bridge.rs
+++ b/crates/koan-music/src/remote_bridge.rs
@@ -232,6 +232,7 @@ fn poll_and_stream_loop(
                         codec: track.codec.clone(),
                         sample_rate: track.sample_rate,
                         bit_depth: track.bit_depth,
+                        bitrate_kbps: track.bitrate_kbps,
                         channels: track.channels,
                         duration_ms: track.duration_ms,
                     }));

--- a/crates/koan-music/src/tui/track_info.rs
+++ b/crates/koan-music/src/tui/track_info.rs
@@ -146,6 +146,9 @@ impl Widget for TrackInfoOverlay<'_> {
             if let Some(bd) = info.bit_depth {
                 field("Bit Depth", &bd.to_string());
             }
+            if let Some(kbps) = info.bitrate_kbps {
+                field("Bitrate", &format!("{} kbps", kbps));
+            }
             field("Channels", &info.channels.to_string());
         }
 

--- a/crates/koan-music/src/tui/transport.rs
+++ b/crates/koan-music/src/tui/transport.rs
@@ -8,6 +8,56 @@ use koan_core::player::state::{PlaybackState, QueueEntry, TrackInfo};
 
 use super::theme::Theme;
 
+/// Format audio quality info as a human-readable string.
+///
+/// Examples: "CD quality", "FLAC 96kHz/24bit", "Opus 48kHz/128kbps", "MP3 320kbps"
+#[allow(clippy::manual_is_multiple_of)]
+pub fn format_quality(info: &TrackInfo) -> String {
+    let rate = info.sample_rate;
+    let ch = info.channels;
+
+    // Human-friendly sample rate.
+    let rate_str = match rate {
+        44100 => "44.1kHz".to_string(),
+        48000 => "48kHz".to_string(),
+        88200 => "88.2kHz".to_string(),
+        96000 => "96kHz".to_string(),
+        176400 => "176.4kHz".to_string(),
+        192000 => "192kHz".to_string(),
+        352800 => "352.8kHz".to_string(),
+        384000 => "384kHz".to_string(),
+        _ if rate % 1000 == 0 => format!("{}kHz", rate / 1000),
+        _ => format!("{}Hz", rate),
+    };
+
+    // Quality label for well-known configurations.
+    let label = match (info.codec.as_str(), rate, info.bit_depth, ch) {
+        (_, 44100, Some(16), 2) => return format!("{} · CD quality", info.codec),
+        (_, 44100, Some(16), 1) => return format!("{} · CD quality (mono)", info.codec),
+        _ => None::<&str>,
+    };
+    let _ = label; // Unused — matched above return early.
+
+    // Detail: bit depth for lossless, bitrate for lossy.
+    let detail = if let Some(b) = info.bit_depth {
+        format!("/{}bit", b)
+    } else if let Some(kbps) = info.bitrate_kbps {
+        format!("/{}kbps", kbps)
+    } else {
+        String::new()
+    };
+
+    let ch_str = if ch == 1 {
+        "mono"
+    } else if ch == 2 {
+        "stereo"
+    } else {
+        return format!("{} {}{}/{}ch", info.codec, rate_str, detail, ch);
+    };
+
+    format!("{} {}{} {}", info.codec, rate_str, detail, ch_str)
+}
+
 pub struct TransportBar<'a> {
     track_info: Option<&'a TrackInfo>,
     playing_entry: Option<&'a QueueEntry>,
@@ -254,14 +304,7 @@ impl Widget for TransportBar<'_> {
                     album_spans.push(Span::styled(format!(" ({})", year), self.theme.hint_desc));
                 }
 
-                let bit_str = info
-                    .bit_depth
-                    .map(|b| format!("/{}bit", b))
-                    .unwrap_or_default();
-                let format_info = format!(
-                    " \u{00B7} {} {}Hz{}/{}ch",
-                    info.codec, info.sample_rate, bit_str, info.channels
-                );
+                let format_info = format!(" \u{00B7} {}", format_quality(info));
                 album_spans.push(Span::styled(format_info, self.theme.hint_desc));
 
                 let album_line = Line::from(album_spans);
@@ -276,14 +319,7 @@ impl Widget for TransportBar<'_> {
                 .to_string_lossy()
                 .to_string();
 
-            let bit_str = info
-                .bit_depth
-                .map(|b| format!("/{}bit", b))
-                .unwrap_or_default();
-            let format_info = format!(
-                "{} {}Hz{}/{}ch",
-                info.codec, info.sample_rate, bit_str, info.channels
-            );
+            let format_info = format_quality(info);
 
             let info_line = Line::from(vec![
                 Span::raw(" "),


### PR DESCRIPTION
## Summary

- **Bitrate for lossy codecs**: `bitrate_kbps` wired through StreamInfo → TrackInfo → transport/track info/probe/GraphQL. Estimated from file size / duration for Opus.
- **Quality labels**: `format_quality()` replaces raw format strings. "FLAC · CD quality", "Opus 48kHz/128kbps stereo", "FLAC 96kHz/24bit stereo".
- Sample rates: 44100→44.1kHz, channels: 2ch→stereo

## Test plan

- [ ] FLAC 44.1/16/stereo shows "FLAC · CD quality"
- [ ] Hi-res FLAC shows "FLAC 96kHz/24bit stereo"  
- [ ] Opus shows "Opus 48kHz/Xkbps stereo" with estimated bitrate
- [ ] MP3 shows "MP3 44.1kHz/320kbps stereo"
- [ ] Track info modal shows Bitrate field for lossy, hides for lossless

🤖 Generated with [Claude Code](https://claude.com/claude-code)