### PR TITLE
docs: the crate boundary is real now, and the function count was wrong

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -20,10 +20,10 @@ crates/
 │
 └── koan-cli/      Binary crate. The `koan` executable.
                    Thin entry point: clap CLI, logger, signal handling.
-                   Depends on koan-core, koan-tui, koan-server.
+                   Depends on koan-core, koan-tui and koan-server.
 ```
 
-Four crates, one workspace. `koan-core` is the engine, `koan-tui` is the terminal UI, `koan-server` is the API layer, and `koan-cli` is the binary that ties them together. Dependency rule: `koan-server` must not depend on `koan-tui`. `koan-tui` currently declares an unused `koan-server` dependency; removing it makes the boundary compiler-enforced. If you wanted a different UI, write a new crate against `koan-core` -- the CLI owns zero business logic.
+Four crates, one workspace. `koan-core` is the engine, `koan-tui` is the terminal UI, `koan-server` is the API layer, and `koan-cli` is the binary that ties them together. Dependency rule, enforced by Cargo: `koan-tui` and `koan-server` cannot import each other -- both depend only on `koan-core`. If you wanted a different UI, write a new crate against `koan-core` -- the CLI owns zero business logic.
 
 ## Threading model
 
@@ -220,7 +220,7 @@ fb2k-compatible template engine.
 |---|---|
 | `parser.rs` | Recursive descent tokenizer: `%field%`, `[conditional]`, `$function(args)`, `'quoted'` |
 | `eval.rs` | Evaluates token tree against a `MetadataProvider` trait. Conditionals omit block if any field missing. |
-| `functions.rs` | 55 built-in functions: string ops (`left`, `right`, `pad`, `replace`, `trim`, `caps`, `abbr`, `substr`, `insert`, `repeat`, `rot13`, etc.), logic (`if`, `if2`, `if3`, `ifequal`, `ifgreater`, `iflonger`, `select`, `not`, `and`, `or`, `xor`), numeric (`num`, `add`, `sub`, `mul`, `div`, `mod`, `max`, `min`, `hex`), path (`directory`, `directory_path`, `ext`, `filename`), info (`len`, `info`), special (`tab`, `crlf`, `char`) |
+| `functions.rs` | 59 built-in functions: string ops (`left`, `right`, `pad`, `replace`, `trim`, `caps`, `abbr`, `substr`, `insert`, `repeat`, `rot13`, etc.), logic (`if`, `if2`, `if3`, `ifequal`, `ifgreater`, `iflonger`, `select`, `not`, `and`, `or`, `xor`), numeric (`num`, `add`, `sub`, `mul`, `div`, `mod`, `max`, `min`, `hex`), path (`directory`, `directory_path`, `ext`, `filename`), info (`len`, `info`), special (`tab`, `crlf`, `char`) |
 
 ### `remote/`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ Bit-perfect music player (macOS + Linux). Pure Rust, Ratatui TUI. Four crates:
 - **koan-server** — library crate. GraphQL (async-graphql + axum), Subsonic REST API, MCP server. Depends on koan-core.
 - **koan-cli** — binary crate (`koan`). Thin entry point: clap CLI, logger, signal handling, command routing. Depends on koan-core + koan-tui + koan-server.
 
-Dependency rules: koan-server must not depend on koan-tui. koan-tui declares an unused koan-server dep (`crates/koan-tui/Cargo.toml`) — removing it makes the boundary compiler-enforced. Future iOS app imports only koan-core.
+Dependency rules (compiler-enforced): koan-tui and koan-server cannot import each other; both depend only on koan-core. Future iOS app imports only koan-core.
 
 ## Architecture overview
 
@@ -103,7 +103,7 @@ Pre-push hook (`.claude/settings.json`) runs `cargo fmt --all` + `cargo clippy -
 | `db/queries/` | Row types, upsert (3-strategy dedup), FTS5 search, scan cache, stats, snapshots |
 | `index/scanner.rs` | Parallel library scan: walkdir → rayon → sequential DB upsert |
 | `index/metadata.rs` | Tag reading via lofty (ID3, Vorbis, MP4, APE), codec detection |
-| `format/` | fb2k-compatible template engine: parser (recursive descent), evaluator, 55 built-in functions |
+| `format/` | fb2k-compatible template engine: parser (recursive descent), evaluator, 59 built-in functions |
 | `remote/client.rs` | Subsonic/Navidrome HTTP client (reqwest blocking, MD5+salt auth) |
 | `remote/download.rs` | Streaming downloads: `.part` → verify → atomic rename, progress, retries. All disk-bound remote bytes go through here |
 | `remote/sync.rs` | Parallel library sync: paginate → rayon fetch → batch DB write |


### PR DESCRIPTION
Two small corrections, both to files that are wrong *right now* on main.

**The crate boundary.** #184 corrected `CLAUDE.md` and `ARCHITECTURE.md`, which claimed Cargo enforced that koan-tui and koan-server can't import each other — it didn't, koan-tui declared the dependency. Then #185 actually *removed* that dependency, which left my own correction stale in the opposite direction: both files now say removing it "makes the boundary compiler-enforced", as future work. It's done. Verified: no `koan-server` entry in `crates/koan-tui/Cargo.toml`, and zero `koan_server` references in `crates/koan-tui/src/`.

**The function count.** `format/functions.rs` dispatches **59** distinct names, not 55. The enumeration in `ARCHITECTURE.md:223` omits `caps2`, `fix_eol`, `greater`, `longer`, `longest`, `lower`, `upper`, `muldiv`, `pad_right`, `padcut`, `padcut_right`, `shortest`, `strchr`, `strcmp`, `stricmp`, `stripprefix`, `strrchr`, `strstr` and `swapprefix`.

`CLAUDE.md` is loaded into every AI session in this repo, so a wrong line there propagates into every subsequent piece of work — which is exactly how the original false claim survived long enough to be worth two PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PcSS6nwxDTpjT2BCMB18V2