### PR TITLE
docs: comprehensive audit and update

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -7,15 +7,23 @@ Developer manual for working on koan. Read this before touching the code.
 ```
 crates/
 ├── koan-core/     Library crate. Audio engine, player, database, indexer,
-│                  format strings, file organization, remote client.
+│                  format strings, file organization, remote client, auth.
 │                  No UI code, no terminal deps.
 │
-└── koan-music/      Binary crate. The `koan` executable.
-                   Ratatui TUI, CLI arg parsing, media keys.
-                   Depends on koan-core.
+├── koan-tui/      Library crate. Ratatui TUI, visualizers, media keys,
+│                  transport, download queue. Exports `run_tui()`.
+│                  Depends on koan-core and koan-server.
+│
+├── koan-server/   Library crate. GraphQL (async-graphql + axum),
+│                  Subsonic REST API, MCP server.
+│                  Depends on koan-core.
+│
+└── koan-cli/      Binary crate. The `koan` executable.
+                   Thin entry point: clap CLI, logger, signal handling.
+                   Depends on koan-core, koan-tui, koan-server.
 ```
 
-Two crates, one workspace. `koan-core` is the engine, `koan-music` is the interface. If you wanted a different UI (GUI, web, whatever), you'd write a new crate that depends on `koan-core` — the CLI doesn't own any business logic.
+Four crates, one workspace. `koan-core` is the engine, `koan-tui` is the terminal UI, `koan-server` is the API layer, and `koan-cli` is the binary that ties them together. Dependency rules are enforced by Cargo: `koan-tui` and `koan-server` cannot import each other. If you wanted a different UI, write a new crate against `koan-core` -- the CLI owns zero business logic.
 
 ## Threading model
 
@@ -231,56 +239,41 @@ fb2k-compatible template engine.
 | `organize.rs` | File renaming using format strings. Preview/execute/undo. Scoped operations via `preview_for_tracks()`/`execute_for_tracks()` (used by TUI modal). Moves ancillary files (cover art, cue sheets). Logs moves for undo. |
 | `lyrics.rs` | LRCLIB lyrics fetching and parsing (synced LRC + plain text). Cached per-track in SQLite. |
 
-## koan-music modules
+## koan-cli modules
 
-### `main.rs`
+Thin binary crate. `main.rs` has the clap CLI struct definitions, match dispatch, logger setup, and signal handling. Delegates everything to command handlers (some in koan-cli itself, some calling into koan-tui and koan-server).
 
-CLI entry point (clap). Struct definitions, match dispatch, logger. Delegates everything to `commands/` modules.
-
-### `commands/`
-
-Subcommand handlers split into focused modules:
-
-| File | Functions |
-|---|---|
-| `mod.rs` | Shared helpers: `open_db`, `format_time`, `format_bytes`, `install_terminal_panic_hook`, `get_remote_password`, `sanitise_filename`, `cache_path_for_track`, `playlist_item_from_track`, `playlist_items_from_paths` |
-| `play.rs` | `cmd_play` (path resolution, player spawn), `run_tui` (event loop, picker loading, enqueue routing) |
-| `probe.rs` | `cmd_probe`, `cmd_devices` |
-| `scan.rs` | `cmd_scan` |
-| `search.rs` | `cmd_search` (FTS5 search with tree-grouped output) |
-| `library.rs` | `cmd_artists`, `cmd_albums`, `cmd_library` |
-| `config.rs` | `cmd_config`, `cmd_init` |
-| `remote.rs` | `cmd_remote_login`, `cmd_remote_sync`, `cmd_remote_status` |
-| `cache.rs` | `cmd_cache_status`, `cmd_cache_clear` |
-| `organize.rs` | `cmd_organize` |
-| `pick.rs` | `cmd_pick` (standalone fuzzy picker TUI) |
-| `enqueue.rs` | `enqueue_playlist` (action-aware: append/play/replace), `resolve_item_path`, `download_single_track` |
-| `picker_items.rs` | `load_picker_items`, `make_track_picker_items`, `make_album_picker_items`, `make_artist_picker_items` |
-
-### `tui/`
+## koan-tui modules
 
 | File | Purpose |
 |---|---|
 | `app.rs` | `App` struct (state machine), `Mode` enum, `PickerAction` enum, `ContextAction` enum, event handlers (key/mouse per mode). Sub-state structs: `QueueState`, `LayoutRects`, `ArtState`. |
-| `ui.rs` | Render pipeline: layout computation → transport bar → content area (queue ± library) → overlays (picker, context menu, organize, track info, cover art zoom) → hint bar |
-| `transport.rs` | `TransportBar` widget: seek bar (━─), current track info, click-to-seek |
+| `ui.rs` | Render pipeline: layout computation -> transport bar -> content area (queue +/- library) -> overlays (picker, context menu, organize, track info, cover art zoom) -> hint bar |
+| `transport.rs` | `TransportBar` widget: seek bar, current track info, click-to-seek |
 | `queue.rs` | `QueueView` widget: album-grouped display with headers, status icons, selection markers, drag target line |
-| `library.rs` | `LibraryState` + `LibraryView`: flattened tree (artist→album→track), expand/collapse, substring filter with cached artist list |
+| `library.rs` | `LibraryState` + `LibraryView`: flattened tree (artist->album->track), expand/collapse, substring filter with cached artist list |
 | `picker.rs` | `PickerState`: Nucleo fuzzy search engine, multi-select, colored result parts. Sentinel helpers for artist drill-down. |
-| `cover_art.rs` | Halfblock rendering: extract from tags → resize with Lanczos3 → 2 pixels per terminal cell (upper half block char with FG/BG colors). Forces even pixel height to prevent black bar artifacts. |
+| `cover_art.rs` | Halfblock rendering: extract from tags -> resize with Lanczos3 -> 2 pixels per terminal cell (upper half block char with FG/BG colors). Forces even pixel height to prevent black bar artifacts. |
 | `track_info.rs` | `TrackInfoOverlay`: modal with full metadata fields + embedded album art |
 | `theme.rs` | Color palette. Cyan for active/cursor, green for albums, DarkGray for hints. |
 | `context_menu.rs` | `ContextMenuOverlay` widget: action list popup (currently: Organize) |
 | `organize.rs` | `OrganizeModalState` + `OrganizeOverlay`: pattern picker, scoped preview table, background execute with path update propagation to player |
-| `visualizer.rs` | Spectrum analyzer widget: reads `VizSnapshot`, renders 48-band bars with Unicode block chars, peak markers. Configurable palettes (`mono`/`spectrum`/`fire`/`neon`) with frequency-mapped gradients, beat-reactive brightness, and peak glow |
+| `visualizer.rs` | 22-mode visualizer: bars, oscilloscope, radial, particles, lissajous, spectrogram, stereo waveform, VU meter, flame, plasma, tunnel, wireframe, metaballs, starfield, terrain, moire, kaleidoscope, julia, spiral, interference, wormhole, matrix. Picker with live preview, matrix overlay, bass shake. |
+| `viz_picker.rs` | Visualizer mode picker modal with live preview |
 | `lyrics.rs` | Lyrics side panel: synced (LRC) line highlighting with auto-scroll, plain text fallback |
 | `device_selector.rs` | Audio output device selection modal |
 | `help_modal.rs` | Help overlay with key binding reference |
 | `keys.rs` | `HintBar` widget: mode-specific key binding hints |
+| `media_keys.rs` | macOS Control Center integration via souvlaki. Pumps CFRunLoop manually (terminal apps don't have a Cocoa event loop). Maps media key events to PlayerCommands. |
 
-### `media_keys.rs`
+## koan-server modules
 
-macOS Control Center integration via souvlaki. Pumps CFRunLoop manually (terminal apps don't have a Cocoa event loop). Maps media key events to PlayerCommands: play/pause/stop, next/prev, seek (absolute + relative), quit. Sends track metadata including album art (extracted to temp file, passed as file:// URL).
+| File | Purpose |
+|---|---|
+| `graphql/` | async-graphql schema, resolvers, axum HTTP server. Relay pagination, rich filters, mutations for playback/queue/library/favourites/snapshots/radio. |
+| `subsonic/` | Subsonic REST API endpoints for compatibility with existing clients (DSub, Symfonium, play:Sub). |
+| `mcp.rs` | MCP server on stdio -- exposes `schema_sdl` and `graphql` tools for Claude Desktop integration. |
+| `auth.rs` | JWT middleware, Ed25519 token generation/validation, role-based guards. |
 
 ## Picker actions
 
@@ -320,7 +313,7 @@ Mouse works in every mode — modality is keyboard-only. Double-click a queue tr
 
 **Audio path:** `audio/buffer.rs` has `start_decode` → `decode_queue_loop` → `decode_single` (the actual Symphonia decode loop). `audio/backend.rs` defines the `AudioBackend` trait; platform implementations live in `coreaudio_backend.rs` (macOS) and `cpal_backend.rs` (Linux).
 
-**TUI:** `koan-music/src/tui/app.rs` is the state machine. Follow `handle_normal_key()` for the main mode, `handle_tick()` for the per-frame update cycle. `ui.rs` is the render pipeline.
+**TUI:** `koan-tui/src/app.rs` is the state machine. Follow `handle_normal_key()` for the main mode, `handle_tick()` for the per-frame update cycle. `ui.rs` is the render pipeline.
 
 **Database:** Start at `db/schema.rs` for the table definitions, then `db/queries/tracks.rs` for the dedup logic in `upsert_track`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ just fmt
 
 ## Architecture
 
-Two crates: `koan-core` (library — audio engine, player, database, indexer) and `koan-music` (binary — TUI, CLI). See [ARCHITECTURE.md](ARCHITECTURE.md) for the full technical manual.
+Four crates: `koan-core` (library -- audio engine, player, database, indexer), `koan-tui` (TUI, visualizers, media keys), `koan-server` (GraphQL, Subsonic REST, MCP), and `koan-cli` (binary -- CLI entry point). See [ARCHITECTURE.md](ARCHITECTURE.md) for the full technical manual.
 
 If you're touching the audio path: the render callback must never allocate or lock. Read the threading model docs before changing anything in `audio/`.
 

--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ brew install radiosilence/koan/koan
 mise use -g github:radiosilence/koan@latest
 
 # or via cargo
-cargo install koan-music
+cargo install koan-cli
 
 # or build from source
 git clone https://github.com/radiosilence/koan.git && cd koan
-cargo install --path crates/koan-music
+cargo install --path crates/koan-cli
 ```
 
 Single binary. macOS works out of the box (CoreAudio). Linux needs ALSA dev headers:
@@ -66,7 +66,8 @@ Local and remote tracks merge into one library. Local files take playback priori
 - **Bit-perfect playback** -- CoreAudio AUHAL / ALSA via cpal, automatic sample rate switching, no resampling
 - **Gapless transitions** -- decode thread keeps the ring buffer alive across track boundaries
 - **Format support** -- FLAC, MP3, AAC, Vorbis, Opus, ALAC, ADPCM, WAV/AIFF/CAF, Ogg, MKV/WebM, MP4
-- **Full-screen TUI** -- transport bar with album art, album-grouped queue, fuzzy picker, library browser, track info modal, spectrum analyzer, lyrics panel, mouse support
+- **Full-screen TUI** -- transport bar with album art, album-grouped queue, fuzzy picker, library browser, track info modal, visualizer, lyrics panel, mouse support
+- **Authentication** -- Ed25519 JWT tokens, three roles (admin/user/readonly), 1Password CLI integration
 - **Subsonic/Navidrome** -- incremental sync, unified local+remote browsing, streaming playback, favourite sync
 - **Radio mode** -- infinite play using Subsonic similarity, cached artist relationships, and genre matching
 - **ReplayGain** -- track and album modes with peak limiting and configurable pre-amp
@@ -78,7 +79,7 @@ Local and remote tracks merge into one library. Local files take playback priori
 - **SQLite FTS5 search** -- full-text search across your entire library
 - **Media keys** -- macOS Control Center integration (play/pause, next/prev, now playing info)
 - **Lyrics** -- synced (LRC) and plain lyrics from LRCLIB, current line highlighting
-- **22 visualizer modes** -- spectrum bars, oscilloscope, radial, particles, lissajous, spectrogram, stereo waveform, VU meter, flame, plasma, tunnel, wireframe, metaballs, starfield, pleasures, moiré, kaleidoscope, julia fractal, spiral, interference, wormhole, matrix rain. Picker with live preview (`v`), matrix overlay (`X`), bass shake (`S`), configurable reactivity
+- **22 visualizer modes** -- spectrum bars, oscilloscope, radial, particles, lissajous, spectrogram, stereo waveform, VU meter, flame, plasma, tunnel, wireframe, metaballs, starfield, terrain, moiré, kaleidoscope, julia fractal, spiral, interference, wormhole, matrix rain. Picker with live preview (`v`), matrix overlay (`X`), bass shake (`S`), configurable reactivity
 
 <img width="815" height="598" alt="Screenshot 2026-03-04 at 18 30 43" src="https://github.com/user-attachments/assets/9dab1d13-5d48-4e60-8625-7d72dd2e7957" />
 
@@ -107,13 +108,14 @@ No TUI player combines bit-perfect audio, Subsonic streaming, album art, fb2k-st
 | **Media keys** | **macOS CC** | Via MPRIS | Via MPRIS | -- | Via MPRIS | Via MPRIS | -- |
 | **Drag & drop** | **Finder -> TUI** | No | No | No | No | No | No |
 | **Lyrics** | **Synced + plain** | Via MPD | No | Plugin | No | Via MPD | No |
-| **Spectrum analyzer** | **48-band FFT** | No | No | No | No | No | No |
+| **Visualizer** | **22 modes** | No | No | No | No | No | No |
 | **Favourites** | **Yes (syncs)** | Via MPD | No | Yes | No | Via MPD | **Yes** |
 | **Streaming playback** | **Yes (256KB)** | Via MPD | No | No | No | Via MPD | **Yes** |
 | **API / MCP** | **GraphQL + MCP** | MPD protocol | No | No | No | MPD protocol | No |
 | **Tag editing** | Soon | Via MPD | No | Yes | Yes | Via MPD | No |
 | **DSP / EQ** | Soon | Via MPD | Yes | Yes | No | Via MPD | No |
-| **Platforms** | macOS | Linux/macOS | Linux/macOS/BSD | Linux/macOS/Win | Linux/macOS/Win | Linux/macOS | Linux/macOS |
+| **Auth** | **JWT + roles** | No | No | No | No | No | No |
+| **Platforms** | macOS, Linux | Linux/macOS | Linux/macOS/BSD | Linux/macOS/Win | Linux/macOS/Win | Linux/macOS | Linux/macOS |
 | **Maintained** | Yes | Yes | Yes (2.12.0) | Slowing | Yes | Very active | Stale |
 
 ### Desktop players (GUI)
@@ -129,10 +131,10 @@ No TUI player combines bit-perfect audio, Subsonic streaming, album art, fb2k-st
 | **File organization** | **Yes** | Yes (component) | **Yes** | No |
 | **Queue undo/redo** | **100-deep** | Partial | No | Yes |
 | **Lyrics** | **Synced + plain** | Plugin | No | Plugin |
-| **Spectrum analyzer** | **48-band FFT** | Plugin | No | Plugin |
+| **Visualizer** | **22 modes** | Plugin | No | Plugin |
 | **Tag editing** | Soon | **Yes** | Yes | **Yes** |
 | **DSP / EQ** | Soon | **Yes (VST)** | Yes | Yes |
-| **Platforms** | macOS | Windows/macOS | All | All |
+| **Platforms** | macOS, Linux | Windows/macOS | All | All |
 
 <img width="768" height="612" alt="Screenshot 2026-03-04 at 18 31 01" src="https://github.com/user-attachments/assets/0ad4879e-815f-42f3-8ebe-f6d01616bc96" />
 
@@ -141,6 +143,7 @@ No TUI player combines bit-perfect audio, Subsonic streaming, album art, fb2k-st
 | Guide | What it covers |
 |-------|---------------|
 | **[Getting Started](docs/getting-started.md)** | First-time setup, local and remote libraries, your first session |
+| **[Authentication](docs/guide/authentication.md)** | JWT auth, user management, 1Password integration, recovery |
 | **[Radio Mode](docs/guide/radio-mode.md)** | Infinite play, similarity scoring, tuning discovery |
 | **[Remote Servers](docs/guide/remote-servers.md)** | Navidrome/Subsonic setup, sync, streaming, cache management |
 | **[File Organization](docs/guide/file-organization.md)** | Rename and reorganize your library from the TUI |
@@ -160,11 +163,10 @@ No TUI player combines bit-perfect audio, Subsonic streaming, album art, fb2k-st
 File -> Symphonia -> f32 samples -> rtrb ring buffer -> CoreAudio/cpal callback -> DAC
 ```
 
-Two crates: `koan-core` (audio engine, player, database, indexer) and `koan-music` (`koan` binary, TUI). See [ARCHITECTURE.md](ARCHITECTURE.md) for the full technical manual.
+Four crates: `koan-core` (audio engine, player, database, indexer), `koan-tui` (Ratatui TUI, visualizers, media keys), `koan-server` (GraphQL, Subsonic REST, MCP), and `koan-cli` (the `koan` binary). See [ARCHITECTURE.md](ARCHITECTURE.md) for the full technical manual.
 
 ## Coming soon
 
-- **Linux support** -- ALSA/PipeWire backends via trait-based audio abstraction ([plan](/.claude/plans/01-linux-and-audio-backends.md))
 - **DSP pipeline** -- EQ, headphone correction profiles, crossfeed ([plan](/.claude/plans/02-dsp-and-profiles.md))
 - **Tag editing** -- inline editing, bulk operations, vimv-style external editor ([plan](/.claude/plans/04-tagging.md))
 - **Artist metadata** -- bios, images, similar artists from MusicBrainz/Last.fm ([plan](/.claude/plans/09-artist-metadata.md))
@@ -174,7 +176,7 @@ Two crates: `koan-core` (audio engine, player, database, indexer) and `koan-musi
 ```bash
 just check    # test + clippy
 just fmt      # cargo fmt
-just cli      # cargo run -p koan-music -- <args>
+just cli      # cargo run -p koan-cli -- <args>
 ```
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.

--- a/docs/architecture-improvements.md
+++ b/docs/architecture-improvements.md
@@ -1,102 +1,19 @@
 # Architecture Improvements Plan
 
-## 1. Audio Backend Decoupling
+> **Status:** Sections 1 and 2 are DONE as of v0.21.0. The `AudioBackend` trait exists in `audio/backend.rs` with `CoreAudioBackend` (macOS) and `CpalBackend` (Linux via cpal) implementations. Platform switching is via `#[cfg(target_os)]`.
 
-### Current State
+## 1. Audio Backend Decoupling -- DONE
 
-Audio output is deeply coupled to CoreAudio across two files:
+Completed in v0.21.0. The `AudioBackend` and `AudioEngineHandle` traits live in `audio/backend.rs`. Platform implementations:
 
-- **`audio/engine.rs`** (~270 lines) — AUHAL output unit, render callback, start/stop lifecycle
-- **`audio/device.rs`** (~270 lines) — device enumeration, sample rate get/set, CFString conversion
+- `audio/coreaudio_backend.rs` -- macOS (AUHAL, bit-perfect)
+- `audio/cpal_backend.rs` -- Linux (ALSA/PipeWire/PulseAudio via cpal)
 
-The good news: **`audio/buffer.rs` is entirely platform-agnostic.** The decode thread, ring buffer producer, timeline tracking, gapless logic — none of it touches CoreAudio. The interface between platform-specific and generic code is already clean:
+Conditional compilation via `#[cfg(target_os = "...")]` in the backend module.
 
-- Engine takes: `device_id`, `sample_rate`, `channels`, `rtrb::Consumer<f32>`, `Arc<AtomicU64>`
-- Engine provides: `start()`, `stop()`, `is_running()`, `Drop`
+## 2. Linux Audio Backend -- DONE
 
-Total replacement surface: ~540 lines.
-
-### Proposed Trait
-
-```rust
-pub trait AudioOutput: Send {
-    fn start(&mut self) -> Result<(), PlayerError>;
-    fn stop(&mut self) -> Result<(), PlayerError>;
-    fn is_running(&self) -> bool;
-}
-
-pub trait AudioDevices {
-    fn default_output() -> Result<DeviceId, PlayerError>;
-    fn list_outputs() -> Result<Vec<OutputDevice>, PlayerError>;
-    fn get_sample_rate(device: &DeviceId) -> Result<f64, PlayerError>;
-    fn set_sample_rate(device: &DeviceId, rate: f64) -> Result<(), PlayerError>;
-    fn available_sample_rates(device: &DeviceId) -> Result<Vec<f64>, PlayerError>;
-}
-```
-
-### File Layout
-
-```
-audio/
-├── mod.rs              # re-exports, #[cfg] switching
-├── buffer.rs           # unchanged — platform-agnostic
-├── replaygain.rs       # unchanged — platform-agnostic
-├── output.rs           # trait definitions
-├── macos/
-│   ├── engine.rs       # current engine.rs
-│   └── device.rs       # current device.rs
-└── linux/
-    ├── engine.rs       # ALSA write thread
-    └── device.rs       # ALSA card/device enumeration
-```
-
-### Approach
-
-Conditional compilation via `#[cfg(target_os = "...")]` in `mod.rs`. Both backends expose the same trait. Feature flags optional but not required — platform detection at compile time is sufficient.
-
----
-
-## 2. Linux Audio Backend
-
-### Recommendation: ALSA Direct
-
-ALSA `hw:` device is the only path to true bit-perfect on Linux. It bypasses PulseAudio/PipeWire entirely — no resampling, no mixing, no format conversion. This matches koan's CoreAudio philosophy exactly.
-
-| Option | Bit-perfect | Sample Rate Switch | Crate Maturity | Verdict |
-|--------|:-----------:|:------------------:|:--------------:|---------|
-| **alsa** (direct hw:) | **Yes** | **Yes** | Stable (v0.9) | **Use this** |
-| PipeWire | Partial (needs force-rate) | Via graph negotiation | OK (v0.9, docs spotty) | Future option |
-| cpal | No (uses `default` device) | No (issue #788 open) | Popular but wrong tool | Skip |
-| rodio | No (adds mixing layer) | No | N/A | Skip |
-
-### How ALSA Fits
-
-The render model flips from pull (CoreAudio calls you via callback) to push (you call `writei()`). This is actually **simpler** — no unsafe extern "C" callback, no raw pointer juggling:
-
-```
-Decode thread → rtrb::Producer<f32>
-ALSA write thread → rtrb::Consumer<f32> → pcm.writei() → DAC
-```
-
-The write thread owns the consumer directly, blocks on ALSA when the hardware buffer is full, increments `samples_played` after each successful write.
-
-### Gotchas
-
-- Requires `libasound2-dev` at build time, `libasound2` at runtime
-- `hw:` device is exclusive (one app at a time) — that's the point, but users need to know
-- Some DACs don't accept f32 — may need s32le/s24le fallback with trivial conversion
-- No desktop integration (volume knob in GNOME won't work) — ALSA bypasses the sound server
-
-### Non-Audio Platform Concerns
-
-| Component | macOS | Linux | Status |
-|-----------|-------|-------|--------|
-| **souvlaki** (media keys) | CFRunLoop | MPRIS/D-Bus | Already cross-platform, code has `#[cfg]` |
-| **security-framework** (Keychain) | macOS only | N/A | Password already in config.local.toml, Keychain is legacy fallback |
-| **core-foundation** (CFRunLoop) | macOS only | N/A | Already `#[cfg(target_os = "macos")]` gated |
-| **build.rs** | Links CoreAudio framework | Needs `#[cfg]` guard | Trivial fix |
-| **TUI** (ratatui + crossterm) | Works | Works | No changes needed |
-| Everything else | Works | Works | Pure Rust / cross-platform |
+Implemented via cpal (`CpalBackend`). Supports ALSA, PipeWire, and PulseAudio. Not direct ALSA `hw:` as originally planned -- cpal was chosen for broader compatibility. A direct ALSA backend for bit-perfect output remains a future option.
 
 ---
 
@@ -143,8 +60,6 @@ Config fields that exist but aren't wired into anything:
 
 | Field | Config Location | Library Code | Wired In? |
 |-------|----------------|-------------|-----------|
-| `playback.replaygain` | config.rs | replaygain.rs (full impl) | **No** — needs decode pipeline integration |
-| `playback.software_volume` | config.rs | N/A | **No** — needs sample scaling in decode |
-| `remote.transcode_quality` | config.rs | N/A | **No** — needs stream URL parameter |
-
-These should be wired in or removed. ReplayGain wiring is in progress on the `rg-config-wiring` branch.
+| `playback.replaygain` | config.rs | replaygain.rs (full impl) | **Yes** -- wired into decode pipeline |
+| `playback.software_volume` | config.rs | N/A | **No** -- needs sample scaling in decode |
+| `remote.transcode_quality` | config.rs | N/A | **No** -- needs stream URL parameter |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -19,14 +19,14 @@ mise use -g github:radiosilence/koan@latest
 ### Cargo
 
 ```bash
-cargo install koan-music
+cargo install koan-cli
 ```
 
 ### Build from source
 
 ```bash
 git clone https://github.com/radiosilence/koan.git && cd koan
-cargo install --path crates/koan-music
+cargo install --path crates/koan-cli
 ```
 
 ### Linux dependencies
@@ -81,7 +81,7 @@ Then scan your library:
 koan scan
 ```
 
-Scanning runs in parallel -- fast even for large collections (tens of thousands of tracks). koan reads metadata from FLAC, MP3, AAC, Vorbis, Opus, ALAC, WavPack, WAV, and AIFF files.
+Scanning runs in parallel -- fast even for large collections (tens of thousands of tracks). koan reads metadata from FLAC, MP3, AAC, Vorbis, Opus, ALAC, ADPCM, WAV, AIFF, CAF, Ogg, MKV/WebM, and MP4 files.
 
 ### Option B: Remote server (Navidrome/Subsonic)
 
@@ -144,6 +144,7 @@ Type to filter. In any picker, press `Enter` to add to queue, `Ctrl+Enter` to ad
 | `i` | Track info (codec, sample rate, bit depth, cover art) |
 | `L` | Toggle lyrics panel |
 | `f` | Favourite / unfavourite |
+| `v` | Visualizer picker (22 modes with live preview) |
 | `R` | Toggle radio mode (infinite play) |
 
 ### Managing the queue
@@ -174,6 +175,7 @@ Then `koan play --album <TAB>` shows your actual albums with artist names.
 ## What's next?
 
 - **[Configuration](reference/configuration.md)** -- customize playback, visualizer, organize patterns, and more
+- **[Authentication](guide/authentication.md)** -- set up API auth, manage users
 - **[Radio Mode](guide/radio-mode.md)** -- let koan pick tracks for you
 - **[File Organization](guide/file-organization.md)** -- rename your library using format string patterns
 - **[Remote Servers](guide/remote-servers.md)** -- advanced Subsonic/Navidrome setup

--- a/docs/guide/graphql-api.md
+++ b/docs/guide/graphql-api.md
@@ -18,9 +18,31 @@ koan -d --playground
 Then open `http://localhost:4000/graphql` for the GraphiQL IDE, or query directly:
 
 ```bash
+# If auth is enabled (default), get a token first
+TOKEN=$(curl -s -X POST http://localhost:4000/auth/login \
+  -H 'Content-Type: application/json' \
+  -d '{"username": "admin", "password": "your-password"}' | jq -r '.access_token')
+
 curl -s http://localhost:4000/graphql \
+  -H "Authorization: Bearer $TOKEN" \
   -H 'Content-Type: application/json' \
   -d '{"query": "{ nowPlaying { state, track { title, artist } } }"}'
+```
+
+## Authentication
+
+Auth is enabled by default (since v0.22.0). Run `koan auth setup` to create a keypair and first admin user before starting the server. See [Authentication](authentication.md) for the full guide.
+
+```bash
+koan auth setup              # generate keypair + create admin user
+koan --headless --playground # start server
+```
+
+To disable auth:
+
+```toml
+[graphql]
+auth_enabled = false
 ```
 
 ## Configuration
@@ -31,10 +53,13 @@ enabled = true                # run alongside TUI (default: true, --no-api disab
 port = 4000                   # API port (default: 4000)
 bind = "127.0.0.1"            # bind address (default: 127.0.0.1)
 playground = false             # GraphiQL IDE at GET /graphql (default: false)
+auth_enabled = true           # JWT authentication (default: true)
+access_token_ttl = "15m"      # access token lifetime (default: 15m)
+refresh_token_ttl = "30d"     # refresh token lifetime (default: 30d)
 # subsonic_port = 4040         # optional Subsonic REST API port (default: disabled, set to enable)
 ```
 
-The server binds to `127.0.0.1` by default. Use `--bind 0.0.0.0` or `bind = "0.0.0.0"` in config to expose on all interfaces. There's no authentication, so only do this on trusted networks.
+The server binds to `127.0.0.1` by default. Use `--bind 0.0.0.0` or `bind = "0.0.0.0"` in config to expose on all interfaces.
 
 ## Example queries
 

--- a/docs/guide/headless-server.md
+++ b/docs/guide/headless-server.md
@@ -64,8 +64,15 @@ koan --server http://host:4000          # full TUI
 koan --server http://host:4000 --jukebox  # remote control only (no local playback)
 ```
 
-## Security
+## Authentication
 
-The GraphQL API has **no authentication**. By default it binds to `127.0.0.1` (localhost only). If you expose it on `0.0.0.0`, anyone on your network can control playback, browse your library, move files (via organize), and clear your queue.
+Auth is enabled by default. Run `koan auth setup` before starting the server to create a keypair and admin user. See [Authentication](authentication.md) for the full guide.
 
-Only bind to all interfaces on trusted networks.
+The API binds to `127.0.0.1` by default. If you expose it on `0.0.0.0` with `--bind 0.0.0.0`, make sure auth is enabled (it is by default) or restrict access at the network level.
+
+To disable auth (localhost-only setups):
+
+```toml
+[graphql]
+auth_enabled = false
+```

--- a/docs/recipes/troubleshooting.md
+++ b/docs/recipes/troubleshooting.md
@@ -43,7 +43,7 @@ Another koan instance (or another process) is using port 4000. Either:
 
 - Check that `[library] folders` in `config.local.toml` points to the right directory
 - koan scans recursively -- you only need the top-level directory
-- Supported formats: FLAC, MP3, AAC, Vorbis, Opus, ALAC, WavPack, WAV, AIFF, APE, M4A
+- Supported formats: FLAC, MP3, AAC, Vorbis, Opus, ALAC, ADPCM, WAV, AIFF, CAF, Ogg, MKV/WebM, MP4
 - Run `koan config` to verify the resolved config
 
 ### Duplicate tracks after remote sync
@@ -97,9 +97,10 @@ If art shows as garbled characters, your terminal may not support halfblock rend
 
 ### Visualizer not showing
 
-The spectrum analyzer renders in the transport area when album art is present. If it's not visible:
+The visualizer renders in the transport area when album art is present. If it's not visible:
 - Check that `[visualizer] enabled = true` (default)
 - The terminal window needs to be wide enough to fit both album art and the visualizer
+- Press `v` to open the visualizer picker and try different modes
 - Some terminals with limited Unicode support may not render the block characters correctly
 
 ### Terminal not restored after crash

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -27,7 +27,7 @@ koan --headless                   # GraphQL API on 127.0.0.1:4000, no TUI
 koan --headless --playground      # with GraphiQL web IDE
 koan --headless --subsonic 4040   # + Subsonic REST on port 4040
 koan --port 8080                  # custom GraphQL port
-koan --bind 0.0.0.0              # listen on all interfaces (no auth)
+koan --bind 0.0.0.0              # listen on all interfaces (auth enabled by default)
 koan -d                           # background daemon
 koan -d --subsonic 4040           # daemon with Subsonic
 ```
@@ -151,6 +151,34 @@ koan cache evict                  # run LRU eviction based on cache_limit
 ```
 
 See [Cache Management](../recipes/cache-management.md) for details.
+
+---
+
+## `koan auth`
+
+Manage authentication -- users, tokens, keypair.
+
+```bash
+koan auth setup                       # generate keypair + create first admin user
+koan auth create-user --username alice --role user  # create a user (admin, user, readonly)
+koan auth delete-user alice           # delete a user
+koan auth list-users                  # list all users
+koan auth login --server http://localhost:4000 --username admin  # login (stores refresh token in keychain)
+koan auth logout --server http://localhost:4000  # logout (revoke token)
+koan auth reset-password admin        # reset password (revokes all tokens for that user)
+koan auth set-role alice admin        # change role
+koan auth regenerate-keys             # regenerate Ed25519 keypair (invalidates all tokens)
+koan auth reset                       # nuclear: delete all keys, users, tokens
+```
+
+Non-interactive setup for scripting:
+
+```bash
+KOAN_USERNAME=admin KOAN_PASSWORD=secret koan auth setup
+KOAN_PASSWORD=secret koan auth create-user --username alice --role user
+```
+
+See [Authentication](../guide/authentication.md) for the full guide.
 
 ---
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -170,17 +170,25 @@ See [Remote Servers](../guide/remote-servers.md) for the full setup guide.
 
 ```toml
 [visualizer]
-enabled = true                # show spectrum analyzer in transport area (default: true)
+enabled = true                # show visualizer in transport area (default: true)
+mode = "bars"                 # visualizer mode (default: bars). Press `v` in TUI to pick.
 fps = 60                      # analysis thread update rate in Hz (default: 60)
 scale = "bark"                # frequency scale (default: bark)
 amplitude_scale = "aweight"   # amplitude scale (default: aweight)
 bar_decay_ms = 50             # bar drop half-life in ms (default: 50)
 peak_decay_ms = 180           # peak marker linger half-life in ms (default: 180)
+palette = "spectrum"          # color palette: spectrum, mono, fire, neon (default: spectrum)
+reactivity = 1.0              # animation reactivity 0.0..2.0 (default: 1.0)
+bass_shake = false            # camera jitter on bass hits for braille modes (default: false)
+matrix_overlay = false        # replace characters with matrix glyphs (default: false)
+reactive_bg = false           # beat-reactive background on braille modes (default: false)
 ```
 
 Also accepts `[visualiser]` spelling.
 
-The spectrum analyzer renders above the transport text when album art is present. 48-band FFT with sub-cell resolution using Unicode block characters, peak hold markers, and smooth exponential decay. Bars are colored by signal level -- green at safe headroom, yellow when getting hot, red near clipping (0dBFS). The FFT runs on a dedicated thread so the UI is never blocked.
+22 modes available: bars, oscilloscope, radial, particles, lissajous, spectrogram, stereo waveform, VU meter, flame, plasma, tunnel, wireframe, metaballs, starfield, terrain, moire, kaleidoscope, julia, spiral, interference, wormhole, matrix. Press `v` in the TUI to open the picker with live preview.
+
+The visualizer renders above the transport text when album art is present. 48-band FFT with sub-cell resolution using Unicode block characters, peak hold markers, and smooth exponential decay. The FFT runs on a dedicated thread so the UI is never blocked.
 
 ### Frequency scales (`scale`)
 
@@ -237,11 +245,14 @@ port = 4000                   # API port (default: 4000)
 bind = "127.0.0.1"            # bind address (default: 127.0.0.1)
 playground = false             # enable GraphiQL IDE at GET /graphql (default: false)
 subsonic_port = 4040           # optional Subsonic REST API port (default: disabled)
+auth_enabled = true           # JWT authentication (default: true)
+access_token_ttl = "15m"      # access token lifetime (default: 15m)
+refresh_token_ttl = "30d"     # refresh token lifetime (default: 30d)
 ```
 
-Set `bind = "0.0.0.0"` to listen on all interfaces. There's no authentication, so only do this on trusted networks.
+Auth is enabled by default. Run `koan auth setup` to create a keypair and admin user. Set `auth_enabled = false` if you only use localhost and don't need auth.
 
-See [GraphQL API](../guide/graphql-api.md) and [Headless Server](../guide/headless-server.md) for usage guides.
+See [Authentication](../guide/authentication.md), [GraphQL API](../guide/graphql-api.md), and [Headless Server](../guide/headless-server.md) for usage guides.
 
 ---
 

--- a/docs/reference/keybindings.md
+++ b/docs/reference/keybindings.md
@@ -36,6 +36,9 @@ Every key in every mode. The hint bar at the bottom of the TUI shows available k
 | `e` | Enter queue edit mode |
 | `i` | Track info modal (codec, sample rate, cover art) |
 | `z` | Zoom album art |
+| `v` | Visualizer picker (22 modes with live preview) |
+| `X` | Toggle matrix overlay on visualizer |
+| `S` | Toggle bass shake on visualizer |
 | `L` | Toggle lyrics panel |
 | `R` | Toggle radio mode |
 | `f` | Favourite / unfavourite current track |

--- a/justfile
+++ b/justfile
@@ -6,7 +6,7 @@ build:
 
 # Build + run CLI in release mode
 cli *ARGS:
-    cargo run --release -p koan-music -- {{ARGS}}
+    cargo run --release -p koan-cli -- {{ARGS}}
 
 # Run tests + clippy
 check:


### PR DESCRIPTION
## Summary

- **Install instructions** — `koan-music` -> `koan-cli` across README, getting-started, ARCHITECTURE
- **Crate structure** — "two crates" -> "four crates" (koan-core, koan-tui, koan-server, koan-cli) in README, ARCHITECTURE, CONTRIBUTING
- **Auth docs** — added auth section to GraphQL API guide, headless server guide, CLI reference, configuration reference. Fixed stale "no authentication" claims
- **Visualizer** — updated from "spectrum analyzer" to "22 visualizer modes" in comparison tables, config reference (added `mode`, `palette`, `reactivity`, `bass_shake`, `matrix_overlay`, `reactive_bg` fields), keybindings (`v`/`X`/`S`), troubleshooting
- **Format support** — consistent list across README, getting-started, troubleshooting (ADPCM, CAF, MKV/WebM, Ogg, MP4)
- **Linux support** — removed from "Coming soon", updated platform column in comparison tables
- **Stale references** — architecture-improvements.md sections 1-2 marked DONE, ReplayGain marked wired
- **justfile** — `koan-music` -> `koan-cli`

## Test plan

- [x] All doc links verified against existing files
- [x] `cargo fmt --all` passes
- [x] Config field names verified against `koan-core/src/config.rs`
- [x] CLI commands verified against `koan-cli/src/main.rs`
- [x] Visualizer modes verified against `koan-tui/src/visualizer.rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)