### PR TITLE
fix(server): always mount Subsonic on GraphQL port

### DIFF
--- a/crates/koan-cli/src/main.rs
+++ b/crates/koan-cli/src/main.rs
@@ -122,7 +122,9 @@ struct Cli {
     #[arg(long)]
     bind: Option<std::net::IpAddr>,
 
-    /// Enable Subsonic REST API on this port (e.g. --subsonic 4040)
+    /// Also expose Subsonic REST on a dedicated port (e.g. --subsonic 4040).
+    /// Subsonic is always mounted on the GraphQL port when remote creds are configured;
+    /// this flag adds an additional listener for clients that expect a separate port.
     #[arg(long)]
     subsonic: Option<u16>,
 

--- a/crates/koan-server/src/graphql/server.rs
+++ b/crates/koan-server/src/graphql/server.rs
@@ -188,7 +188,19 @@ fn run_api_blocking(opts: ApiServerOpts) {
                 .allow_credentials(true)
         };
 
-        let mut app = auth_app.merge(gql_app).layer(cors);
+        // Subsonic REST routes — always mounted on the GraphQL port when
+        // remote creds are configured. Previously only available on the
+        // dedicated `--subsonic <port>` listener, which broke `koan play
+        // --server <url>` because the remote TUI bridge builds its stream
+        // URL off the GraphQL base.
+        let subsonic_merged = crate::subsonic::subsonic_router(db_path.clone());
+        let subsonic_on_main = subsonic_merged.is_some();
+
+        let mut app = auth_app.merge(gql_app);
+        if let Some(sub) = subsonic_merged {
+            app = app.merge(sub);
+        }
+        let mut app = app.layer(cors);
         if playground_enabled {
             app = app.route(
                 "/graphql",
@@ -212,6 +224,9 @@ fn run_api_blocking(opts: ApiServerOpts) {
         let gql_listener = match tokio::net::TcpListener::bind(gql_addr).await {
             Ok(l) => {
                 log::info!("GraphQL API on http://{}:{}/graphql", bind, port);
+                if subsonic_on_main {
+                    log::info!("Subsonic REST on http://{}:{}/rest/", bind, port);
+                }
                 if playground_enabled {
                     log::info!("GraphiQL: {}", playground_url);
                     // Open browser on macOS/Linux.
@@ -234,43 +249,42 @@ fn run_api_blocking(opts: ApiServerOpts) {
         let gql_server =
             axum::serve(gql_listener, app).with_graceful_shutdown(shutdown_signal());
 
-        if let Some(sub_port) = subsonic_port {
-            if let Some(sub_app) = crate::subsonic::subsonic_router(db_path) {
-                let sub_addr = std::net::SocketAddr::new(bind, sub_port);
+        // If `--subsonic <port>` is set AND differs from the GraphQL port,
+        // run an additional dedicated listener. This preserves the old
+        // behavior for users who want Subsonic on its own port.
+        let extra_sub_port = subsonic_port.filter(|p| *p != port);
+        if let Some(sub_port) = extra_sub_port
+            && let Some(sub_app) = crate::subsonic::subsonic_router(db_path)
+        {
+            let sub_addr = std::net::SocketAddr::new(bind, sub_port);
+            match tokio::net::TcpListener::bind(sub_addr).await {
+                Ok(sub_listener) => {
+                    log::info!(
+                        "Subsonic REST also on http://{}:{}/rest/ (dedicated port)",
+                        bind,
+                        sub_port,
+                    );
+                    let sub_server = axum::serve(sub_listener, sub_app)
+                        .with_graceful_shutdown(shutdown_signal());
 
-                match tokio::net::TcpListener::bind(sub_addr).await {
-                    Ok(sub_listener) => {
-                        log::info!("Subsonic REST on http://{}:{}/rest/", bind, sub_port);
-                        let sub_server = axum::serve(sub_listener, sub_app)
-                            .with_graceful_shutdown(shutdown_signal());
-
-                        tokio::select! {
-                            r = gql_server => { if let Err(e) = r { log::error!("GraphQL server error: {e}"); } },
-                            r = sub_server => { if let Err(e) = r { log::error!("Subsonic server error: {e}"); } },
-                        }
+                    tokio::select! {
+                        r = gql_server => { if let Err(e) = r { log::error!("GraphQL server error: {e}"); } },
+                        r = sub_server => { if let Err(e) = r { log::error!("Subsonic server error: {e}"); } },
                     }
-                    Err(e) => {
-                        log::warn!(
-                            "Subsonic API disabled: failed to bind port {} — {}",
-                            sub_port,
-                            e,
-                        );
-                        // Run GraphQL-only.
-                        if let Err(e) = gql_server.await {
-                            log::error!("GraphQL server error: {e}");
-                        }
-                    }
+                    return;
                 }
-            } else {
-                // subsonic_router returned None — credentials not configured.
-                if let Err(e) = gql_server.await {
-                    log::error!("GraphQL server error: {e}");
+                Err(e) => {
+                    log::warn!(
+                        "Dedicated Subsonic port {} unavailable — {}. Mounted on GraphQL port only.",
+                        sub_port,
+                        e,
+                    );
                 }
             }
-        } else {
-            if let Err(e) = gql_server.await {
-                log::error!("GraphQL server error: {e}");
-            }
+        }
+
+        if let Err(e) = gql_server.await {
+            log::error!("GraphQL server error: {e}");
         }
     });
 }

--- a/mise.toml
+++ b/mise.toml
@@ -1,1 +1,3 @@
 [tools]
+rust = "latest"
+just = "latest"


### PR DESCRIPTION
## Summary
- The remote TUI bridge (`remote_bridge.rs:52`) builds its stream URL as `${server_url}/rest/stream`, but Subsonic routes used to only bind on the dedicated `--subsonic <port>` listener. Result: `koan play --server <url>` silently failed unless the server was started with matching ports (which nothing does).
- Subsonic routes are now merged into the main axum app whenever remote credentials are configured. `--subsonic <port>` still works as an additional dedicated listener for clients that want a separate port.
- `mise.toml` picks up `just` so `just check` / `just build` work from a clean checkout.

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — green.
- [x] `cargo test --workspace` — 618/618 passing.
- [x] Start `koan --headless --port 4001` (no `--subsonic` flag), hit `GET /rest/ping?...` on :4001 → authenticated response; stream `/rest/stream?id=<n>` returns a valid FLAC (magic `664c6143`, 11.7MB for a 1:42 track).
- [x] Concurrent two-stream probe (gapless prerequisite) → both finish simultaneously with valid audio magic bytes.
- [x] Transport path: `addToQueue` → jukebox playback → pause / seek / resume / stop — all green against the merged router.

## Related
- Uncovers #173 (client-side auth not wired) which remains as follow-up.