### PR TITLE
release: v0.23.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.23.1 (2026-04-18)
+
+Re-release of v0.23.0 to publish the split crates to crates.io. No code changes from v0.23.0.
+
+### Fixed
+
+- **Missing crates on crates.io** — the publish-crate CI job referenced the pre-split binary name (`koan-music`) and silently failed for every release since v0.21.0. `koan-tui`, `koan-server`, and `koan-cli` had never been published. The job now publishes all four crates in dependency order and is idempotent across partial retries. ([#177](https://github.com/radiosilence/koan/pull/177))
+
 ## v0.23.0 (2026-04-18)
 
 Groundwork for the upcoming browser SPA: full GraphQL schema for web clients, real-time subscriptions, cookie auth, and configurable CORS. Subsonic streaming now rides the GraphQL port by default, so the remote TUI (`koan play --server`) finally works end-to-end.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2076,7 +2076,7 @@ dependencies = [
 
 [[package]]
 name = "koan-cli"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "chrono",
  "clap",
@@ -2102,7 +2102,7 @@ dependencies = [
 
 [[package]]
 name = "koan-core"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "argon2",
  "bliss-audio",
@@ -2142,7 +2142,7 @@ dependencies = [
 
 [[package]]
 name = "koan-server"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",
@@ -2173,7 +2173,7 @@ dependencies = [
 
 [[package]]
 name = "koan-tui"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "chrono",
  "core-foundation 0.9.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/koan-core", "crates/koan-server", "crates/koan-tui", "crates/koan-cli"]
 
 [workspace.package]
-version = "0.23.0"
+version = "0.23.1"
 edition = "2024"
 homepage = "https://github.com/radiosilence/koan"
 repository = "https://github.com/radiosilence/koan"

--- a/crates/koan-cli/Cargo.toml
+++ b/crates/koan-cli/Cargo.toml
@@ -20,9 +20,9 @@ crossbeam-channel = "0.5"
 crossterm = "0.28"
 ctrlc = "3"
 jwalk = "0.8"
-koan-core = { path = "../koan-core", version = "0.23.0" }
-koan-server = { path = "../koan-server", version = "0.23.0" }
-koan-tui = { path = "../koan-tui", version = "0.23.0" }
+koan-core = { path = "../koan-core", version = "0.23.1" }
+koan-server = { path = "../koan-server", version = "0.23.1" }
+koan-tui = { path = "../koan-tui", version = "0.23.1" }
 log = "0.4"
 owo-colors = "4"
 rayon = "1"

--- a/crates/koan-server/Cargo.toml
+++ b/crates/koan-server/Cargo.toml
@@ -16,7 +16,7 @@ axum = { version = "0.8", features = ["ws"] }
 base64 = "0.22.1"
 crossbeam-channel = "0.5"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "webp"] }
-koan-core = { path = "../koan-core", version = "0.23.0" }
+koan-core = { path = "../koan-core", version = "0.23.1" }
 log = "0.4"
 nucleo = "0.5"
 md5 = "0.8"

--- a/crates/koan-tui/Cargo.toml
+++ b/crates/koan-tui/Cargo.toml
@@ -14,8 +14,8 @@ crossbeam-channel = "0.5"
 crossterm = "0.28"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "webp"] }
 jwalk = "0.8"
-koan-core = { path = "../koan-core", version = "0.23.0" }
-koan-server = { path = "../koan-server", version = "0.23.0" }
+koan-core = { path = "../koan-core", version = "0.23.1" }
+koan-server = { path = "../koan-server", version = "0.23.1" }
 log = "0.4"
 reqwest = { version = "0.13.2", default-features = false, features = ["blocking", "json", "rustls"] }
 nucleo = "0.5"


### PR DESCRIPTION
## Summary

Re-release of v0.23.0 to actually publish the split crates to crates.io. No code changes from v0.23.0 — this is a CI-only catch-up.

### Fixed

- **Missing crates on crates.io** — the publish-crate CI job referenced the pre-split binary name (`koan-music`) and silently failed for every release since v0.21.0. `koan-tui`, `koan-server`, and `koan-cli` had never been published. The job now publishes all four crates in dependency order and is idempotent across partial retries. (#177)

## Test plan

- [x] `cargo check --workspace` — green (0.23.1 across all four crates)
- [x] `cargo test --workspace` already verified at v0.23.0 — no code delta since.