### PR TITLE
fix(audio): configure the engine from the source PCM format, not the device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- **MP3s at unusual sample rates played at the wrong speed** — the audio engine was configured with the rate the *device* settled on, not the rate the PCM actually is. Output devices reject the MPEG-2/2.5 rates that only MP3 uses (8/11.025/12/16/22.05/24 kHz, and 32 kHz on many DACs), so a 22.05 kHz MP3 on a 44.1 kHz device played at exactly double speed. The engine is now always configured from the source format and the device switch is a best-effort bit-perfect optimisation; when it fails the platform resamples instead. FLAC never hit this because it is only ever ripped at rates every device supports. ([#181](https://github.com/radiosilence/koan/pull/181))
+- **Mixed-format queues played the second track at the wrong speed** — every track in a gapless session shares one ring buffer and therefore one engine, but the decode thread would happily push a 48 kHz track in behind a 44.1 kHz one. A track whose rate or channel count differs now ends the decode session so the player can restart it on a correctly configured engine.
+- **Tail of the last decoded track was cut off** — the decode thread signalled completion as soon as it had *written* the last sample, up to 4 seconds before the audio engine had played it. It now waits for the ring buffer to drain first.
+
 ## v0.23.3 (2026-04-19)
 
 ### Fixed

--- a/crates/koan-core/src/audio/buffer.rs
+++ b/crates/koan-core/src/audio/buffer.rs
@@ -452,6 +452,11 @@ where
 // ---------------------------------------------------------------------------
 
 /// Gapless decode loop: decode first entry, then call next_track on EOF.
+///
+/// Every track in a session shares one ring buffer, and therefore the audio
+/// engine configured for it. A track whose PCM format differs from the first
+/// ends the session rather than being written at the wrong format; the player
+/// restarts it on a correctly configured engine.
 #[allow(clippy::too_many_arguments)]
 fn decode_queue_loop<N>(
     first: SourceEntry,
@@ -466,74 +471,103 @@ fn decode_queue_loop<N>(
 ) where
     N: Fn() -> Option<SourceEntry>,
 {
-    let path = first.path.clone();
-    let hint = first.hint.clone();
-    let mss = match (first.make_mss)() {
-        Ok(mss) => mss,
-        Err(e) => {
-            if !stop.load(Ordering::Relaxed) {
-                log::error!("failed to open {}: {}", path.display(), e);
-            }
-            return;
-        }
-    };
-
-    if let Err(e) = decode_single(
-        first.id,
-        &path,
-        &hint,
-        mss,
-        &mut producer,
-        stop,
-        initial_seek_ms,
-        timeline,
-        viz_buffer,
-        rg_mode,
-        pre_amp_db,
-    ) {
-        if !stop.load(Ordering::Relaxed) {
-            log::error!("decode error on {}: {}", path.display(), e);
-        }
-        return;
-    }
-
-    while !stop.load(Ordering::Relaxed) {
-        let Some(entry) = (next_track)() else {
-            log::info!("playlist exhausted, decode thread finishing");
-            break;
-        };
-
-        log::info!("gapless transition → {}", entry.path.display());
-        let next_path = entry.path.clone();
-        let next_hint = entry.hint.clone();
-        let next_mss = match (entry.make_mss)() {
+    'session: {
+        let path = first.path.clone();
+        let hint = first.hint.clone();
+        let mss = match (first.make_mss)() {
             Ok(mss) => mss,
             Err(e) => {
                 if !stop.load(Ordering::Relaxed) {
-                    log::error!("failed to open {}: {}", next_path.display(), e);
+                    log::error!("failed to open {}: {}", path.display(), e);
                 }
-                break;
+                break 'session;
             }
         };
 
-        if let Err(e) = decode_single(
-            entry.id,
-            &next_path,
-            &next_hint,
-            next_mss,
+        let format = match decode_single(
+            first.id,
+            &path,
+            &hint,
+            mss,
             &mut producer,
             stop,
-            0,
+            initial_seek_ms,
             timeline,
             viz_buffer,
             rg_mode,
             pre_amp_db,
+            None,
         ) {
-            if !stop.load(Ordering::Relaxed) {
-                log::error!("decode error on {}: {}", next_path.display(), e);
+            Ok(Decoded::Complete(format)) => format,
+            Ok(Decoded::FormatMismatch) => break 'session,
+            Err(e) => {
+                if !stop.load(Ordering::Relaxed) {
+                    log::error!("decode error on {}: {}", path.display(), e);
+                }
+                break 'session;
             }
-            break;
+        };
+
+        while !stop.load(Ordering::Relaxed) {
+            let Some(entry) = (next_track)() else {
+                log::info!("playlist exhausted, decode thread finishing");
+                break;
+            };
+
+            log::info!("gapless transition → {}", entry.path.display());
+            let next_path = entry.path.clone();
+            let next_hint = entry.hint.clone();
+            let next_mss = match (entry.make_mss)() {
+                Ok(mss) => mss,
+                Err(e) => {
+                    if !stop.load(Ordering::Relaxed) {
+                        log::error!("failed to open {}: {}", next_path.display(), e);
+                    }
+                    break;
+                }
+            };
+
+            match decode_single(
+                entry.id,
+                &next_path,
+                &next_hint,
+                next_mss,
+                &mut producer,
+                stop,
+                0,
+                timeline,
+                viz_buffer,
+                rg_mode,
+                pre_amp_db,
+                Some(format),
+            ) {
+                Ok(Decoded::Complete(_)) => {}
+                Ok(Decoded::FormatMismatch) => break,
+                Err(e) => {
+                    if !stop.load(Ordering::Relaxed) {
+                        log::error!("decode error on {}: {}", next_path.display(), e);
+                    }
+                    break;
+                }
+            }
         }
+    }
+
+    wait_for_drain(&producer, stop);
+}
+
+/// Block until the audio engine has consumed everything in the ring buffer.
+///
+/// A session ends only once its audio has been heard, so the player can tear
+/// the engine down without clipping the tail of the last track decoded.
+/// Returns early if playback is torn down underneath us.
+fn wait_for_drain(producer: &rtrb::Producer<f32>, stop: &AtomicBool) {
+    let capacity = producer.buffer().capacity();
+    while !stop.load(Ordering::Relaxed) && !producer.is_abandoned() {
+        if producer.slots() >= capacity {
+            return;
+        }
+        thread::sleep(std::time::Duration::from_millis(2));
     }
 }
 
@@ -541,7 +575,24 @@ fn decode_queue_loop<N>(
 // Core decode single track
 // ---------------------------------------------------------------------------
 
-/// Decode a single source into the producer. Returns Ok(()) on clean EOF.
+/// The PCM format of a decoded stream: sample rate in Hz and channel count.
+/// The audio engine is configured from this, so the ring buffer may only ever
+/// hold samples of one such format at a time.
+type PcmFormat = (u32, u16);
+
+/// Outcome of decoding one source.
+enum Decoded {
+    /// Decoded to EOF, in the given format.
+    Complete(PcmFormat),
+    /// The source's format differs from the stream already in the ring buffer.
+    /// Nothing further was written — the engine must be reconfigured first.
+    FormatMismatch,
+}
+
+/// Decode a single source into the producer. Returns on clean EOF.
+///
+/// `expected` — the format already in the ring buffer, if any. A source that
+/// does not match it is rejected without writing samples or pushing a boundary.
 #[allow(clippy::too_many_arguments)]
 fn decode_single(
     queue_item_id: QueueItemId,
@@ -555,7 +606,8 @@ fn decode_single(
     viz_buffer: Option<&VizBuffer>,
     rg_mode: ReplayGainMode,
     pre_amp_db: f64,
-) -> Result<(), DecodeError> {
+    expected: Option<PcmFormat>,
+) -> Result<Decoded, DecodeError> {
     let format_opts = FormatOptions {
         enable_gapless: true,
         ..Default::default()
@@ -606,6 +658,20 @@ fn decode_single(
         bitrate_kbps,
         duration_ms,
     };
+
+    if let Some(expected) = expected
+        && expected != (sample_rate, channels)
+    {
+        log::info!(
+            "format change at {}: {}Hz/{}ch → {}Hz/{}ch, restarting audio engine",
+            path.display(),
+            expected.0,
+            expected.1,
+            sample_rate,
+            channels
+        );
+        return Ok(Decoded::FormatMismatch);
+    }
 
     let seek_samples = seek_ms * sample_rate as u64 * channels as u64 / 1000;
 
@@ -686,7 +752,7 @@ fn decode_single(
 
     loop {
         if stop.load(Ordering::Relaxed) {
-            return Ok(());
+            return Ok(Decoded::Complete((sample_rate, channels)));
         }
 
         let packet = match reader.next_packet() {
@@ -694,7 +760,7 @@ fn decode_single(
             Err(symphonia::core::errors::Error::IoError(ref e))
                 if e.kind() == std::io::ErrorKind::UnexpectedEof =>
             {
-                return Ok(());
+                return Ok(Decoded::Complete((sample_rate, channels)));
             }
             Err(e) => return Err(DecodeError::Decode(e.to_string())),
         };
@@ -724,6 +790,20 @@ fn decode_single(
             };
 
             let spec = *decoded.spec();
+            // The engine is configured from the probed format. PCM that
+            // disagrees with it would play at the wrong speed, so end the
+            // session instead and let the player reconfigure.
+            if (spec.rate, spec.channels.count() as u16) != (sample_rate, channels) {
+                log::warn!(
+                    "{}: decoded {}Hz/{}ch but stream declares {}Hz/{}ch, restarting audio engine",
+                    path.display(),
+                    spec.rate,
+                    spec.channels.count(),
+                    sample_rate,
+                    channels
+                );
+                return Ok(Decoded::FormatMismatch);
+            }
             let duration = decoded.capacity();
             let sbuf = sample_buf.get_or_insert_with(|| SampleBuffer::new(duration as u64, spec));
             sbuf.copy_interleaved_ref(decoded);
@@ -754,7 +834,7 @@ fn decode_single(
         let mut offset = 0;
         while offset < samples.len() {
             if stop.load(Ordering::Relaxed) {
-                return Ok(());
+                return Ok(Decoded::Complete((sample_rate, channels)));
             }
 
             let slots = producer.slots();
@@ -1086,8 +1166,12 @@ mod tests {
             None,
             crate::config::ReplayGainMode::Off,
             0.0,
+            None,
         );
-        assert!(result.is_ok(), "decode_single should succeed: {:?}", result);
+        assert!(
+            matches!(result, Ok(Decoded::Complete((44100, 1)))),
+            "decode_single should complete at the source format"
+        );
 
         // Read samples from the consumer side.
         let available = consumer.slots();
@@ -1114,5 +1198,134 @@ mod tests {
             found_nonzero,
             "expected non-zero samples from 440Hz sine decode"
         );
+    }
+
+    // --- Ring buffer format contract ---
+
+    /// Decode a queue of files through `decode_queue_loop` with a consumer
+    /// draining in the background. Returns the boundaries the decode thread
+    /// pushed onto the timeline.
+    fn run_queue(paths: &[PathBuf]) -> Vec<TrackBoundary> {
+        let (producer, mut consumer) = rtrb::RingBuffer::new(1 << 16);
+        let timeline = PlaybackTimeline::new();
+        let stop = Arc::new(AtomicBool::new(false));
+
+        let drain_stop = Arc::new(AtomicBool::new(false));
+        let drain_flag = drain_stop.clone();
+        let drainer = std::thread::spawn(move || {
+            while !drain_flag.load(Ordering::Relaxed) {
+                let n = consumer.slots();
+                if n > 0
+                    && let Ok(chunk) = consumer.read_chunk(n)
+                {
+                    chunk.commit_all();
+                }
+                std::thread::sleep(std::time::Duration::from_micros(200));
+            }
+        });
+
+        let rest: std::sync::Mutex<Vec<PathBuf>> = std::sync::Mutex::new(paths[1..].to_vec());
+        let next_track = move || {
+            let mut rest = rest.lock().ok()?;
+            if rest.is_empty() {
+                return None;
+            }
+            Some(SourceEntry::from_file(QueueItemId::new(), rest.remove(0)))
+        };
+
+        decode_queue_loop(
+            SourceEntry::from_file(QueueItemId::new(), paths[0].clone()),
+            producer,
+            &stop,
+            0,
+            &next_track,
+            &timeline,
+            None,
+            crate::config::ReplayGainMode::Off,
+            0.0,
+        );
+
+        drain_stop.store(true, Ordering::Relaxed);
+        drainer.join().unwrap();
+
+        timeline.boundaries.read().clone()
+    }
+
+    #[test]
+    fn gapless_continues_when_format_matches() {
+        let dir = tempfile::tempdir().unwrap();
+        let a = dir.path().join("a.wav");
+        let b = dir.path().join("b.wav");
+        crate::test_utils::generate_wav(&a, 44100, 2, 0.1, 16);
+        crate::test_utils::generate_wav(&b, 44100, 2, 0.1, 16);
+
+        let bounds = run_queue(&[a, b]);
+        assert_eq!(
+            bounds.len(),
+            2,
+            "same-format tracks should decode gaplessly"
+        );
+    }
+
+    #[test]
+    fn gapless_stops_at_sample_rate_change() {
+        let dir = tempfile::tempdir().unwrap();
+        let a = dir.path().join("a.wav");
+        let b = dir.path().join("b.wav");
+        crate::test_utils::generate_wav(&a, 44100, 2, 0.1, 16);
+        crate::test_utils::generate_wav(&b, 48000, 2, 0.1, 16);
+
+        let bounds = run_queue(&[a, b]);
+        assert_eq!(
+            bounds.len(),
+            1,
+            "a 48kHz track must not join a 44.1kHz ring buffer"
+        );
+        assert_eq!(bounds[0].info.sample_rate, 44100);
+    }
+
+    #[test]
+    fn gapless_stops_at_channel_change() {
+        let dir = tempfile::tempdir().unwrap();
+        let a = dir.path().join("a.wav");
+        let b = dir.path().join("b.wav");
+        crate::test_utils::generate_wav(&a, 44100, 2, 0.1, 16);
+        crate::test_utils::generate_wav(&b, 44100, 1, 0.1, 16);
+
+        let bounds = run_queue(&[a, b]);
+        assert_eq!(
+            bounds.len(),
+            1,
+            "a mono track must not join a stereo ring buffer"
+        );
+        assert_eq!(bounds[0].info.channels, 2);
+    }
+
+    #[test]
+    fn drain_waits_for_the_consumer() {
+        let (mut producer, mut consumer) = rtrb::RingBuffer::new(64);
+        for _ in 0..64 {
+            producer.push(0.0).unwrap();
+        }
+        let stop = Arc::new(AtomicBool::new(false));
+
+        let reader = std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(20));
+            let chunk = consumer.read_chunk(64).unwrap();
+            chunk.commit_all();
+            consumer
+        });
+
+        wait_for_drain(&producer, &stop);
+        assert_eq!(producer.slots(), 64, "drain must wait for an empty buffer");
+        drop(reader.join().unwrap());
+    }
+
+    #[test]
+    fn drain_returns_when_playback_is_torn_down() {
+        let (producer, consumer) = rtrb::RingBuffer::<f32>::new(64);
+        let stop = Arc::new(AtomicBool::new(true));
+        wait_for_drain(&producer, &stop);
+        drop(consumer);
     }
 }

--- a/crates/koan-core/src/index/features.rs
+++ b/crates/koan-core/src/index/features.rs
@@ -47,8 +47,8 @@ pub fn bytes_to_embedding(bytes: &[u8]) -> Option<Vec<f32>> {
     }
     let count = bytes.len() / 4;
     let mut embedding = Vec::with_capacity(count);
-    for chunk in bytes.chunks_exact(4) {
-        embedding.push(f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]));
+    for chunk in bytes.as_chunks::<4>().0 {
+        embedding.push(f32::from_le_bytes(*chunk));
     }
     Some(embedding)
 }

--- a/crates/koan-core/src/player/mod.rs
+++ b/crates/koan-core/src/player/mod.rs
@@ -118,6 +118,53 @@ impl Player {
         &self.undo_stack
     }
 
+    /// Create an audio engine for a stream, switching the output device to the
+    /// source rate first so output is bit-perfect.
+    ///
+    /// The engine is always configured with the source's own rate and channel
+    /// count — the format the decode thread writes into the ring buffer. A
+    /// device that cannot take the requested rate (MPEG-2/2.5 MP3 rates are
+    /// commonly refused) resamples instead of playing at the wrong speed.
+    fn create_engine_for(
+        &self,
+        info: &buffer::StreamInfo,
+        consumer: rtrb::Consumer<f32>,
+    ) -> Result<Box<dyn AudioEngineHandle>, PlayerError> {
+        let device = self.resolve_device()?;
+        let device_rate = self.backend.get_device_sample_rate(&device)?;
+        let source_rate = info.sample_rate as f64;
+
+        if (device_rate - source_rate).abs() > 0.1 {
+            log::info!(
+                "switching device sample rate: {}Hz → {}Hz",
+                device_rate,
+                source_rate
+            );
+            let settled = match self.backend.set_device_sample_rate(&device, source_rate) {
+                Ok(rate) => rate,
+                Err(e) => {
+                    log::warn!("failed to set device sample rate: {}", e);
+                    device_rate
+                }
+            };
+            if (settled - source_rate).abs() > 0.1 {
+                log::warn!(
+                    "device stayed at {}Hz (wanted {}Hz) — output is resampled, not bit-perfect",
+                    settled,
+                    source_rate
+                );
+            }
+        }
+
+        Ok(self.backend.create_engine(
+            &device,
+            source_rate,
+            info.channels as u32,
+            consumer,
+            self.timeline.samples_played_counter(),
+        )?)
+    }
+
     /// Resolve the output device: use configured device name if set,
     /// falling back to system default if not set or if the named device is unavailable.
     fn resolve_device(&self) -> Result<backend::DeviceInfo, PlayerError> {
@@ -268,39 +315,6 @@ impl Player {
             }
         );
 
-        let device = self.resolve_device()?;
-        let device_rate = self.backend.get_device_sample_rate(&device)?;
-        let source_rate = info.sample_rate as f64;
-
-        let actual_rate = if (device_rate - source_rate).abs() > 0.1 {
-            log::info!(
-                "switching device sample rate: {}Hz → {}Hz",
-                device_rate,
-                source_rate
-            );
-            match self.backend.set_device_sample_rate(&device, source_rate) {
-                Ok(confirmed_rate) => {
-                    if (confirmed_rate - source_rate).abs() > 0.1 {
-                        log::warn!(
-                            "device stayed at {}Hz (wanted {}Hz) — playback will use device rate",
-                            confirmed_rate,
-                            source_rate
-                        );
-                    }
-                    confirmed_rate
-                }
-                Err(e) => {
-                    log::warn!(
-                        "failed to set sample rate (continuing at device rate): {}",
-                        e
-                    );
-                    device_rate
-                }
-            }
-        } else {
-            device_rate
-        };
-
         let (producer, consumer) = rtrb::RingBuffer::new(RING_BUFFER_SIZE);
 
         let _generation = self.shared_state.bump_generation();
@@ -345,14 +359,7 @@ impl Player {
             },
         )?;
 
-        // Create and start audio engine with the confirmed device rate.
-        let engine = self.backend.create_engine(
-            &device,
-            actual_rate,
-            info.channels as u32,
-            consumer,
-            self.timeline.samples_played_counter(),
-        )?;
+        let engine = self.create_engine_for(&info, consumer)?;
         engine.start()?;
 
         self.shared_state.set_playback_state(PlaybackState::Playing);
@@ -481,39 +488,6 @@ impl Player {
             info.duration_ms,
         );
 
-        let device = self.resolve_device()?;
-        let device_rate = self.backend.get_device_sample_rate(&device)?;
-        let source_rate = info.sample_rate as f64;
-
-        let actual_rate = if (device_rate - source_rate).abs() > 0.1 {
-            log::info!(
-                "switching device sample rate: {}Hz → {}Hz",
-                device_rate,
-                source_rate
-            );
-            match self.backend.set_device_sample_rate(&device, source_rate) {
-                Ok(confirmed_rate) => {
-                    if (confirmed_rate - source_rate).abs() > 0.1 {
-                        log::warn!(
-                            "device stayed at {}Hz (wanted {}Hz) — playback will use device rate",
-                            confirmed_rate,
-                            source_rate
-                        );
-                    }
-                    confirmed_rate
-                }
-                Err(e) => {
-                    log::warn!(
-                        "failed to set sample rate (continuing at device rate): {}",
-                        e
-                    );
-                    device_rate
-                }
-            }
-        } else {
-            device_rate
-        };
-
         let (producer, consumer) = rtrb::RingBuffer::new(RING_BUFFER_SIZE);
 
         let _generation = self.shared_state.bump_generation();
@@ -583,14 +557,7 @@ impl Player {
             },
         )?;
 
-        // Create and start audio engine with the confirmed device rate.
-        let engine = self.backend.create_engine(
-            &device,
-            actual_rate,
-            info.channels as u32,
-            consumer,
-            self.timeline.samples_played_counter(),
-        )?;
+        let engine = self.create_engine_for(&info, consumer)?;
         engine.start()?;
 
         self.shared_state.set_playback_state(PlaybackState::Playing);
@@ -1655,5 +1622,107 @@ mod tests {
             dropped.load(Ordering::SeqCst),
             "AudioEngine must be dropped synchronously in stop_engine (GitHub #89)"
         );
+    }
+
+    // --- Engine format matches the decoded PCM ---
+
+    /// Backend pinned to one sample rate that refuses every switch, recording
+    /// the format the engine is asked for.
+    struct StuckBackend {
+        rate: f64,
+        asked: Arc<std::sync::Mutex<Option<(f64, u32)>>>,
+    }
+
+    struct NullEngine;
+    impl AudioEngineHandle for NullEngine {
+        fn start(&self) -> Result<(), BackendError> {
+            Ok(())
+        }
+        fn stop(&self) -> Result<(), BackendError> {
+            Ok(())
+        }
+        fn is_running(&self) -> bool {
+            false
+        }
+    }
+
+    impl AudioBackend for StuckBackend {
+        fn list_devices(&self) -> Result<Vec<backend::DeviceInfo>, BackendError> {
+            Ok(vec![self.default_device()?])
+        }
+        fn default_device(&self) -> Result<backend::DeviceInfo, BackendError> {
+            Ok(backend::DeviceInfo {
+                name: "Stuck DAC".into(),
+                sample_rates: vec![self.rate],
+                platform_id: 0,
+            })
+        }
+        fn supported_sample_rates(
+            &self,
+            _device: &backend::DeviceInfo,
+        ) -> Result<Vec<f64>, BackendError> {
+            Ok(vec![self.rate])
+        }
+        fn get_device_sample_rate(
+            &self,
+            _device: &backend::DeviceInfo,
+        ) -> Result<f64, BackendError> {
+            Ok(self.rate)
+        }
+        fn set_device_sample_rate(
+            &self,
+            _device: &backend::DeviceInfo,
+            rate: f64,
+        ) -> Result<f64, BackendError> {
+            Err(BackendError::UnsupportedSampleRate(rate))
+        }
+        fn create_engine(
+            &self,
+            _device: &backend::DeviceInfo,
+            sample_rate: f64,
+            channels: u32,
+            _consumer: rtrb::Consumer<f32>,
+            _samples_played: Arc<AtomicU64>,
+        ) -> Result<Box<dyn AudioEngineHandle>, BackendError> {
+            *self.asked.lock().unwrap() = Some((sample_rate, channels));
+            Ok(Box::new(NullEngine))
+        }
+    }
+
+    fn engine_format_for(source_rate: u32, channels: u16, device_rate: f64) -> (f64, u32) {
+        let asked = Arc::new(std::sync::Mutex::new(None));
+        let mut player = Player::new();
+        player.backend = Box::new(StuckBackend {
+            rate: device_rate,
+            asked: asked.clone(),
+        });
+
+        let info = buffer::StreamInfo {
+            codec: "MP3".into(),
+            sample_rate: source_rate,
+            channels,
+            bit_depth: Some(16),
+            bitrate_kbps: None,
+            duration_ms: 1000,
+        };
+        let (_producer, consumer) = rtrb::RingBuffer::new(16);
+        player
+            .create_engine_for(&info, consumer)
+            .expect("engine creation should succeed");
+        let asked = *asked.lock().unwrap();
+        asked.expect("engine was never created")
+    }
+
+    #[test]
+    fn engine_uses_source_rate_when_device_refuses_switch() {
+        // MPEG-2 MP3 rates are routinely rejected by output devices. The engine
+        // must still be told the rate the PCM actually is.
+        assert_eq!(engine_format_for(22050, 2, 48000.0), (22050.0, 2));
+        assert_eq!(engine_format_for(32000, 2, 44100.0), (32000.0, 2));
+    }
+
+    #[test]
+    fn engine_uses_source_channel_count() {
+        assert_eq!(engine_format_for(44100, 1, 44100.0), (44100.0, 1));
     }
 }


### PR DESCRIPTION
## Root cause

`player/mod.rs` created the audio engine with the rate the **device** settled on, not the rate of the PCM the decode thread writes into the ring buffer:

```rust
let actual_rate = match self.backend.set_device_sample_rate(&device, source_rate) {
    Ok(confirmed_rate) => confirmed_rate,          // device may have refused
    Err(_) => device_rate,                          // ...or hard-failed
};
self.backend.create_engine(&device, actual_rate, ...)   // engine now lies about the PCM
```

Bit-perfect output means no resampling, so the engine's stream format *is* the playback clock. Whenever the device could not take the requested rate, the two disagreed and playback ran at `device_rate / source_rate`.

This is MP3-specific in practice: MPEG-2 and MPEG-2.5 give MP3 sample rates no other format in a normal library uses (8/11.025/12/16/22.05/24 kHz), and 32 kHz is common in rips and podcasts. Output devices reject all of them. FLAC is only ever ripped at 44.1/48/88.2/96/192 kHz, which every device supports — hence "MP3s, sometimes".

macOS only. On Linux `set_device_sample_rate` is a no-op that echoes the requested rate back, so `actual_rate` already equalled `source_rate` and cpal was configured correctly.

### Measured

Default device is a Scarlett 4i4 USB, supported rates `[44100, 48000, 88200, 96000, 176400, 192000]`. Every rate only MP3 uses is refused:

```
set  8000 -> Err(Platform("CoreAudio error: 2003329396"))   # kAudioDeviceUnsupportedFormatError
set 11025 -> Err(...)   set 12000 -> Err(...)   set 16000 -> Err(...)
set 22050 -> Err(...)   set 24000 -> Err(...)   set 32000 -> Err(...)
set 44100 -> Ok(44100.0)                        set 48000 -> Ok(48000.0)
```

Frames per second the engine actually pulls out of the ring buffer, measured over a 1.5 s window against the real device:

| engine configured at | device at | source PCM | observed frames/s | speed |
|---|---|---|---|---|
| 44100 | 44100 | 44100 | 43893 | 0.995x |
| **44100 (old code)** | 44100 | **22050** | 43987 | **1.995x** |
| 22050 (this PR) | 44100 | 22050 | 22140 | 1.004x |
| 8000 (this PR) | 44100 | 8000 | 8039 | 1.005x |
| 32000 (this PR) | 44100 | 32000 | 32102 | 1.003x |
| 48000 | 48000 | 48000 | 47990 | 1.000x |
| 44100 mono | 44100 | 44100 mono | 44079 | 1.000x |
| 22050 mono | 44100 | 22050 mono | 22067 | 1.001x |

Row 2 is the bug: exactly 44100/22050 = 2x. Every row where the engine is told the truth reads 1.00x, including the rates the device cannot switch to.

### Ruled out

Channel count was the other hypothesis, since mono is far more common in MP3s than FLACs and gives exactly 2x. It is not the cause — the old code already passed `info.channels`, and the last two rows above show a mono engine on a stereo device runs at pitch.

The probe was not the cause either. koan's `probe_file()` was checked against `ffprobe` over a 14-file fixture matrix, alongside the `spec()` of every decoded packet in each file:

| fixture | ffprobe | koan probe | decoded specs (all packets) |
|---|---|---|---|
| `mpeg1_48000_st.mp3` | 48000/2 | 48000/2 | 48000/2 |
| `mpeg1_44100_st.mp3` | 44100/2 | 44100/2 | 44100/2 |
| `mpeg1_32000_st.mp3` | 32000/2 | 32000/2 | 32000/2 |
| `mpeg2_24000_st.mp3` | 24000/2 | 24000/2 | 24000/2 |
| `mpeg2_22050_st.mp3` | 22050/2 | 22050/2 | 22050/2 |
| `mpeg2_16000_st.mp3` | 16000/2 | 16000/2 | 16000/2 |
| `mpeg25_12000_st.mp3` | 12000/2 | 12000/2 | 12000/2 |
| `mpeg25_11025_st.mp3` | 11025/2 | 11025/2 | 11025/2 |
| `mpeg25_8000_st.mp3` | 8000/2 | 8000/2 | 8000/2 |
| `mono_44100.mp3` | 44100/1 | 44100/1 | 44100/1 |
| `mono_48000.mp3` | 48000/1 | 48000/1 | 48000/1 |
| `vbr_44100.mp3` (`-V 2`) | 44100/2 | 44100/2 | 44100/2 |
| `bigid3_22050.mp3` (200 KB ID3v2) | 22050/2 | 22050/2 | 22050/2 |
| `joined_44100_48000.mp3` | 44100/2 | 44100/2 | 44100/2 |

No fixture disagrees, so `codec_params.sample_rate.unwrap_or(44100)` never fired and never lied. The probed rate was always right; it was thrown away downstream.

A second, independent cause: every track in a gapless session shares one ring buffer and therefore one engine, but `decode_queue_loop` pushed the next track in regardless of its format. A 48 kHz track following a 44.1 kHz one played 8.8% slow for its entire duration.

## What this does

- `Player::create_engine_for()` — one helper replacing the two near-identical device-setup blocks. The engine is **always** created at `info.sample_rate` / `info.channels`. Switching the device is now purely a best-effort bit-perfect optimisation; when it fails, the platform resamples (AUHAL's input-scope converter on macOS, cpal's stream config on Linux) and the log says output is not bit-perfect.
- `decode_single()` takes the format already in the ring buffer and rejects a source that does not match — before writing a sample or pushing a `TrackBoundary`. `decode_queue_loop` ends the session, and the player restarts that track on a correctly configured engine. It also verifies each decoded packet's own `spec()` against the probed format, so a demuxer that misreports (or a stream that changes rate mid-file) cannot slip PCM of the wrong format into the buffer either.
- `wait_for_drain()` — the decode thread waits for the engine to consume the ring buffer before signalling `DecodeFinished`. Needed so ending a session at a format change doesn't clip the outgoing track; it also fixes the pre-existing truncation of the last ~4 s of the final track in a queue.

## Load-bearing decisions

**Setting the client format to the source rate is correct, not a workaround.** The AUHAL client format (`kAudioUnitProperty_StreamFormat` on `kAudioUnitScope_Input`) describes what the render callback provides; the unit converts to the device format itself. The table above is the evidence — the engine pulls at the ASBD rate every time, whatever the device is doing. When the device *does* switch, client rate == device rate and nothing is converted, so bit-perfect playback is unchanged.

**Ending the session rather than resampling at a format boundary.** Gapless across a format change is not possible without a resampler, which this project does not have and does not want. Restarting the engine costs one gap; the alternative is a whole track at the wrong pitch.

**A rejected track is not lost.** The decode thread keeps its own cursor; the UI cursor only moves when a `TrackBoundary` is pushed. A track rejected for format mismatch pushes no boundary, so `on_decode_finished` → `advance_cursor()` lands on exactly that track and replays it on a fresh engine.

## Confirming it works

- `cargo test -p koan-core` — `engine_uses_source_rate_when_device_refuses_switch` drives `create_engine_for` through a backend stuck at one rate that rejects every switch, and asserts the engine is still asked for 22050/32000 Hz. `engine_uses_source_channel_count` covers mono.
- `gapless_stops_at_sample_rate_change` / `gapless_stops_at_channel_change` / `gapless_continues_when_format_matches` run `decode_queue_loop` over WAVs generated at runtime and assert on the boundaries the timeline received.
- `drain_waits_for_the_consumer` / `drain_returns_when_playback_is_torn_down` cover the drain, including the teardown escape hatch.
- Manually: play any 22.05 or 32 kHz MP3. Before, it was fast and the log said `device stayed at 44100Hz (wanted 22050Hz) — playback will use device rate`; now it plays at pitch and the log says output is resampled, not bit-perfect.

Fixtures are generated at runtime; no binary audio is committed. The MP3 matrix above was built with `lame`/`sox` in a scratch directory and is not part of the suite.

## Conflicts

#182 (`chore/deps-symphonia-06`) also rewrites `audio/buffer.rs` (+107/-77) and touches `player/mod.rs`. **This should land first.** It is a user-facing bug fix and its changes are semantic — the `Decoded` enum, the `expected` format parameter, the drain. #182 is a mechanical dep bump, and re-applying an API rename over this diff is much easier than re-deriving this logic on top of a changed symphonia API.

## Also here

One line in `index/features.rs` moves from `chunks_exact(4)` to `as_chunks::<4>()`. Unrelated to the audio fix, but `chunks_exact_to_as_chunks` is new in clippy 1.98 and fails CI on every branch until it is addressed.

## Out of scope — found, not fixed

- Symphonia's MP3 reader stops at a mid-file sample-rate change (`joined_44100_48000.mp3` decodes 3.03 s of a 6.08 s file), so a concatenated MP3 is silently truncated at the join rather than played through.
- `PlaybackTimeline::current_playback()` divides interleaved samples by channels before converting to ms, losing up to one frame of precision per read — harmless, but it means position is not exactly reversible.
