### PR TITLE
fix(ci): publish the right crates to crates.io after the split

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -176,17 +176,32 @@ jobs:
     runs-on: ubuntu-latest
     needs: [publish-release, check-version]
     if: ${{ !cancelled() && !failure() && needs.check-version.outputs.should_release == 'true' }}
+    env:
+      VERSION: ${{ needs.check-version.outputs.version }}
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Install system deps
         run: sudo apt-get update && sudo apt-get install -y libasound2-dev libdbus-1-dev
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
-      - run: cargo publish -p koan-core --no-verify
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-      - run: cargo publish -p koan-music --no-verify
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      # Publish in dependency order: koan-core first, then the libraries that
+      # depend on it, then the binary crate. `publish_crate` is idempotent —
+      # if the version already exists on crates.io (e.g. from a partial
+      # previous run) it logs and continues rather than failing the job.
+      - name: Publish crates
+        run: |
+          publish_crate() {
+            local crate="$1"
+            if curl -sf "https://crates.io/api/v1/crates/${crate}/${VERSION}" > /dev/null; then
+              echo "${crate}@${VERSION} already on crates.io, skipping"
+            else
+              cargo publish -p "${crate}" --no-verify
+            fi
+          }
+          publish_crate koan-core
+          publish_crate koan-tui
+          publish_crate koan-server
+          publish_crate koan-cli
 
   update-homebrew:
     name: Update Homebrew Tap


### PR DESCRIPTION
## Summary

The crate-split in #160 renamed the top-level binary from `koan-music` to `koan-cli` and introduced `koan-tui` + `koan-server` alongside `koan-core`. The `publish-crate` job in CI was never updated, so every release since v0.21.0 has silently failed:

\`\`\`
error: package ID specification \`koan-music\` did not match any packages
help: a package with a similar name exists: \`koan-tui\`
\`\`\`

Net effect: \`koan-tui\`, \`koan-server\`, and \`koan-cli\` are **not** on crates.io at any version. Only \`koan-core\` kept publishing because it's named on the first line and ran before the broken one.

## Changes

- Publish in dependency order: \`koan-core\` → \`koan-tui\` + \`koan-server\` → \`koan-cli\`.
- Add idempotent \`publish_crate\` shell helper that short-circuits when a version is already on crates.io. That way a partially-failed release (like v0.23.0's) doesn't wedge future runs on "already uploaded" errors when they retry \`koan-core\`.
- Hoist \`CARGO_REGISTRY_TOKEN\` + \`VERSION\` into job-level \`env\` to avoid repeating them on every step.

## One-off cleanup still needed

This PR only fixes *future* releases. The v0.23.0 crates (\`koan-tui\`, \`koan-server\`, \`koan-cli\`) that got skipped will need a one-time manual publish from a dev with the registry token:

\`\`\`bash
cargo publish -p koan-tui --no-verify
cargo publish -p koan-server --no-verify
cargo publish -p koan-cli --no-verify
\`\`\`

\`koan-core\` v0.23.0 is already up.

## Test plan

- [x] YAML parses (no syntax errors introduced).
- [ ] Next release (v0.23.1 or later) publishes all four crates successfully.