### PR TITLE
chore(db): version the schema and stop migrations depending on error text

### DIFF
--- a/crates/koan-core/src/db/schema.rs
+++ b/crates/koan-core/src/db/schema.rs
@@ -1,7 +1,22 @@
 use rusqlite::Connection;
 
 /// Create all tables. Idempotent — safe to call on every startup.
+/// Bumped whenever the schema changes. Stored in `PRAGMA user_version` so an
+/// older build refuses a database it does not understand rather than writing to it.
+pub const SCHEMA_VERSION: i64 = 1;
+
 pub fn create_tables(conn: &Connection) -> rusqlite::Result<()> {
+    let found: i64 = conn.query_row("PRAGMA user_version", [], |r| r.get(0))?;
+    if found > SCHEMA_VERSION {
+        return Err(rusqlite::Error::SqliteFailure(
+            rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_ERROR),
+            Some(format!(
+                "database schema version {found} is newer than this build understands \
+                 ({SCHEMA_VERSION}) — upgrade koan rather than downgrading the library"
+            )),
+        ));
+    }
+
     conn.execute_batch(
         "
         CREATE TABLE IF NOT EXISTS artists (
@@ -175,27 +190,52 @@ pub fn create_tables(conn: &Connection) -> rusqlite::Result<()> {
         CREATE INDEX IF NOT EXISTS idx_refresh_tokens_expires ON refresh_tokens(expires_at);
         ",
     )?;
-    // --- Migrations: add columns that didn't exist in earlier versions ---
-    // SQLite has no ADD COLUMN IF NOT EXISTS, so we catch the "duplicate column" error.
-    let migrations = [
-        "ALTER TABLE tracks ADD COLUMN cache_size_bytes INTEGER",
-        "ALTER TABLE tracks ADD COLUMN cache_download_date INTEGER",
-        "ALTER TABLE similar_artists ADD COLUMN relationship TEXT NOT NULL DEFAULT 'similar'",
-        // Undo checks these against the file before moving it back, so a file that
-        // was replaced since the organize is left alone.
-        "ALTER TABLE organize_log ADD COLUMN size_bytes INTEGER",
-        "ALTER TABLE organize_log ADD COLUMN mtime INTEGER",
-    ];
-    for sql in &migrations {
-        match conn.execute(sql, []) {
-            Ok(_) => {}
-            Err(rusqlite::Error::ExecuteReturnedResults) => {}
-            Err(e) if e.to_string().contains("duplicate column") => {}
-            Err(e) => return Err(e),
-        }
-    }
+    apply_migrations(conn)?;
+    conn.pragma_update(None, "user_version", SCHEMA_VERSION)?;
 
     Ok(())
+}
+
+/// Columns added after the initial schema. Applied when absent, so a database
+/// created by any earlier version converges on the current shape.
+///
+/// `organize_log.size_bytes`/`mtime` are checked against the file before undo
+/// moves it back, so a file replaced since the organize is left alone.
+const ADDED_COLUMNS: &[(&str, &str, &str)] = &[
+    ("tracks", "cache_size_bytes", "INTEGER"),
+    ("tracks", "cache_download_date", "INTEGER"),
+    (
+        "similar_artists",
+        "relationship",
+        "TEXT NOT NULL DEFAULT 'similar'",
+    ),
+    ("organize_log", "size_bytes", "INTEGER"),
+    ("organize_log", "mtime", "INTEGER"),
+];
+
+fn apply_migrations(conn: &Connection) -> rusqlite::Result<()> {
+    for (table, column, ty) in ADDED_COLUMNS {
+        if !column_exists(conn, table, column)? {
+            conn.execute(&format!("ALTER TABLE {table} ADD COLUMN {column} {ty}"), [])?;
+        }
+    }
+    Ok(())
+}
+
+/// Whether `table` already has `column`.
+///
+/// PRAGMA cannot take a bound parameter for the table name, so the name is
+/// interpolated — every caller passes a literal from `ADDED_COLUMNS`, never
+/// user input.
+fn column_exists(conn: &Connection, table: &str, column: &str) -> rusqlite::Result<bool> {
+    let mut stmt = conn.prepare(&format!("PRAGMA table_info({table})"))?;
+    let mut rows = stmt.query([])?;
+    while let Some(row) = rows.next()? {
+        if row.get::<_, String>(1)? == column {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }
 
 #[cfg(test)]
@@ -352,5 +392,75 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM refresh_tokens", [], |row| row.get(0))
             .unwrap();
         assert_eq!(remaining, 0, "ON DELETE CASCADE did not fire");
+    }
+    #[test]
+    fn fresh_database_is_stamped_with_the_current_version() {
+        let conn = Connection::open_in_memory().unwrap();
+        create_tables(&conn).unwrap();
+        let v: i64 = conn
+            .query_row("PRAGMA user_version", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(v, SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn create_tables_is_idempotent_across_repeated_opens() {
+        let conn = Connection::open_in_memory().unwrap();
+        for _ in 0..3 {
+            create_tables(&conn).unwrap();
+        }
+        assert!(column_exists(&conn, "tracks", "cache_size_bytes").unwrap());
+        assert!(column_exists(&conn, "organize_log", "mtime").unwrap());
+    }
+
+    #[test]
+    fn a_database_missing_added_columns_is_migrated() {
+        let conn = Connection::open_in_memory().unwrap();
+        create_tables(&conn).unwrap();
+        // Rebuild `organize_log` without the columns added after the initial
+        // schema, so the file looks like one written by an earlier version.
+        conn.execute_batch(
+            "DROP TABLE organize_log;
+             CREATE TABLE organize_log (
+                 id         INTEGER PRIMARY KEY,
+                 batch_id   TEXT NOT NULL,
+                 track_id   INTEGER,
+                 from_path  TEXT NOT NULL,
+                 to_path    TEXT NOT NULL,
+                 created_at TEXT DEFAULT (datetime('now'))
+             );
+             PRAGMA user_version = 0;",
+        )
+        .unwrap();
+        assert!(!column_exists(&conn, "organize_log", "size_bytes").unwrap());
+
+        create_tables(&conn).unwrap();
+
+        assert!(column_exists(&conn, "organize_log", "size_bytes").unwrap());
+        assert!(column_exists(&conn, "organize_log", "mtime").unwrap());
+    }
+
+    #[test]
+    fn migration_does_not_depend_on_sqlite_error_text() {
+        // The previous implementation swallowed a duplicate-column ALTER by
+        // string-matching SQLite's message, so a wording change in a bundled
+        // SQLite upgrade would have failed every open. Adding a column that is
+        // already present must now be a no-op decided by schema inspection.
+        let conn = Connection::open_in_memory().unwrap();
+        create_tables(&conn).unwrap();
+        apply_migrations(&conn).unwrap();
+        apply_migrations(&conn).unwrap();
+    }
+
+    #[test]
+    fn a_newer_database_is_refused_rather_than_written_to() {
+        let conn = Connection::open_in_memory().unwrap();
+        create_tables(&conn).unwrap();
+        conn.pragma_update(None, "user_version", SCHEMA_VERSION + 1)
+            .unwrap();
+
+        let err = create_tables(&conn).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("newer than this build"), "unexpected: {msg}");
     }
 }


### PR DESCRIPTION
The schema's additive migrations were idempotent only because of this:

```rust
Err(e) if e.to_string().contains("duplicate column") => {}
Err(e) => return Err(e),
```

That is a **string match against SQLite's error message**. If a bundled-SQLite upgrade reworded it, every `ALTER` would take the `return Err(e)` arm → `create_tables` fails → `Database::open` fails → `koan-cli` exits. **koan would not start, for every existing user.**

And it isn't a rare path. On a *fresh* database `similar_artists` is created with `relationship` already present, so the duplicate-column branch fires on the very first open of a brand-new library and on every connection open thereafter. The error path was the normal path.

`deps-ship` confirmed during the rusqlite 0.38 → 0.40 bump that SQLite 3.53.2 still says `duplicate column name:`, so nothing is broken today — but the contract was pinned by a test rather than made robust. This makes it robust.

## What changed

**Migrations decide by schema, not by diagnostics.** `PRAGMA table_info` is consulted and the column added only when genuinely absent. No error is swallowed, so a *real* failure now surfaces instead of being mistaken for a duplicate.

**The database carries `PRAGMA user_version`.** A build predating a schema change refuses to open a newer library rather than writing to it. Harmless today — every added column is nullable or defaulted — and it stops being harmless the first time someone adds a `NOT NULL` without a default.

The columns themselves are unchanged, so this is a no-op on every existing database.

## Verify

Ten schema tests pass, five of them new:

- `fresh_database_is_stamped_with_the_current_version`
- `create_tables_is_idempotent_across_repeated_opens` — three consecutive opens
- `a_database_missing_added_columns_is_migrated` — rebuilds `organize_log` without the post-initial columns and resets `user_version`, so the file looks like one written by an earlier build
- `migration_does_not_depend_on_sqlite_error_text` — adding a column that already exists is a no-op decided by inspection; this is the regression test for the actual bug
- `a_newer_database_is_refused_rather_than_written_to`

Plus the existing `pre_migration_database_gains_the_new_columns` and `reopening_a_migrated_database_succeeds` from the rusqlite bump, which still pass unmodified.

## Not in scope

This does **not** introduce a numbered migration list or the ability to run data transformations. `Database::open` is currently called per GraphQL request, so an `UPDATE` in that path would execute on every HTTP request forever — that wants fixing first (a separate PR is doing exactly that). Nor does it add the missing `ON DELETE CASCADE`s: `CREATE TABLE IF NOT EXISTS` is a no-op on an existing table, so those need a table rebuild, which wants the ordered-migration machinery this PR deliberately stops short of.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PcSS6nwxDTpjT2BCMB18V2