### PR TITLE
fix(gql): disable nodes field on connections, edges-only

### DIFF
--- a/crates/koan-server/src/graphql/helpers.rs
+++ b/crates/koan-server/src/graphql/helpers.rs
@@ -1,12 +1,14 @@
 use std::sync::Arc;
 
-use async_graphql::connection::{Connection, Edge, EmptyFields};
+use async_graphql::connection::Edge;
 use crossbeam_channel::Sender;
 use koan_core::config::Config;
 use koan_core::db::connection::Database;
 use koan_core::db::queries;
 use koan_core::player::commands::PlayerCommand;
 use koan_core::player::state::{QueueItemId, SharedPlayerState};
+
+use super::types::Conn;
 
 // ---------------------------------------------------------------------------
 // Pagination helper — uses usize as cursor (async-graphql has built-in impl)
@@ -16,7 +18,7 @@ pub(super) fn paginate<T: async_graphql::OutputType>(
     items: Vec<T>,
     after: Option<String>,
     first: Option<i32>,
-) -> async_graphql::Result<Connection<usize, T, EmptyFields, EmptyFields>> {
+) -> async_graphql::Result<Conn<T>> {
     let total = items.len();
 
     let start = if let Some(ref cursor) = after {
@@ -31,7 +33,7 @@ pub(super) fn paginate<T: async_graphql::OutputType>(
         total
     };
 
-    let mut conn = Connection::new(start > 0, end < total);
+    let mut conn = Conn::new(start > 0, end < total);
     for (i, item) in items.into_iter().enumerate().skip(start).take(end - start) {
         conn.edges.push(Edge::new(i, item));
     }

--- a/crates/koan-server/src/graphql/queries.rs
+++ b/crates/koan-server/src/graphql/queries.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use async_graphql::connection::{Connection, EmptyFields};
 use async_graphql::{Context, Object};
 use koan_core::audio;
 use koan_core::db::queries;
@@ -30,7 +29,7 @@ impl QueryRoot {
         first: Option<i32>,
         #[graphql(default_with = "ArtistSortField::Name")] _sort_by: ArtistSortField,
         #[graphql(default_with = "SortDirection::Asc")] _sort_dir: SortDirection,
-    ) -> async_graphql::Result<Connection<usize, GqlArtist, EmptyFields, EmptyFields>> {
+    ) -> async_graphql::Result<Conn<GqlArtist>> {
         let db = ctx.data::<DbHandle>()?.open()?;
         let mut artists = if let Some(ref query) = search {
             queries::find_artists(&db.conn, query)
@@ -88,7 +87,7 @@ impl QueryRoot {
         first: Option<i32>,
         #[graphql(default_with = "AlbumSortField::ArtistThenDate")] _sort_by: AlbumSortField,
         #[graphql(default_with = "SortDirection::Asc")] _sort_dir: SortDirection,
-    ) -> async_graphql::Result<Connection<usize, GqlAlbum, EmptyFields, EmptyFields>> {
+    ) -> async_graphql::Result<Conn<GqlAlbum>> {
         let db = ctx.data::<DbHandle>()?.open()?;
 
         let mut albums = if let Some(aid) = artist_id {
@@ -203,7 +202,7 @@ impl QueryRoot {
         first: Option<i32>,
         #[graphql(default_with = "TrackSortField::ArtistAlbumDiscTrack")] _sort_by: TrackSortField,
         #[graphql(default_with = "SortDirection::Asc")] _sort_dir: SortDirection,
-    ) -> async_graphql::Result<Connection<usize, GqlTrack, EmptyFields, EmptyFields>> {
+    ) -> async_graphql::Result<Conn<GqlTrack>> {
         let db = ctx.data::<DbHandle>()?.open()?;
 
         let mut tracks = if let Some(ref query) = search {
@@ -454,7 +453,7 @@ impl QueryRoot {
         ctx: &Context<'_>,
         after: Option<String>,
         first: Option<i32>,
-    ) -> async_graphql::Result<Connection<usize, GqlTrack, EmptyFields, EmptyFields>> {
+    ) -> async_graphql::Result<Conn<GqlTrack>> {
         let db = ctx.data::<DbHandle>()?.open()?;
         let fav_paths = queries::load_favourites(&db.conn)
             .map_err(|e| async_graphql::Error::new(format!("db error: {}", e)))?;

--- a/crates/koan-server/src/graphql/types.rs
+++ b/crates/koan-server/src/graphql/types.rs
@@ -1,10 +1,21 @@
+use async_graphql::connection::{DisableNodesField, EmptyFields};
 use async_graphql::{Context, Enum, Object, SimpleObject};
-
-use async_graphql::connection::{Connection, EmptyFields};
 use koan_core::db::queries;
 
 use super::DbHandle;
 use super::helpers::paginate;
+
+/// Connection type alias — standard async-graphql Connection with `nodes` field disabled.
+/// Exposes `edges` + `pageInfo` only (proper Relay spec).
+pub(super) type Conn<T> = async_graphql::connection::Connection<
+    usize,
+    T,
+    EmptyFields,
+    EmptyFields,
+    async_graphql::connection::DefaultConnectionName,
+    async_graphql::connection::DefaultEdgeName,
+    DisableNodesField,
+>;
 
 // ---------------------------------------------------------------------------
 // Enums
@@ -84,7 +95,7 @@ impl GqlArtist {
         ctx: &Context<'_>,
         after: Option<String>,
         first: Option<i32>,
-    ) -> async_graphql::Result<Connection<usize, GqlAlbum, EmptyFields, EmptyFields>> {
+    ) -> async_graphql::Result<Conn<GqlAlbum>> {
         let db = ctx.data::<DbHandle>()?.open()?;
         let all = queries::albums_for_artist(&db.conn, self.row.id)
             .map_err(|e| async_graphql::Error::new(format!("db error: {}", e)))?;
@@ -100,7 +111,7 @@ impl GqlArtist {
         ctx: &Context<'_>,
         after: Option<String>,
         first: Option<i32>,
-    ) -> async_graphql::Result<Connection<usize, GqlTrack, EmptyFields, EmptyFields>> {
+    ) -> async_graphql::Result<Conn<GqlTrack>> {
         let db = ctx.data::<DbHandle>()?.open()?;
         let all = queries::tracks_for_artist(&db.conn, self.row.id)
             .map_err(|e| async_graphql::Error::new(format!("db error: {}", e)))?;
@@ -169,7 +180,7 @@ impl GqlAlbum {
         ctx: &Context<'_>,
         after: Option<String>,
         first: Option<i32>,
-    ) -> async_graphql::Result<Connection<usize, GqlTrack, EmptyFields, EmptyFields>> {
+    ) -> async_graphql::Result<Conn<GqlTrack>> {
         let db = ctx.data::<DbHandle>()?.open()?;
         let all = queries::tracks_for_album(&db.conn, self.row.id)
             .map_err(|e| async_graphql::Error::new(format!("db error: {}", e)))?;


### PR DESCRIPTION
## Summary

- async-graphql's `Connection` type exposes both `edges` and `nodes` by default. The `nodes` field is a GitHub-style convenience shortcut that duplicates data from edges — not part of the Relay Connection spec.
- Switched to `DisableNodesField` (a built-in type parameter in async-graphql) so connections only expose `edges` + `pageInfo`.
- Introduced `Conn<T>` type alias to avoid repeating the 7-generic-param `Connection` type everywhere.
- All 8 connection return sites updated (artists, albums, tracks, favourites, nested Artist.albums, Artist.tracks, Album.tracks).

Zero custom types — uses async-graphql's built-in mechanism.

## Test plan

- [x] `cargo test --workspace` — 598 tests pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --all` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)