### PR TITLE
release: v0.23.3 — fix similarArtists migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- **`similarArtists` crashed on old DBs** — schema added a `relationship` column to `similar_artists` but shipped no `ALTER TABLE` migration, so databases created before the column existed blew up with `no such column: sa.relationship` the moment the query ran. Added the migration and a regression test that boots a pre-migration schema and verifies `create_tables` patches it.
+
 ## v0.23.2 (2026-04-18)
 
 Second attempt at getting the split crates on crates.io. v0.23.1 published `koan-core` but then failed because the publish order had `koan-tui` before `koan-server` — and `koan-tui` depends on `koan-server`. Flipped the order; no code delta.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-## Unreleased
+## v0.23.3 (2026-04-19)
 
 ### Fixed
 
-- **`similarArtists` crashed on old DBs** — schema added a `relationship` column to `similar_artists` but shipped no `ALTER TABLE` migration, so databases created before the column existed blew up with `no such column: sa.relationship` the moment the query ran. Added the migration and a regression test that boots a pre-migration schema and verifies `create_tables` patches it.
+- **`similarArtists` crashed on pre-existing DBs** — schema added a `relationship` column to `similar_artists` but shipped no `ALTER TABLE` migration, so databases created before the column existed blew up with `no such column: sa.relationship` the moment the query ran. Added the migration alongside the existing cache-column migrations and a regression test that boots a pre-migration schema and verifies `create_tables` patches it. ([#180](https://github.com/radiosilence/koan/pull/180))
 
 ## v0.23.2 (2026-04-18)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2076,7 +2076,7 @@ dependencies = [
 
 [[package]]
 name = "koan-cli"
-version = "0.23.2"
+version = "0.23.3"
 dependencies = [
  "chrono",
  "clap",
@@ -2102,7 +2102,7 @@ dependencies = [
 
 [[package]]
 name = "koan-core"
-version = "0.23.2"
+version = "0.23.3"
 dependencies = [
  "argon2",
  "bliss-audio",
@@ -2142,7 +2142,7 @@ dependencies = [
 
 [[package]]
 name = "koan-server"
-version = "0.23.2"
+version = "0.23.3"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",
@@ -2173,7 +2173,7 @@ dependencies = [
 
 [[package]]
 name = "koan-tui"
-version = "0.23.2"
+version = "0.23.3"
 dependencies = [
  "chrono",
  "core-foundation 0.9.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/koan-core", "crates/koan-server", "crates/koan-tui", "crates/koan-cli"]
 
 [workspace.package]
-version = "0.23.2"
+version = "0.23.3"
 edition = "2024"
 homepage = "https://github.com/radiosilence/koan"
 repository = "https://github.com/radiosilence/koan"

--- a/crates/koan-core/src/db/schema.rs
+++ b/crates/koan-core/src/db/schema.rs
@@ -178,6 +178,7 @@ pub fn create_tables(conn: &Connection) -> rusqlite::Result<()> {
     let migrations = [
         "ALTER TABLE tracks ADD COLUMN cache_size_bytes INTEGER",
         "ALTER TABLE tracks ADD COLUMN cache_download_date INTEGER",
+        "ALTER TABLE similar_artists ADD COLUMN relationship TEXT NOT NULL DEFAULT 'similar'",
     ];
     for sql in &migrations {
         match conn.execute(sql, []) {
@@ -189,4 +190,57 @@ pub fn create_tables(conn: &Connection) -> rusqlite::Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn migrates_similar_artists_relationship_column() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE artists (id INTEGER PRIMARY KEY, name TEXT NOT NULL UNIQUE);
+             CREATE TABLE similar_artists (
+                 artist_id  INTEGER NOT NULL REFERENCES artists(id),
+                 similar_id INTEGER NOT NULL REFERENCES artists(id),
+                 score      REAL NOT NULL DEFAULT 0.0,
+                 source     TEXT NOT NULL DEFAULT 'subsonic',
+                 updated_at TEXT DEFAULT (datetime('now')),
+                 PRIMARY KEY (artist_id, similar_id, source)
+             );",
+        )
+        .unwrap();
+
+        create_tables(&conn).unwrap();
+
+        let has_relationship: bool = conn
+            .query_row(
+                "SELECT COUNT(*) FROM pragma_table_info('similar_artists') WHERE name = 'relationship'",
+                [],
+                |row| row.get::<_, i64>(0).map(|n| n > 0),
+            )
+            .unwrap();
+        assert!(has_relationship, "relationship column was not added");
+
+        conn.execute(
+            "INSERT INTO artists (id, name) VALUES (1, 'A'), (2, 'B')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO similar_artists (artist_id, similar_id, score, source)
+             VALUES (1, 2, 0.9, 'subsonic')",
+            [],
+        )
+        .unwrap();
+        let rel: String = conn
+            .query_row(
+                "SELECT relationship FROM similar_artists WHERE artist_id = 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(rel, "similar");
+    }
 }


### PR DESCRIPTION
## Summary

Patch release bundling a single fix: `similarArtists` crashed on any DB created before the `relationship` column was added to `similar_artists` — schema had the column but no `ALTER TABLE` migration shipped, so existing DBs returned `no such column: sa.relationship`.

- Added the migration to the existing `migrations` array in `schema.rs` alongside the `cache_size_bytes` / `cache_download_date` entries.
- Added a regression test that creates a pre-migration `similar_artists` schema, runs `create_tables`, and asserts both the column was added and the default value materialises.
- Bumped workspace version `0.23.2` → `0.23.3`, updated `Cargo.lock`, finalized changelog entry.

## Changelog

### Fixed

- **`similarArtists` crashed on pre-existing DBs** — schema added a `relationship` column to `similar_artists` but shipped no `ALTER TABLE` migration, so databases created before the column existed blew up with `no such column: sa.relationship` the moment the query ran. Added the migration alongside the existing cache-column migrations and a regression test that boots a pre-migration schema and verifies `create_tables` patches it.

## Context

Spotted by a user running `similarArtists(artistId: 768)` (Nightmares on Wax). Verified on the live DB:

```
PRAGMA table_info(similar_artists);
-- no 'relationship' column before patch
-- column present after ALTER, default 'similar' materialises on existing rows
```

Unrelated: `similarTracks` returns `[]` for every track because `track_vectors` is empty (0 rows vs 47906 tracks) — the neural index has never been populated. Not a bug, but the resolver silently returning `[]` when the whole index is empty is arguably misleading; left for a separate issue.

## Test plan

- [x] `cargo test --workspace` (503 + 54 + 45 + 17 passed)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (clean)
- [x] Applied migration to local DB, re-ran `similarArtists(artistId: 768)` — resolves without error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)