### PR TITLE
release: v0.23.2 — fix crates.io publish order

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -198,9 +198,12 @@ jobs:
               cargo publish -p "${crate}" --no-verify
             fi
           }
+          # Order matters: koan-tui depends on koan-server, not the other way
+          # around. Publishing tui before server breaks with "no matching
+          # package named `koan-server`" because the index hasn't seen it yet.
           publish_crate koan-core
-          publish_crate koan-tui
           publish_crate koan-server
+          publish_crate koan-tui
           publish_crate koan-cli
 
   update-homebrew:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.23.2 (2026-04-18)
+
+Second attempt at getting the split crates on crates.io. v0.23.1 published `koan-core` but then failed because the publish order had `koan-tui` before `koan-server` — and `koan-tui` depends on `koan-server`. Flipped the order; no code delta.
+
+### Fixed
+
+- **Publish order** — `koan-server` now publishes before `koan-tui` so the crates.io index sees the dependency before downstream crates try to resolve it.
+
 ## v0.23.1 (2026-04-18)
 
 Re-release of v0.23.0 to publish the split crates to crates.io. No code changes from v0.23.0.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2076,7 +2076,7 @@ dependencies = [
 
 [[package]]
 name = "koan-cli"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "chrono",
  "clap",
@@ -2102,7 +2102,7 @@ dependencies = [
 
 [[package]]
 name = "koan-core"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "argon2",
  "bliss-audio",
@@ -2142,7 +2142,7 @@ dependencies = [
 
 [[package]]
 name = "koan-server"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",
@@ -2173,7 +2173,7 @@ dependencies = [
 
 [[package]]
 name = "koan-tui"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "chrono",
  "core-foundation 0.9.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/koan-core", "crates/koan-server", "crates/koan-tui", "crates/koan-cli"]
 
 [workspace.package]
-version = "0.23.1"
+version = "0.23.2"
 edition = "2024"
 homepage = "https://github.com/radiosilence/koan"
 repository = "https://github.com/radiosilence/koan"

--- a/crates/koan-cli/Cargo.toml
+++ b/crates/koan-cli/Cargo.toml
@@ -20,9 +20,9 @@ crossbeam-channel = "0.5"
 crossterm = "0.28"
 ctrlc = "3"
 jwalk = "0.8"
-koan-core = { path = "../koan-core", version = "0.23.1" }
-koan-server = { path = "../koan-server", version = "0.23.1" }
-koan-tui = { path = "../koan-tui", version = "0.23.1" }
+koan-core = { path = "../koan-core", version = "0.23.2" }
+koan-server = { path = "../koan-server", version = "0.23.2" }
+koan-tui = { path = "../koan-tui", version = "0.23.2" }
 log = "0.4"
 owo-colors = "4"
 rayon = "1"

--- a/crates/koan-server/Cargo.toml
+++ b/crates/koan-server/Cargo.toml
@@ -16,7 +16,7 @@ axum = { version = "0.8", features = ["ws"] }
 base64 = "0.22.1"
 crossbeam-channel = "0.5"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "webp"] }
-koan-core = { path = "../koan-core", version = "0.23.1" }
+koan-core = { path = "../koan-core", version = "0.23.2" }
 log = "0.4"
 nucleo = "0.5"
 md5 = "0.8"

--- a/crates/koan-tui/Cargo.toml
+++ b/crates/koan-tui/Cargo.toml
@@ -14,8 +14,8 @@ crossbeam-channel = "0.5"
 crossterm = "0.28"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "webp"] }
 jwalk = "0.8"
-koan-core = { path = "../koan-core", version = "0.23.1" }
-koan-server = { path = "../koan-server", version = "0.23.1" }
+koan-core = { path = "../koan-core", version = "0.23.2" }
+koan-server = { path = "../koan-server", version = "0.23.2" }
 log = "0.4"
 reqwest = { version = "0.13.2", default-features = false, features = ["blocking", "json", "rustls"] }
 nucleo = "0.5"


### PR DESCRIPTION
## Summary

v0.23.1 got `koan-core` onto crates.io, then broke on `cargo publish -p koan-tui` because `koan-tui` depends on `koan-server` and the previous workflow published tui *before* server. Index hadn't seen server yet → "no matching package named \`koan-server\`".

## Changes

- Flip publish order in `.github/workflows/ci-cd.yml`: `core → server → tui → cli` (matches actual dep graph).
- Version bump to v0.23.2 so the workflow actually runs on merge (check-version gates on version diff).

## One-liner diff

\`\`\`diff
 publish_crate koan-core
-publish_crate koan-tui
 publish_crate koan-server
+publish_crate koan-tui
 publish_crate koan-cli
\`\`\`

## Current crates.io state

| crate | latest on crates.io |
|-------|---------------------|
| koan-core | 0.23.1 ✓ |
| koan-server | — |
| koan-tui | — |
| koan-cli | — |

After this merges + the workflow runs, all four should be at 0.23.2.