### PR TITLE
feat(server): cookie auth + configurable CORS for web SPA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- **Cookie auth for web clients** — auth routes set `HttpOnly; Secure; SameSite=None` cookies alongside JSON responses. Middleware checks cookie before Bearer header (priority: cookie > Bearer > query param). Logout clears the cookie. No breaking changes for CLI/mobile clients.
+- **Configurable CORS origins** — `[graphql] cors_origins = [...]` restricts allowed origins with `credentials: true` for cookie auth. Empty (default) keeps `Allow-Origin: *` for dev/backward compat.
+
 - **GraphQL subscriptions** — real-time data over WebSocket at `/graphql/ws`. Three subscriptions: `nowPlaying` (playback state at configurable interval), `queueUpdated` (full queue snapshot on change), `vizFrame` (spectrum/VU/waveform at configurable FPS). ([#162](https://github.com/radiosilence/koan/issues/162))
 - **Queue snapshot with status** — `queue` query returns `QueueSnapshot` with versioned entries, each with derived `status` (Queued/Playing/Played/Downloading/PriorityPending/Failed) and optional `downloadProgress`. Replaces flat `Vec<QueueEntry>`.
 - **Visualizer query** — `vizFrame` query returns current spectrum, peaks, VU levels, beat energy, and optional waveform. Returns null when no analyzer is running.

--- a/crates/koan-core/src/config.rs
+++ b/crates/koan-core/src/config.rs
@@ -276,6 +276,9 @@ pub struct GraphqlConfig {
     pub access_token_ttl: String,
     /// Refresh token TTL (default: "30d"). Supports: "30d", "7d", "720h".
     pub refresh_token_ttl: String,
+    /// Allowed CORS origins. Empty = allow all (dev mode). Set for production.
+    /// Example: ["https://music.example.com"]
+    pub cors_origins: Vec<String>,
 }
 
 fn default_bind() -> std::net::IpAddr {
@@ -293,6 +296,7 @@ impl Default for GraphqlConfig {
             auth_enabled: true,
             access_token_ttl: "15m".into(),
             refresh_token_ttl: "30d".into(),
+            cors_origins: Vec::new(),
         }
     }
 }

--- a/crates/koan-server/src/auth/middleware.rs
+++ b/crates/koan-server/src/auth/middleware.rs
@@ -52,13 +52,25 @@ pub async fn auth_middleware(
         return next.run(request).await;
     }
 
-    // Extract token from Authorization header or ?token= query parameter.
+    // Priority: 1. koan_access cookie  2. Authorization: Bearer
+    //           3. ?token= query param
     let token = request
         .headers()
-        .get(header::AUTHORIZATION)
+        .get(axum::http::header::COOKIE)
         .and_then(|v| v.to_str().ok())
-        .and_then(|v| v.strip_prefix("Bearer "))
-        .map(String::from)
+        .and_then(|cookies| {
+            cookies
+                .split(';')
+                .find_map(|c| c.trim().strip_prefix("koan_access=").map(String::from))
+        })
+        .or_else(|| {
+            request
+                .headers()
+                .get(header::AUTHORIZATION)
+                .and_then(|v| v.to_str().ok())
+                .and_then(|v| v.strip_prefix("Bearer "))
+                .map(String::from)
+        })
         .or_else(|| {
             // Fall back to ?token= query parameter (for playground URLs).
             request.uri().query().and_then(|q| {

--- a/crates/koan-server/src/auth/routes.rs
+++ b/crates/koan-server/src/auth/routes.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use axum::Json;
 use axum::extract::State;
 use axum::http::StatusCode;
+use axum::http::header::SET_COOKIE;
 use axum::response::{IntoResponse, Response};
 use axum::routing::post;
 use serde::{Deserialize, Serialize};
@@ -163,6 +164,11 @@ async fn login(State(state): State<AuthRouteState>, Json(req): Json<LoginRequest
     // Housekeeping: clean up expired tokens on login (non-blocking).
     let _ = auth_queries::cleanup_expired_tokens(&db.conn);
 
+    let cookie = format!(
+        "koan_access={}; HttpOnly; Secure; SameSite=None; Path=/; Max-Age={}",
+        access_token, state.access_ttl_secs
+    );
+
     let resp = LoginResponse {
         access_token,
         refresh_token: refresh_token_id,
@@ -175,7 +181,7 @@ async fn login(State(state): State<AuthRouteState>, Json(req): Json<LoginRequest
         },
     };
 
-    (StatusCode::OK, Json(resp)).into_response()
+    (StatusCode::OK, [(SET_COOKIE, cookie)], Json(resp)).into_response()
 }
 
 async fn refresh(State(state): State<AuthRouteState>, Json(req): Json<RefreshRequest>) -> Response {
@@ -246,6 +252,11 @@ async fn refresh(State(state): State<AuthRouteState>, Json(req): Json<RefreshReq
         return (StatusCode::INTERNAL_SERVER_ERROR, "token error").into_response();
     }
 
+    let cookie = format!(
+        "koan_access={}; HttpOnly; Secure; SameSite=None; Path=/; Max-Age={}",
+        access_token, state.access_ttl_secs
+    );
+
     let resp = RefreshResponse {
         access_token,
         refresh_token: new_refresh_id,
@@ -253,7 +264,7 @@ async fn refresh(State(state): State<AuthRouteState>, Json(req): Json<RefreshReq
         expires_in: state.access_ttl_secs,
     };
 
-    (StatusCode::OK, Json(resp)).into_response()
+    (StatusCode::OK, [(SET_COOKIE, cookie)], Json(resp)).into_response()
 }
 
 async fn logout(State(state): State<AuthRouteState>, Json(req): Json<LogoutRequest>) -> Response {
@@ -264,8 +275,11 @@ async fn logout(State(state): State<AuthRouteState>, Json(req): Json<LogoutReque
 
     let _ = auth_queries::revoke_refresh_token(&db.conn, &req.refresh_token);
 
+    let cookie = "koan_access=; HttpOnly; Secure; SameSite=None; Path=/; Max-Age=0";
+
     (
         StatusCode::OK,
+        [(SET_COOKIE, cookie.to_owned())],
         Json(MessageResponse {
             message: "logged out".into(),
         }),

--- a/crates/koan-server/src/graphql/server.rs
+++ b/crates/koan-server/src/graphql/server.rs
@@ -154,14 +154,39 @@ fn run_api_blocking(opts: ApiServerOpts) {
         let auth_app = auth_router(auth_route_state);
 
         // CORS — allow cross-origin requests for browser clients.
-        let cors = tower_http::cors::CorsLayer::new()
-            .allow_origin(tower_http::cors::Any)
-            .allow_methods([
-                axum::http::Method::GET,
-                axum::http::Method::POST,
-                axum::http::Method::OPTIONS,
-            ])
-            .allow_headers(tower_http::cors::Any);
+        // With specific origins we can enable credentials (cookies); with Any we cannot per spec.
+        let cors = if cfg.graphql.cors_origins.is_empty() {
+            // Dev mode: allow all origins (no credentials support with Any).
+            tower_http::cors::CorsLayer::new()
+                .allow_origin(tower_http::cors::Any)
+                .allow_methods([
+                    axum::http::Method::GET,
+                    axum::http::Method::POST,
+                    axum::http::Method::OPTIONS,
+                ])
+                .allow_headers(tower_http::cors::Any)
+        } else {
+            // Production: specific origins with credentials for cookie auth.
+            let origins: Vec<axum::http::HeaderValue> = cfg
+                .graphql
+                .cors_origins
+                .iter()
+                .filter_map(|o| o.parse().ok())
+                .collect();
+            tower_http::cors::CorsLayer::new()
+                .allow_origin(origins)
+                .allow_methods([
+                    axum::http::Method::GET,
+                    axum::http::Method::POST,
+                    axum::http::Method::OPTIONS,
+                ])
+                .allow_headers([
+                    axum::http::header::AUTHORIZATION,
+                    axum::http::header::CONTENT_TYPE,
+                    axum::http::HeaderName::from_static("x-introspection-key"),
+                ])
+                .allow_credentials(true)
+        };
 
         let mut app = auth_app.merge(gql_app).layer(cors);
         if playground_enabled {


### PR DESCRIPTION
## Summary

- Auth routes (`/auth/login`, `/auth/refresh`, `/auth/logout`) now set `HttpOnly; Secure; SameSite=None` cookies alongside the existing JSON response body — CLI clients still read from JSON, web clients get automatic cookie auth.
- Auth middleware checks `koan_access` cookie before `Authorization: Bearer` header (priority: cookie > Bearer > introspection key > query param).
- New `[graphql] cors_origins` config field: empty (default) keeps `Allow-Origin: *` for dev; set specific origins to enable `allow_credentials(true)` for production cookie auth.

No breaking changes. Precursor to koan-web SPA client.

## Test plan

- [x] `cargo test --workspace` — 45 pass, 0 fail
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [ ] Manual: start server with `auth_enabled = true`, login via curl, verify `Set-Cookie` header
- [ ] Manual: verify cookie cleared on logout (`Max-Age=0`)
- [ ] Manual: test with `cors_origins = ["http://localhost:5173"]` and verify `Access-Control-Allow-Credentials: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)