### PR TITLE
release: v0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,31 @@
 # Changelog
 
-## Unreleased
+## v0.23.0 (2026-04-18)
+
+Groundwork for the upcoming browser SPA: full GraphQL schema for web clients, real-time subscriptions, cookie auth, and configurable CORS. Subsonic streaming now rides the GraphQL port by default, so the remote TUI (`koan play --server`) finally works end-to-end.
 
 ### Added
 
-- **Cookie auth for web clients** — auth routes set `HttpOnly; Secure; SameSite=None` cookies alongside JSON responses. Middleware checks cookie before Bearer header (priority: cookie > Bearer > query param). Logout clears the cookie. No breaking changes for CLI/mobile clients.
-- **Configurable CORS origins** — `[graphql] cors_origins = [...]` restricts allowed origins with `credentials: true` for cookie auth. Empty (default) keeps `Allow-Origin: *` for dev/backward compat.
-
-- **GraphQL subscriptions** — real-time data over WebSocket at `/graphql/ws`. Three subscriptions: `nowPlaying` (playback state at configurable interval), `queueUpdated` (full queue snapshot on change), `vizFrame` (spectrum/VU/waveform at configurable FPS). ([#162](https://github.com/radiosilence/koan/issues/162))
+- **GraphQL subscriptions** — real-time data over WebSocket at `/graphql/ws`. Three subscriptions: `nowPlaying` (playback state at configurable interval), `queueUpdated` (full queue snapshot on change), `vizFrame` (spectrum/VU/waveform at configurable FPS). ([#162](https://github.com/radiosilence/koan/issues/162), [#171](https://github.com/radiosilence/koan/pull/171))
 - **Queue snapshot with status** — `queue` query returns `QueueSnapshot` with versioned entries, each with derived `status` (Queued/Playing/Played/Downloading/PriorityPending/Failed) and optional `downloadProgress`. Replaces flat `Vec<QueueEntry>`.
 - **Visualizer query** — `vizFrame` query returns current spectrum, peaks, VU levels, beat energy, and optional waveform. Returns null when no analyzer is running.
 - **Config query + mutation** — `config` query exposes current settings, `updateConfig` mutation writes individual fields to `config.toml` (admin-only).
 - **Playlist version query** — `playlistVersion` returns monotonic counter for change detection.
 - **Playback state persistence** — `savePlaybackState` and `clearPlaybackState` mutations for web clients.
+- **Cookie auth for web clients** — auth routes set `HttpOnly; Secure; SameSite=None` cookies alongside JSON responses. Middleware checks cookie before Bearer header (priority: cookie > Bearer > query param). Logout clears the cookie. No breaking changes for CLI/mobile clients. ([#172](https://github.com/radiosilence/koan/pull/172))
+- **Configurable CORS origins** — `[graphql] cors_origins = [...]` restricts allowed origins with `credentials: true` for cookie auth. Empty (default) keeps `Allow-Origin: *` for dev/backward compat.
+
+### Fixed
+
+- **Subsonic streaming works on the GraphQL port** — Subsonic REST is now merged onto the GraphQL router whenever remote credentials are configured, so `koan play --server <url>` can pull streams without a second listener. `--subsonic <port>` continues to expose an additional dedicated listener for clients that expect a separate port. ([#174](https://github.com/radiosilence/koan/pull/174))
+- **Rust 1.95 clippy lints** — resolved `collapsible_match`, `manual_checked_ops`, and `absurd_extreme_comparisons` across `koan-core` and `koan-tui`. Pure refactor; no behaviour change. ([#175](https://github.com/radiosilence/koan/pull/175))
+
+### Known issues
+
+- **Remote TUI client doesn't send a JWT yet** — `koan play --server <url>` still fails against `auth_enabled = true` servers because the client has no login/token flow. Tracked in [#173](https://github.com/radiosilence/koan/issues/173).
+
+### Internal
+
 - **`ApiServerOpts` struct** — replaces positional args on internal `run_api_blocking`, carries optional `VizSnapshot` for subscription support.
 
 ## v0.22.0 (2026-04-12)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2076,7 +2076,7 @@ dependencies = [
 
 [[package]]
 name = "koan-cli"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2102,7 +2102,7 @@ dependencies = [
 
 [[package]]
 name = "koan-core"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "argon2",
  "bliss-audio",
@@ -2142,7 +2142,7 @@ dependencies = [
 
 [[package]]
 name = "koan-server"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",
@@ -2173,7 +2173,7 @@ dependencies = [
 
 [[package]]
 name = "koan-tui"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "chrono",
  "core-foundation 0.9.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/koan-core", "crates/koan-server", "crates/koan-tui", "crates/koan-cli"]
 
 [workspace.package]
-version = "0.22.0"
+version = "0.23.0"
 edition = "2024"
 homepage = "https://github.com/radiosilence/koan"
 repository = "https://github.com/radiosilence/koan"

--- a/crates/koan-cli/Cargo.toml
+++ b/crates/koan-cli/Cargo.toml
@@ -20,9 +20,9 @@ crossbeam-channel = "0.5"
 crossterm = "0.28"
 ctrlc = "3"
 jwalk = "0.8"
-koan-core = { path = "../koan-core", version = "0.22.0" }
-koan-server = { path = "../koan-server", version = "0.22.0" }
-koan-tui = { path = "../koan-tui", version = "0.22.0" }
+koan-core = { path = "../koan-core", version = "0.23.0" }
+koan-server = { path = "../koan-server", version = "0.23.0" }
+koan-tui = { path = "../koan-tui", version = "0.23.0" }
 log = "0.4"
 owo-colors = "4"
 rayon = "1"

--- a/crates/koan-server/Cargo.toml
+++ b/crates/koan-server/Cargo.toml
@@ -16,7 +16,7 @@ axum = { version = "0.8", features = ["ws"] }
 base64 = "0.22.1"
 crossbeam-channel = "0.5"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "webp"] }
-koan-core = { path = "../koan-core", version = "0.22.0" }
+koan-core = { path = "../koan-core", version = "0.23.0" }
 log = "0.4"
 nucleo = "0.5"
 md5 = "0.8"

--- a/crates/koan-tui/Cargo.toml
+++ b/crates/koan-tui/Cargo.toml
@@ -14,8 +14,8 @@ crossbeam-channel = "0.5"
 crossterm = "0.28"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "webp"] }
 jwalk = "0.8"
-koan-core = { path = "../koan-core", version = "0.22.0" }
-koan-server = { path = "../koan-server", version = "0.22.0" }
+koan-core = { path = "../koan-core", version = "0.23.0" }
+koan-server = { path = "../koan-server", version = "0.23.0" }
 log = "0.4"
 reqwest = { version = "0.13.2", default-features = false, features = ["blocking", "json", "rustls"] }
 nucleo = "0.5"


### PR DESCRIPTION
## Summary

Groundwork release for the upcoming browser SPA: full GraphQL schema for web clients, real-time subscriptions, cookie auth, configurable CORS. Subsonic streaming now rides the GraphQL port by default, so `koan play --server` finally works end-to-end.

## v0.23.0 (2026-04-18)

### Added

- **GraphQL subscriptions** — real-time data over WebSocket at `/graphql/ws`. Three subscriptions: `nowPlaying`, `queueUpdated`, `vizFrame`. (#162, #171)
- **Queue snapshot with status** — `queue` query returns `QueueSnapshot` with versioned entries, each with derived `status` and optional `downloadProgress`.
- **Visualizer query** — `vizFrame` returns spectrum, peaks, VU levels, beat energy, and optional waveform. Returns null when no analyzer is running.
- **Config query + mutation** — `config` query exposes current settings; `updateConfig` writes individual fields to `config.toml` (admin-only).
- **Playlist version query** — `playlistVersion` returns monotonic counter for change detection.
- **Playback state persistence** — `savePlaybackState` / `clearPlaybackState` mutations for web clients.
- **Cookie auth for web clients** — auth routes set `HttpOnly; Secure; SameSite=None` cookies alongside JSON responses. Priority: cookie > Bearer > query param. (#172)
- **Configurable CORS origins** — `[graphql] cors_origins = [...]` restricts allowed origins with `credentials: true` for cookie auth. Empty (default) keeps `Allow-Origin: *` for dev.

### Fixed

- **Subsonic streaming works on the GraphQL port** — merged onto the GraphQL router whenever remote creds are configured, so `koan play --server <url>` can pull streams without a second listener. `--subsonic <port>` still works as an additional dedicated listener. (#174)
- **Rust 1.95 clippy lints** — resolved `collapsible_match`, `manual_checked_ops`, `absurd_extreme_comparisons` across `koan-core` and `koan-tui`. (#175)

### Known issues

- **Remote TUI client doesn't send a JWT yet** — `koan play --server <url>` still fails against `auth_enabled = true` servers. Tracked in #173.

### Internal

- `ApiServerOpts` struct replaces positional args on internal `run_api_blocking`, carries optional `VizSnapshot` for subscription support.

## Test plan

- [x] `cargo check --workspace` — green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — green on rust 1.95
- [x] `cargo test --workspace` — 618 / 618 passing
- [x] Manual E2E via `/tmp/koan-test/` harness: jukebox transport (addToQueue → play → pause → seek → resume → stop), Subsonic ping, `/rest/stream` returns valid FLAC bytes on the GraphQL port, concurrent two-stream gapless prerequisite.