### PR TITLE
fix(ci): satisfy clippy 1.98's chunks_exact_to_as_chunks lint

### DIFF
--- a/crates/koan-core/src/index/features.rs
+++ b/crates/koan-core/src/index/features.rs
@@ -47,8 +47,8 @@ pub fn bytes_to_embedding(bytes: &[u8]) -> Option<Vec<f32>> {
     }
     let count = bytes.len() / 4;
     let mut embedding = Vec::with_capacity(count);
-    for chunk in bytes.chunks_exact(4) {
-        embedding.push(f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]));
+    for chunk in bytes.as_chunks::<4>().0 {
+        embedding.push(f32::from_le_bytes(*chunk));
     }
     Some(embedding)
 }


### PR DESCRIPTION
CI is red on `main` and on every open PR, with no code change on anyone's part. Clippy rolled to 1.98 and its new `chunks_exact_to_as_chunks` lint fires at `crates/koan-core/src/index/features.rs:50`, which `-D warnings` turns into a hard failure.

Two lines, no behaviour change: `chunks_exact(4)` → `as_chunks::<4>().0`, which yields `&[u8; 4]` directly so the manual `[chunk[0], chunk[1], chunk[2], chunk[3]]` reassembly goes away.

Cherry-picked from `fix/mp3-playback-speed` (#181), where it was hit first and fixed out of necessity. Landing it separately so the other open PRs can go green without waiting on that one.

## Why it keeps happening

This is the third time — `4bae19c fix(lint): resolve rust 1.95 clippy lints` was the last. CI pins the toolchain action by SHA but not the toolchain, so every run uses whatever stable is that day, and a new lint turns `main` red with zero commits. Worth a decision separately: either pin the clippy toolchain, or accept a small fix each time a lint lands. This PR just unblocks the queue.

## Verify

`cargo clippy -p koan-core --all-targets -- -D warnings` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PcSS6nwxDTpjT2BCMB18V2