### PR TITLE
fix(server): stop GraphQL resolvers eating the async runtime

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -271,7 +271,7 @@ Thin binary crate. `main.rs` has the clap CLI struct definitions, match dispatch
 
 | File | Purpose |
 |---|---|
-| `graphql/` | async-graphql schema, resolvers, axum HTTP server. Relay pagination, rich filters, mutations for playback/queue/library/favourites/snapshots/radio. |
+| `graphql/` | async-graphql schema, resolvers, axum HTTP server. Relay pagination, rich filters, mutations for playback/queue/library/favourites/snapshots/radio. rusqlite is blocking, so resolvers run their DB and HTTP work on `spawn_blocking` with a pooled connection; parent → child edges go through dataloaders. |
 | `subsonic/` | Subsonic REST API endpoints for compatibility with existing clients (DSub, Symfonium, play:Sub). |
 | `mcp.rs` | MCP server on stdio -- exposes `schema_sdl` and `graphql` tools for Claude Desktop integration. |
 | `auth.rs` | JWT middleware, Ed25519 token generation/validation, role-based guards. |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,53 @@
 
 - **Symphonia 0.5 → 0.6.1** — 0.6 rebuilt the format/codec registry, audio primitives, and metadata types around multi-track (audio/video/subtitle) media. Track timing moved off `CodecParameters` onto `Track`, which is where the audible wins come from: 24-bit/96 kHz ALAC now reports 96 kHz instead of 48 kHz (it previously played at half speed, and switched the output device to the wrong rate — fatal for a bit-perfect player), and ALAC-in-CAF decodes at all instead of erroring out. Playback frame counts are byte-identical across every other format.
 
+### Changed
+
+- **GraphQL collections default to 50 rows and cap at 500.** A query with no `first` used to return
+  the entire collection, so `{ tracks { edges { node { title } } } }` materialised a whole library as
+  rows, as GraphQL values and as serialised JSON at once. Clients that relied on the unbounded form
+  must paginate with `first`/`after`.
+- **`triggerScan` and `triggerRemoteSync` return a `Job`, not a result.** Both run for minutes; they
+  now start a detached worker and hand back `{ id, kind, state, message }`, polled with the new
+  `job(id:)` and `jobs` queries. One job of each kind runs at a time — a second call returns the
+  running one. The old `ScanResult` type is gone; added/updated/unchanged counts arrive in the
+  finished job's `message`.
+- **`sortBy` and `sortDir` now do something.** They were declared, published in the SDL and to MCP,
+  and silently dropped: a client asking for `sortBy: DATE` got DB order and no error.
+- **GraphQL queries time out at 30s, shed load past 64 in flight (503) and survive a panicking
+  resolver.** The concurrency limit alone queued the surplus, so an overloaded server answered
+  everyone slowly instead of telling the excess to come back. Subscriptions are exempt from the
+  timeout.
+
 ### Fixed
 
+- **A GraphQL query could stall audio in every connected Subsonic client.** rusqlite is blocking and
+  nothing in the server ran it off the async runtime, so resolvers occupied tokio workers directly.
+  Four concurrent `fuzzySearch` calls on a 4-core box took every worker, the `ReaderStream` feeding
+  each in-flight `/rest/stream` response stopped producing bytes, and clients dropped the connection
+  mid-track. One `triggerScan` did it single-handedly for the length of the scan. Every SQLite call,
+  HTTP fetch, tag read and file decode now runs on the blocking pool.
+- **A fresh SQLite connection was opened per resolver field.** `Database::open` creates the parent
+  directory, chmods the file, sets four pragmas, attempts a WAL checkpoint and runs a ~30-statement
+  DDL batch plus three migrations — all of it, every field. On a 500-artist library the nested
+  artists → albums → tracks query cost roughly 3,500 open cycles, about 120,000 statements. The
+  schema now holds a small connection pool sized to the core count, `Database::open_existing` skips
+  the setup for pooled connections, and the DDL runs once.
+- **N+1 queries across the type graph.** `Track.isFavourite` opened a connection and scanned the
+  whole `favourites` table per track; `Album.trackCount` and `totalDurationMs` each materialised
+  every row of the album to count or sum them; `Artist.albumCount`/`trackCount` re-ran the query
+  their sibling field had just run. Counts and sums are now `COUNT(*)`/`SUM(...)` in SQLite, and
+  parent → child edges go through dataloaders, so `{ tracks(first: 500) { isFavourite } }` is one
+  query rather than 500 connections and 500 table scans.
+- **`tracks(...)` loaded the whole library and filtered it in Rust.** Every predicate ran as a
+  `retain()` over every row before pagination, `search:` silently truncated at 10,000 rows, and
+  `yearStart`/`yearEnd` ran `SELECT date FROM albums WHERE id = ?` once per track in the library.
+  Filters, ordering and the page window are now SQL with bound parameters.
+- **`first: -1` overflowed the page arithmetic** — a panic in debug, a request for the entire
+  library in release.
+- **A full player command channel parked a tokio worker.** `send_cmd` used crossbeam's blocking
+  `send` on a bounded(16) channel while the player can sit in `start_playback` for about a second
+  during a device rate change. It now waits 250ms and reports "player busy".
 - **`cargo test` overwrote the user's real JWT signing key.** `auth`'s keypair tests called
   `generate_keypair()`, which writes to `~/.config/koan/auth/`, so running the test suite rotated the
   live Ed25519 key and invalidated every issued token. Keypair derivation is now split from the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ Pre-push hook (`.claude/settings.json`) runs `cargo fmt --all` + `cargo clippy -
 | `player/undo.rs` | Undo/redo stack for playlist operations (100-deep) |
 | `db/schema.rs` | DDL: artists, albums, tracks, scan_cache, remote_servers, organize_log, tracks_fts (FTS5) |
 | `db/connection.rs` | `Database::open()`, WAL mode, pragmas |
-| `db/queries/` | Row types, upsert (3-strategy dedup), FTS5 search, scan cache, stats, snapshots |
+| `db/queries/` | Row types, upsert (3-strategy dedup), FTS5 search, scan cache, stats, snapshots, `batch` (SQL-side track filtering, batched parent→child reads) |
 | `index/scanner.rs` | Parallel library scan: walkdir → rayon → sequential DB upsert |
 | `index/metadata.rs` | Tag reading via lofty (ID3, Vorbis, MP4, APE), codec detection |
 | `format/` | fb2k-compatible template engine: parser (recursive descent), evaluator, 55 built-in functions |
@@ -136,11 +136,13 @@ Pre-push hook (`.claude/settings.json`) runs `cargo fmt --all` + `cargo clippy -
 
 | Module | What |
 |--------|------|
-| `graphql/mod.rs` | GraphQL schema builder, `KoanSchema` type, DB handle wrapper |
+| `graphql/mod.rs` | GraphQL schema builder, `KoanSchema` type, SQLite connection pool, `with_db`/`blocking` offload helpers |
+| `graphql/loaders.rs` | Dataloaders for artist→albums, album→tracks, counts, favourites |
+| `graphql/jobs.rs` | Job registry for `triggerScan`/`triggerRemoteSync` — detached threads, polled via `job(id:)` |
 | `graphql/queries.rs` | GraphQL query resolvers (artists, albums, tracks, nowPlaying, etc.) |
 | `graphql/mutations.rs` | GraphQL mutations (playback, queue, favourites, snapshots, organize) |
 | `graphql/types.rs` | GraphQL type definitions (GqlArtist, GqlTrack, GqlNowPlaying, etc.) |
-| `graphql/server.rs` | HTTP server (axum), `cmd_serve`, `start_api_background`, daemon mode |
+| `graphql/server.rs` | HTTP server (axum), `cmd_serve`, `start_api_background`, daemon mode, timeout/load-shed/panic-catch layers |
 | `subsonic.rs` | Subsonic-compatible REST API (XML/JSON, auth, streaming, cover art) |
 | `mcp.rs` | MCP server for Claude Desktop (schema_sdl + graphql tools) |
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,10 +219,12 @@ dependencies = [
  "bytes",
  "fast_chemail",
  "fnv",
+ "futures-channel",
  "futures-util",
  "handlebars",
  "http",
  "indexmap",
+ "lru 0.16.4",
  "mime",
  "multer",
  "num-traits",
@@ -2774,6 +2776,15 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "lru"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
@@ -3912,7 +3923,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "itertools 0.14.0",
  "kasuari",
- "lru",
+ "lru 0.18.2",
  "palette",
  "serde",
  "strum 0.28.0",
@@ -5515,11 +5526,16 @@ checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
 dependencies = [
  "bitflags 2.13.1",
  "bytes",
+ "futures-util",
  "http",
+ "http-body",
+ "http-body-util",
  "percent-encoding",
  "pin-project-lite",
+ "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/koan-core/src/db/connection.rs
+++ b/crates/koan-core/src/db/connection.rs
@@ -24,7 +24,13 @@ pub struct Database {
 }
 
 impl Database {
-    /// Open (or create) a database at the given path.
+    /// Open (or create) a database at the given path, applying the schema and
+    /// pending migrations.
+    ///
+    /// This is the once-per-process path: it creates the parent directory,
+    /// tightens file permissions, checkpoints the WAL and runs the ~30-statement
+    /// DDL batch. Anything opening a connection per request wants
+    /// [`Database::open_existing`] instead.
     pub fn open(path: &Path) -> Result<Self, DbError> {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
@@ -38,14 +44,7 @@ impl Database {
             let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600));
         }
 
-        // WAL mode for concurrent reads + single writer.
-        conn.pragma_update(None, "journal_mode", "wal")?;
-        conn.pragma_update(None, "foreign_keys", "on")?;
-        // Long enough to outlast a scan chunk: a writer that gives up mid-scan
-        // silently loses favourites, queue state and play counts.
-        conn.pragma_update(None, "busy_timeout", 30000)?;
-        // Slightly faster at the cost of durability on power loss (acceptable for a media DB).
-        conn.pragma_update(None, "synchronous", "normal")?;
+        configure(&conn)?;
 
         // Attempt a passive WAL checkpoint on open. This is non-blocking — it
         // moves WAL pages back to the main DB file only if no readers/writers
@@ -57,8 +56,33 @@ impl Database {
         Ok(Self { conn })
     }
 
+    /// Open an additional connection to a database whose schema is already
+    /// applied — pragmas only, no DDL, no checkpoint, no permission syscall.
+    ///
+    /// Callers are responsible for having run [`Database::open`] at least once
+    /// against the same path first.
+    pub fn open_existing(path: &Path) -> Result<Self, DbError> {
+        let conn = Connection::open(path)?;
+        configure(&conn)?;
+        Ok(Self { conn })
+    }
+
     /// Open the default database at the standard data directory.
     pub fn open_default() -> Result<Self, DbError> {
         Self::open(&config::db_path())
     }
+}
+
+/// Connection-scoped pragmas. Every connection needs these; none of them touch
+/// the file on disk, so they are cheap enough to repeat per connection.
+fn configure(conn: &Connection) -> Result<(), DbError> {
+    // WAL mode for concurrent reads + single writer.
+    conn.pragma_update(None, "journal_mode", "wal")?;
+    conn.pragma_update(None, "foreign_keys", "on")?;
+    // Long enough to outlast a scan chunk: a writer that gives up mid-scan
+    // silently loses favourites, queue state and play counts.
+    conn.pragma_update(None, "busy_timeout", 30000)?;
+    // Slightly faster at the cost of durability on power loss (acceptable for a media DB).
+    conn.pragma_update(None, "synchronous", "normal")?;
+    Ok(())
 }

--- a/crates/koan-core/src/db/queries/batch.rs
+++ b/crates/koan-core/src/db/queries/batch.rs
@@ -1,0 +1,627 @@
+//! Batched and SQL-filtered reads for API layers.
+//!
+//! Everything here exists so a caller serving many rows at once issues a bounded
+//! number of statements: one query per batch of parents rather than one per
+//! parent, and `WHERE`/`LIMIT` in SQLite rather than `retain()` in Rust.
+
+use std::collections::{HashMap, HashSet};
+
+use rusqlite::{Connection, ToSql, params_from_iter};
+
+use crate::db::connection::DbError;
+
+use super::tracks::row_to_track_row;
+use super::{AlbumRow, TrackRow};
+
+const TRACK_COLUMNS: &str = "t.id, t.album_id, t.artist_id, a.name, aa.name, al.title,
+                t.disc, t.track_number, t.title, t.duration_ms, t.path,
+                t.codec, t.sample_rate, t.bit_depth, t.channels, t.bitrate,
+                t.genre, t.source, t.remote_id, t.cached_path";
+
+const TRACK_JOINS: &str = "FROM tracks t
+         LEFT JOIN artists a ON t.artist_id = a.id
+         LEFT JOIN albums al ON t.album_id = al.id
+         LEFT JOIN artists aa ON al.artist_id = aa.id";
+
+/// `(?,?,?)` for `n` bound values.
+fn placeholders(n: usize) -> String {
+    let mut s = String::with_capacity(2 + n * 2);
+    s.push('(');
+    for i in 0..n {
+        if i > 0 {
+            s.push(',');
+        }
+        s.push('?');
+    }
+    s.push(')');
+    s
+}
+
+/// Wrap a user substring for `LIKE ... ESCAPE '\'`, neutralising `%` and `_`.
+fn like_contains(needle: &str) -> String {
+    let mut escaped = String::with_capacity(needle.len() + 2);
+    escaped.push('%');
+    for c in needle.chars() {
+        if matches!(c, '\\' | '%' | '_') {
+            escaped.push('\\');
+        }
+        escaped.push(c);
+    }
+    escaped.push('%');
+    escaped
+}
+
+// ---------------------------------------------------------------------------
+// Batched parent → children loads
+// ---------------------------------------------------------------------------
+
+/// Albums for many artists in one query, keyed by artist ID.
+pub fn albums_for_artists(
+    conn: &Connection,
+    artist_ids: &[i64],
+) -> Result<HashMap<i64, Vec<AlbumRow>>, DbError> {
+    if artist_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+    let sql = format!(
+        "SELECT al.id, al.title, al.artist_id, a.name, al.date,
+                al.total_discs, al.total_tracks, al.codec, al.label, al.remote_id
+         FROM albums al
+         LEFT JOIN artists a ON al.artist_id = a.id
+         WHERE al.artist_id IN {}
+         ORDER BY al.date, al.title",
+        placeholders(artist_ids.len())
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(params_from_iter(artist_ids), |row| {
+        Ok(AlbumRow {
+            id: row.get(0)?,
+            title: row.get(1)?,
+            artist_id: row.get(2)?,
+            artist_name: row.get::<_, Option<String>>(3)?.unwrap_or_default(),
+            date: row.get(4)?,
+            total_discs: row.get(5)?,
+            total_tracks: row.get(6)?,
+            codec: row.get(7)?,
+            label: row.get(8)?,
+            remote_id: row.get(9)?,
+        })
+    })?;
+
+    let mut out: HashMap<i64, Vec<AlbumRow>> = HashMap::new();
+    for album in rows {
+        let album = album?;
+        out.entry(album.artist_id).or_default().push(album);
+    }
+    Ok(out)
+}
+
+/// Tracks for many albums in one query, keyed by album ID.
+pub fn tracks_for_albums(
+    conn: &Connection,
+    album_ids: &[i64],
+) -> Result<HashMap<i64, Vec<TrackRow>>, DbError> {
+    if album_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+    let sql = format!(
+        "SELECT {} {} WHERE t.album_id IN {} ORDER BY t.disc, t.track_number",
+        TRACK_COLUMNS,
+        TRACK_JOINS,
+        placeholders(album_ids.len())
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(params_from_iter(album_ids), row_to_track_row)?;
+
+    let mut out: HashMap<i64, Vec<TrackRow>> = HashMap::new();
+    for track in rows {
+        let track = track?;
+        if let Some(aid) = track.album_id {
+            out.entry(aid).or_default().push(track);
+        }
+    }
+    Ok(out)
+}
+
+/// Tracks for many artists in one query, keyed by the requested artist ID.
+///
+/// A track matches on either its own artist or its album artist, so one row can
+/// land under two keys — the map is built by re-checking each requested ID.
+pub fn tracks_for_artists(
+    conn: &Connection,
+    artist_ids: &[i64],
+) -> Result<HashMap<i64, Vec<TrackRow>>, DbError> {
+    if artist_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+    let ph = placeholders(artist_ids.len());
+    let sql = format!(
+        "SELECT {}, al.artist_id {} WHERE t.artist_id IN {} OR al.artist_id IN {}
+         ORDER BY al.date, al.title, t.disc, t.track_number",
+        TRACK_COLUMNS, TRACK_JOINS, ph, ph
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let bind: Vec<i64> = artist_ids
+        .iter()
+        .chain(artist_ids.iter())
+        .copied()
+        .collect();
+    let rows = stmt.query_map(params_from_iter(&bind), |row| {
+        Ok((row_to_track_row(row)?, row.get::<_, Option<i64>>(20)?))
+    })?;
+
+    let wanted: HashSet<i64> = artist_ids.iter().copied().collect();
+    let mut out: HashMap<i64, Vec<TrackRow>> = HashMap::new();
+    for row in rows {
+        let (track, album_artist_id) = row?;
+        for key in [track.artist_id, album_artist_id].into_iter().flatten() {
+            if wanted.contains(&key)
+                && !out.entry(key).or_default().iter().any(|t| t.id == track.id)
+            {
+                out.entry(key).or_default().push(track.clone());
+            }
+        }
+    }
+    Ok(out)
+}
+
+// ---------------------------------------------------------------------------
+// Aggregates — counted in SQLite rather than by materialising rows
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct AlbumStats {
+    pub track_count: i64,
+    pub total_duration_ms: i64,
+}
+
+/// Track count and summed duration per album, in one query.
+pub fn album_stats(
+    conn: &Connection,
+    album_ids: &[i64],
+) -> Result<HashMap<i64, AlbumStats>, DbError> {
+    if album_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+    let sql = format!(
+        "SELECT album_id, COUNT(*), COALESCE(SUM(duration_ms), 0)
+         FROM tracks WHERE album_id IN {} GROUP BY album_id",
+        placeholders(album_ids.len())
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(params_from_iter(album_ids), |row| {
+        Ok((
+            row.get::<_, i64>(0)?,
+            AlbumStats {
+                track_count: row.get(1)?,
+                total_duration_ms: row.get(2)?,
+            },
+        ))
+    })?;
+    rows.collect::<Result<HashMap<_, _>, _>>()
+        .map_err(Into::into)
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ArtistStats {
+    pub album_count: i64,
+    pub track_count: i64,
+}
+
+/// Album and track counts per artist, in two grouped queries rather than one
+/// full row fetch per artist per field.
+pub fn artist_stats(
+    conn: &Connection,
+    artist_ids: &[i64],
+) -> Result<HashMap<i64, ArtistStats>, DbError> {
+    if artist_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+    let ph = placeholders(artist_ids.len());
+    let mut out: HashMap<i64, ArtistStats> = artist_ids
+        .iter()
+        .map(|&id| (id, ArtistStats::default()))
+        .collect();
+
+    let album_sql = format!(
+        "SELECT artist_id, COUNT(*) FROM albums WHERE artist_id IN {} GROUP BY artist_id",
+        ph
+    );
+    let mut stmt = conn.prepare(&album_sql)?;
+    let rows = stmt.query_map(params_from_iter(artist_ids), |row| {
+        Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?))
+    })?;
+    for row in rows {
+        let (id, count) = row?;
+        out.entry(id).or_default().album_count = count;
+    }
+
+    // Mirrors `tracks_for_artist`: own artist or album artist, counted once.
+    let track_sql = format!(
+        "SELECT k.id, COUNT(DISTINCT t.id)
+         FROM artists k
+         JOIN tracks t ON t.artist_id = k.id OR t.album_id IN (
+             SELECT al.id FROM albums al WHERE al.artist_id = k.id
+         )
+         WHERE k.id IN {}
+         GROUP BY k.id",
+        ph
+    );
+    let mut stmt = conn.prepare(&track_sql)?;
+    let rows = stmt.query_map(params_from_iter(artist_ids), |row| {
+        Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?))
+    })?;
+    for row in rows {
+        let (id, count) = row?;
+        out.entry(id).or_default().track_count = count;
+    }
+
+    Ok(out)
+}
+
+/// Which of the given paths are favourited — one query instead of a full table
+/// scan per track.
+pub fn favourite_paths(conn: &Connection, paths: &[String]) -> Result<HashSet<String>, DbError> {
+    if paths.is_empty() {
+        return Ok(HashSet::new());
+    }
+    let sql = format!(
+        "SELECT track_path FROM favourites WHERE track_path IN {}",
+        placeholders(paths.len())
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(params_from_iter(paths), |row| row.get::<_, String>(0))?;
+    rows.collect::<Result<HashSet<_>, _>>().map_err(Into::into)
+}
+
+// ---------------------------------------------------------------------------
+// SQL-side track filtering
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TrackOrder {
+    ArtistAlbumDiscTrack,
+    Title,
+    Artist,
+    Album,
+    Duration,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct TrackFilter {
+    pub ids: Option<Vec<i64>>,
+    /// FTS5 query. Applied as a subquery so it composes with the other filters.
+    pub search: Option<String>,
+    pub album_id: Option<i64>,
+    pub artist_ids: Option<Vec<i64>>,
+    pub title: Option<String>,
+    pub artist_name: Option<String>,
+    pub album_title: Option<String>,
+    pub genre: Option<String>,
+    pub codec: Option<String>,
+    pub source: Option<String>,
+    pub year_start: Option<i32>,
+    pub year_end: Option<i32>,
+    pub min_sample_rate: Option<i32>,
+    pub min_bit_depth: Option<i32>,
+    pub channels: Option<i32>,
+    pub min_duration_ms: Option<i64>,
+    pub max_duration_ms: Option<i64>,
+    pub favourites_only: bool,
+}
+
+/// Fetch a page of tracks matching `filter`.
+///
+/// Both the filtering and the windowing happen in SQLite: the caller never sees
+/// more than `limit` rows regardless of library size.
+pub fn filter_tracks(
+    conn: &Connection,
+    filter: &TrackFilter,
+    order: TrackOrder,
+    descending: bool,
+    limit: u32,
+    offset: u32,
+) -> Result<Vec<TrackRow>, DbError> {
+    let mut clauses: Vec<String> = Vec::new();
+    let mut binds: Vec<Box<dyn ToSql>> = Vec::new();
+
+    if let Some(ids) = &filter.ids {
+        if ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        clauses.push(format!("t.id IN {}", placeholders(ids.len())));
+        binds.extend(ids.iter().map(|&i| Box::new(i) as Box<dyn ToSql>));
+    }
+
+    if let Some(query) = &filter.search {
+        clauses.push("t.id IN (SELECT rowid FROM tracks_fts WHERE tracks_fts MATCH ?)".to_string());
+        binds.push(Box::new(super::search::sanitize_fts_query(query)));
+    }
+
+    if let Some(album_id) = filter.album_id {
+        clauses.push("t.album_id = ?".to_string());
+        binds.push(Box::new(album_id));
+    }
+
+    if let Some(ids) = &filter.artist_ids {
+        if ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let ph = placeholders(ids.len());
+        clauses.push(format!("(t.artist_id IN {ph} OR al.artist_id IN {ph})"));
+        for _ in 0..2 {
+            binds.extend(ids.iter().map(|&i| Box::new(i) as Box<dyn ToSql>));
+        }
+    }
+
+    if let Some(title) = &filter.title {
+        clauses.push("t.title LIKE ? ESCAPE '\\'".to_string());
+        binds.push(Box::new(like_contains(title)));
+    }
+
+    if let Some(name) = &filter.artist_name {
+        clauses.push("(a.name LIKE ? ESCAPE '\\' OR aa.name LIKE ? ESCAPE '\\')".to_string());
+        binds.push(Box::new(like_contains(name)));
+        binds.push(Box::new(like_contains(name)));
+    }
+
+    if let Some(title) = &filter.album_title {
+        clauses.push("al.title LIKE ? ESCAPE '\\'".to_string());
+        binds.push(Box::new(like_contains(title)));
+    }
+
+    if let Some(genre) = &filter.genre {
+        clauses.push("t.genre LIKE ? ESCAPE '\\'".to_string());
+        binds.push(Box::new(like_contains(genre)));
+    }
+
+    if let Some(codec) = &filter.codec {
+        clauses.push("t.codec LIKE ? ESCAPE '\\'".to_string());
+        binds.push(Box::new(like_contains(codec)));
+    }
+
+    if let Some(source) = &filter.source {
+        clauses.push("t.source = ?".to_string());
+        binds.push(Box::new(source.clone()));
+    }
+
+    if filter.year_start.is_some() || filter.year_end.is_some() {
+        // A track with no parsable four-digit year is excluded, matching the
+        // behaviour of the year extraction it replaces.
+        clauses.push("substr(al.date, 1, 4) GLOB '[0-9][0-9][0-9][0-9]'".to_string());
+        if let Some(start) = filter.year_start {
+            clauses.push("CAST(substr(al.date, 1, 4) AS INTEGER) >= ?".to_string());
+            binds.push(Box::new(start));
+        }
+        if let Some(end) = filter.year_end {
+            clauses.push("CAST(substr(al.date, 1, 4) AS INTEGER) <= ?".to_string());
+            binds.push(Box::new(end));
+        }
+    }
+
+    for (column, value) in [
+        ("t.sample_rate >= ?", filter.min_sample_rate),
+        ("t.bit_depth >= ?", filter.min_bit_depth),
+        ("t.channels = ?", filter.channels),
+    ] {
+        if let Some(v) = value {
+            clauses.push(column.to_string());
+            binds.push(Box::new(v));
+        }
+    }
+
+    for (column, value) in [
+        ("t.duration_ms >= ?", filter.min_duration_ms),
+        ("t.duration_ms <= ?", filter.max_duration_ms),
+    ] {
+        if let Some(v) = value {
+            clauses.push(column.to_string());
+            binds.push(Box::new(v));
+        }
+    }
+
+    if filter.favourites_only {
+        clauses.push(
+            "EXISTS (SELECT 1 FROM favourites f
+                     WHERE f.track_path = t.path OR f.track_path = t.cached_path)"
+                .to_string(),
+        );
+    }
+
+    let dir = if descending { "DESC" } else { "ASC" };
+    let order_by = match order {
+        TrackOrder::ArtistAlbumDiscTrack => format!(
+            "a.name {dir}, al.date {dir}, al.title {dir}, t.disc {dir}, t.track_number {dir}"
+        ),
+        TrackOrder::Title => format!("t.title {dir}"),
+        TrackOrder::Artist => {
+            format!("a.name {dir}, al.date {dir}, t.disc {dir}, t.track_number {dir}")
+        }
+        TrackOrder::Album => format!("al.title {dir}, t.disc {dir}, t.track_number {dir}"),
+        TrackOrder::Duration => format!("t.duration_ms {dir}"),
+    };
+
+    let where_clause = if clauses.is_empty() {
+        String::new()
+    } else {
+        format!("WHERE {}", clauses.join(" AND "))
+    };
+
+    let sql = format!(
+        "SELECT {TRACK_COLUMNS} {TRACK_JOINS} {where_clause}
+         ORDER BY {order_by}, t.id {dir} LIMIT ? OFFSET ?"
+    );
+
+    binds.push(Box::new(limit));
+    binds.push(Box::new(offset));
+
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt
+        .query_map(params_from_iter(binds.iter()), row_to_track_row)?
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(rows)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::connection::Database;
+    use crate::db::queries::{add_favourite, sample_meta, upsert_track};
+
+    fn test_db() -> Database {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.pragma_update(None, "foreign_keys", "on").unwrap();
+        crate::db::schema::create_tables(&conn).unwrap();
+        Database { conn }
+    }
+
+    fn seed(db: &Database) {
+        for (title, artist, album) in [
+            ("Vordhosbn", "Aphex Twin", "Drukqs"),
+            ("Avril 14th", "Aphex Twin", "Drukqs"),
+            ("Roygbiv", "Boards of Canada", "MHTRTC"),
+        ] {
+            upsert_track(&db.conn, &sample_meta(title, artist, album)).unwrap();
+        }
+    }
+
+    #[test]
+    fn filter_pushes_limit_into_sql() {
+        let db = test_db();
+        seed(&db);
+        let page = filter_tracks(
+            &db.conn,
+            &TrackFilter::default(),
+            TrackOrder::Title,
+            false,
+            2,
+            0,
+        )
+        .unwrap();
+        assert_eq!(page.len(), 2);
+        let page2 = filter_tracks(
+            &db.conn,
+            &TrackFilter::default(),
+            TrackOrder::Title,
+            false,
+            2,
+            2,
+        )
+        .unwrap();
+        assert_eq!(page2.len(), 1);
+    }
+
+    #[test]
+    fn filter_matches_substrings_and_escapes_wildcards() {
+        let db = test_db();
+        seed(&db);
+        let filter = TrackFilter {
+            title: Some("vril".into()),
+            ..Default::default()
+        };
+        let hits = filter_tracks(&db.conn, &filter, TrackOrder::Title, false, 50, 0).unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].title, "Avril 14th");
+
+        // A bare `%` must not match everything.
+        let filter = TrackFilter {
+            title: Some("%".into()),
+            ..Default::default()
+        };
+        assert!(
+            filter_tracks(&db.conn, &filter, TrackOrder::Title, false, 50, 0)
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn filter_composes_search_with_other_predicates() {
+        let db = test_db();
+        seed(&db);
+        let filter = TrackFilter {
+            search: Some("Aphex".into()),
+            title: Some("Vordhosbn".into()),
+            ..Default::default()
+        };
+        let hits = filter_tracks(&db.conn, &filter, TrackOrder::Title, false, 50, 0).unwrap();
+        assert_eq!(hits.len(), 1);
+    }
+
+    #[test]
+    fn stats_are_aggregated_not_materialised() {
+        let db = test_db();
+        seed(&db);
+        let album_id = db
+            .conn
+            .query_row("SELECT id FROM albums WHERE title = 'Drukqs'", [], |r| {
+                r.get::<_, i64>(0)
+            })
+            .unwrap();
+        let stats = album_stats(&db.conn, &[album_id]).unwrap();
+        assert_eq!(stats[&album_id].track_count, 2);
+        assert_eq!(stats[&album_id].total_duration_ms, 480_000);
+
+        let artist_id = db
+            .conn
+            .query_row(
+                "SELECT id FROM artists WHERE name = 'Aphex Twin'",
+                [],
+                |r| r.get::<_, i64>(0),
+            )
+            .unwrap();
+        let stats = artist_stats(&db.conn, &[artist_id]).unwrap();
+        assert_eq!(stats[&artist_id].album_count, 1);
+        assert_eq!(stats[&artist_id].track_count, 2);
+    }
+
+    #[test]
+    fn favourite_paths_only_returns_the_requested_paths() {
+        let db = test_db();
+        seed(&db);
+        add_favourite(
+            &db.conn,
+            std::path::Path::new("/music/Drukqs/Vordhosbn.flac"),
+        )
+        .unwrap();
+        let hits = favourite_paths(
+            &db.conn,
+            &[
+                "/music/Drukqs/Vordhosbn.flac".to_string(),
+                "/music/MHTRTC/Roygbiv.flac".to_string(),
+            ],
+        )
+        .unwrap();
+        assert_eq!(hits.len(), 1);
+        assert!(hits.contains("/music/Drukqs/Vordhosbn.flac"));
+    }
+
+    #[test]
+    fn batched_children_are_keyed_by_parent() {
+        let db = test_db();
+        seed(&db);
+        let album_ids: Vec<i64> = db
+            .conn
+            .prepare("SELECT id FROM albums ORDER BY id")
+            .unwrap()
+            .query_map([], |r| r.get(0))
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap();
+        let map = tracks_for_albums(&db.conn, &album_ids).unwrap();
+        assert_eq!(map.values().map(Vec::len).sum::<usize>(), 3);
+
+        let artist_ids: Vec<i64> = db
+            .conn
+            .prepare("SELECT id FROM artists ORDER BY id")
+            .unwrap()
+            .query_map([], |r| r.get(0))
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap();
+        let map = albums_for_artists(&db.conn, &artist_ids).unwrap();
+        assert_eq!(map.values().map(Vec::len).sum::<usize>(), 2);
+        let map = tracks_for_artists(&db.conn, &artist_ids).unwrap();
+        assert_eq!(map.values().map(Vec::len).sum::<usize>(), 3);
+    }
+}

--- a/crates/koan-core/src/db/queries/mod.rs
+++ b/crates/koan-core/src/db/queries/mod.rs
@@ -1,6 +1,7 @@
 mod albums;
 mod artists;
 pub mod auth;
+pub mod batch;
 mod favourites;
 pub mod lyrics;
 pub mod playback_state;
@@ -17,6 +18,7 @@ use std::path::PathBuf;
 // Re-export all public items so `use queries::*` still works.
 pub use albums::*;
 pub use artists::*;
+pub use batch::*;
 pub use favourites::*;
 pub use lyrics::*;
 pub use playback_state::*;

--- a/crates/koan-core/src/db/queries/search.rs
+++ b/crates/koan-core/src/db/queries/search.rs
@@ -6,7 +6,7 @@ use super::TrackRow;
 
 /// Sanitize a user query for FTS5 MATCH: escapes double-quotes and wraps in
 /// a quoted phrase so FTS5 special characters are treated as literals.
-fn sanitize_fts_query(query: &str) -> String {
+pub(crate) fn sanitize_fts_query(query: &str) -> String {
     let trimmed = query.trim();
     if trimmed.is_empty() {
         return String::new();

--- a/crates/koan-core/src/db/queries/tracks.rs
+++ b/crates/koan-core/src/db/queries/tracks.rs
@@ -14,7 +14,7 @@ use super::{PlaybackSource, TrackMeta, TrackRow};
 /// disc, track_number, title, duration_ms, path,
 /// codec, sample_rate, bit_depth, channels, bitrate,
 /// genre, source, remote_id, cached_path
-fn row_to_track_row(row: &rusqlite::Row) -> rusqlite::Result<TrackRow> {
+pub(crate) fn row_to_track_row(row: &rusqlite::Row) -> rusqlite::Result<TrackRow> {
     let artist_name: String = row.get::<_, Option<String>>(3)?.unwrap_or_default();
     Ok(TrackRow {
         id: row.get(0)?,

--- a/crates/koan-server/Cargo.toml
+++ b/crates/koan-server/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["audio", "music", "graphql", "subsonic"]
 categories = ["multimedia::audio"]
 
 [dependencies]
-async-graphql = "7"
+async-graphql = { version = "7", features = ["dataloader"] }
 async-graphql-axum = "7"
 async-stream = "0.3"
 axum = { version = "0.8", features = ["ws"] }
@@ -31,7 +31,7 @@ tokio = { version = "1.50.0", features = ["rt-multi-thread", "net", "macros", "s
 tokio-stream = "0.1"
 tokio-util = { version = "0.7", features = ["io"] }
 tower = { version = "0.5", features = ["util", "limit", "load-shed"] }
-tower-http = { version = "0.7", features = ["cors"] }
+tower-http = { version = "0.7", features = ["catch-panic", "cors", "timeout"] }
 uuid = { version = "1.22.0", features = ["v7"] }
 
 [dev-dependencies]

--- a/crates/koan-server/src/graphql/helpers.rs
+++ b/crates/koan-server/src/graphql/helpers.rs
@@ -11,33 +11,68 @@ use koan_core::player::state::{QueueItemId, SharedPlayerState};
 use super::types::Conn;
 
 // ---------------------------------------------------------------------------
-// Pagination helper — uses usize as cursor (async-graphql has built-in impl)
+// Pagination — uses usize as cursor (async-graphql has built-in impl)
 // ---------------------------------------------------------------------------
 
+/// Page size when the client asks for no `first`.
+///
+/// The old behaviour was "everything": one `{ tracks { edges { node { ... } } } }`
+/// materialised the whole library as rows, as GraphQL values and as serialised
+/// JSON at the same time.
+pub(super) const DEFAULT_PAGE: usize = 50;
+
+/// Ceiling on `first`, so a client cannot ask for the library in one response.
+pub(super) const MAX_PAGE: usize = 500;
+
+/// Clamp a client-supplied `first` into the servable range. Negative values are
+/// floored at zero — as a raw `as usize` they wrapped to a request for the
+/// entire library.
+pub(super) fn page_size(first: Option<i32>) -> usize {
+    match first {
+        Some(f) => (f.max(0) as usize).min(MAX_PAGE),
+        None => DEFAULT_PAGE,
+    }
+}
+
+/// Index of the first row after the given cursor.
+pub(super) fn page_offset(after: Option<&str>) -> usize {
+    after
+        .and_then(|c| c.parse::<usize>().ok())
+        .map(|i| i.saturating_add(1))
+        .unwrap_or(0)
+}
+
+/// Paginate an already-materialised list.
 pub(super) fn paginate<T: async_graphql::OutputType>(
     items: Vec<T>,
     after: Option<String>,
     first: Option<i32>,
 ) -> async_graphql::Result<Conn<T>> {
     let total = items.len();
-
-    let start = if let Some(ref cursor) = after {
-        cursor.parse::<usize>().unwrap_or(0) + 1
-    } else {
-        0
-    };
-
-    let end = if let Some(f) = first {
-        (start + f as usize).min(total)
-    } else {
-        total
-    };
+    let start = page_offset(after.as_deref()).min(total);
+    let end = start.saturating_add(page_size(first)).min(total);
 
     let mut conn = Conn::new(start > 0, end < total);
     for (i, item) in items.into_iter().enumerate().skip(start).take(end - start) {
         conn.edges.push(Edge::new(i, item));
     }
     Ok(conn)
+}
+
+/// Wrap a page that SQL already windowed. `rows` may hold one extra row beyond
+/// `limit`, which is how the next-page flag is derived without a `COUNT(*)`.
+pub(super) fn paginate_window<T: async_graphql::OutputType>(
+    mut rows: Vec<T>,
+    offset: usize,
+    limit: usize,
+) -> Conn<T> {
+    let has_next = rows.len() > limit;
+    rows.truncate(limit);
+    let mut conn = Conn::new(offset > 0, has_next);
+    for (i, item) in rows.into_iter().enumerate() {
+        conn.edges.push(Edge::new(offset + i, item));
+    }
+    conn
 }
 
 // ---------------------------------------------------------------------------
@@ -51,15 +86,6 @@ pub(super) fn extract_year(date: &str) -> Option<i32> {
 /// Get album year from its date field.
 pub(super) fn album_year(album: &queries::AlbumRow) -> Option<i32> {
     album.date.as_deref().and_then(extract_year)
-}
-
-/// Get the year for a track via its album's date.
-pub(super) fn track_year(db: &Database, track: &queries::TrackRow) -> Option<i32> {
-    track
-        .album_id
-        .and_then(|aid| queries::album_date(&db.conn, aid).ok().flatten())
-        .as_deref()
-        .and_then(extract_year)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/koan-server/src/graphql/jobs.rs
+++ b/crates/koan-server/src/graphql/jobs.rs
@@ -1,0 +1,124 @@
+//! Background jobs for work that cannot fit in a request.
+//!
+//! A full library scan walks the filesystem and a remote sync paginates a
+//! Subsonic server; both run for minutes. Returning a handle and doing the work
+//! on a detached thread keeps them off the runtime entirely, so audio streaming
+//! on the same process is unaffected.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use async_graphql::Enum;
+use uuid::Uuid;
+
+#[derive(Enum, Copy, Clone, Eq, PartialEq, Debug)]
+#[graphql(name = "JobState")]
+pub(super) enum JobState {
+    Running,
+    Succeeded,
+    Failed,
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct Job {
+    pub id: String,
+    pub kind: String,
+    pub state: JobState,
+    pub message: String,
+}
+
+/// Jobs started by this process, newest last. Bounded so a long-lived server
+/// does not accumulate history forever.
+#[derive(Clone, Default)]
+pub(super) struct JobRegistry {
+    inner: Arc<Mutex<HashMap<String, Job>>>,
+}
+
+const MAX_HISTORY: usize = 64;
+
+impl JobRegistry {
+    /// Register a new running job, or refuse if one of the same kind is live.
+    ///
+    /// Two concurrent scans of the same library fight over the same rows, so
+    /// the second caller gets the first job's handle instead of a second scan.
+    pub(super) fn start(&self, kind: &str) -> Result<Job, Job> {
+        let mut jobs = self.inner.lock().expect("job registry poisoned");
+        if let Some(running) = jobs
+            .values()
+            .find(|j| j.kind == kind && j.state == JobState::Running)
+        {
+            return Err(running.clone());
+        }
+        if jobs.len() >= MAX_HISTORY {
+            let finished: Vec<String> = jobs
+                .values()
+                .filter(|j| j.state != JobState::Running)
+                .map(|j| j.id.clone())
+                .collect();
+            for id in finished {
+                jobs.remove(&id);
+            }
+        }
+        let job = Job {
+            id: Uuid::now_v7().to_string(),
+            kind: kind.to_string(),
+            state: JobState::Running,
+            message: format!("{} started", kind),
+        };
+        jobs.insert(job.id.clone(), job.clone());
+        Ok(job)
+    }
+
+    pub(super) fn finish(&self, id: &str, state: JobState, message: String) {
+        let mut jobs = self.inner.lock().expect("job registry poisoned");
+        if let Some(job) = jobs.get_mut(id) {
+            job.state = state;
+            job.message = message;
+        }
+    }
+
+    pub(super) fn get(&self, id: &str) -> Option<Job> {
+        self.inner
+            .lock()
+            .expect("job registry poisoned")
+            .get(id)
+            .cloned()
+    }
+
+    pub(super) fn list(&self) -> Vec<Job> {
+        let mut jobs: Vec<Job> = self
+            .inner
+            .lock()
+            .expect("job registry poisoned")
+            .values()
+            .cloned()
+            .collect();
+        jobs.sort_by(|a, b| a.id.cmp(&b.id));
+        jobs
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn one_job_per_kind_runs_at_a_time() {
+        let reg = JobRegistry::default();
+        let first = reg.start("scan").unwrap();
+        let clash = reg.start("scan").unwrap_err();
+        assert_eq!(first.id, clash.id);
+
+        reg.finish(&first.id, JobState::Succeeded, "done".into());
+        let second = reg.start("scan").unwrap();
+        assert_ne!(first.id, second.id);
+    }
+
+    #[test]
+    fn different_kinds_do_not_block_each_other() {
+        let reg = JobRegistry::default();
+        reg.start("scan").unwrap();
+        assert!(reg.start("remoteSync").is_ok());
+        assert_eq!(reg.list().len(), 2);
+    }
+}

--- a/crates/koan-server/src/graphql/loaders.rs
+++ b/crates/koan-server/src/graphql/loaders.rs
@@ -1,0 +1,212 @@
+//! Batched loaders for the parent → child edges of the schema.
+//!
+//! Without these, a field like `Album.trackCount` runs one query per album and
+//! `Track.isFavourite` runs a full `favourites` scan per track. Each loader
+//! collapses a whole selection set's worth of keys into one statement.
+
+use std::collections::HashMap;
+
+use async_graphql::dataloader::Loader;
+use koan_core::db::queries::batch::{AlbumStats, ArtistStats};
+use koan_core::db::queries::{self, AlbumRow, TrackRow};
+
+use super::{DbHandle, blocking, internal_error};
+
+macro_rules! id_key {
+    ($($name:ident),* $(,)?) => {
+        $(
+            #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+            pub(super) struct $name(pub i64);
+        )*
+    };
+}
+
+id_key!(
+    ArtistAlbums,
+    ArtistTracks,
+    ArtistStatsOf,
+    AlbumTracks,
+    AlbumStatsOf
+);
+
+/// Favourite lookup keyed by the track's playback path.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(super) struct FavouritePath(pub String);
+
+pub(super) struct DbLoader {
+    handle: DbHandle,
+}
+
+impl DbLoader {
+    pub(super) fn new(handle: DbHandle) -> Self {
+        Self { handle }
+    }
+
+    /// Every loader body is the same shape: take the keys, run one blocking
+    /// query with a pooled connection, hand back a keyed map.
+    async fn batch<K, V, F>(&self, keys: &[K], f: F) -> Result<HashMap<K, V>, async_graphql::Error>
+    where
+        K: Clone + Send + 'static,
+        V: Send + 'static,
+        F: FnOnce(
+                &koan_core::db::connection::Database,
+                Vec<K>,
+            ) -> async_graphql::Result<HashMap<K, V>>
+            + Send
+            + 'static,
+        HashMap<K, V>: Send,
+    {
+        let handle = self.handle.clone();
+        handle.note_batch();
+        let keys = keys.to_vec();
+        blocking(move || {
+            let db = handle.acquire()?;
+            f(&db, keys)
+        })
+        .await
+    }
+}
+
+impl Loader<ArtistAlbums> for DbLoader {
+    type Value = Vec<AlbumRow>;
+    type Error = async_graphql::Error;
+
+    async fn load(
+        &self,
+        keys: &[ArtistAlbums],
+    ) -> Result<HashMap<ArtistAlbums, Self::Value>, Self::Error> {
+        self.batch(keys, |db, keys| {
+            let ids: Vec<i64> = keys.iter().map(|k| k.0).collect();
+            let mut by_artist = queries::batch::albums_for_artists(&db.conn, &ids)
+                .map_err(|e| internal_error("db", e))?;
+            Ok(keys
+                .into_iter()
+                .map(|k| {
+                    let albums = by_artist.remove(&k.0).unwrap_or_default();
+                    (k, albums)
+                })
+                .collect())
+        })
+        .await
+    }
+}
+
+impl Loader<ArtistTracks> for DbLoader {
+    type Value = Vec<TrackRow>;
+    type Error = async_graphql::Error;
+
+    async fn load(
+        &self,
+        keys: &[ArtistTracks],
+    ) -> Result<HashMap<ArtistTracks, Self::Value>, Self::Error> {
+        self.batch(keys, |db, keys| {
+            let ids: Vec<i64> = keys.iter().map(|k| k.0).collect();
+            let mut by_artist = queries::batch::tracks_for_artists(&db.conn, &ids)
+                .map_err(|e| internal_error("db", e))?;
+            Ok(keys
+                .into_iter()
+                .map(|k| {
+                    let tracks = by_artist.remove(&k.0).unwrap_or_default();
+                    (k, tracks)
+                })
+                .collect())
+        })
+        .await
+    }
+}
+
+impl Loader<ArtistStatsOf> for DbLoader {
+    type Value = ArtistStats;
+    type Error = async_graphql::Error;
+
+    async fn load(
+        &self,
+        keys: &[ArtistStatsOf],
+    ) -> Result<HashMap<ArtistStatsOf, Self::Value>, Self::Error> {
+        self.batch(keys, |db, keys| {
+            let ids: Vec<i64> = keys.iter().map(|k| k.0).collect();
+            let stats = queries::batch::artist_stats(&db.conn, &ids)
+                .map_err(|e| internal_error("db", e))?;
+            Ok(keys
+                .into_iter()
+                .map(|k| {
+                    let s = stats.get(&k.0).copied().unwrap_or_default();
+                    (k, s)
+                })
+                .collect())
+        })
+        .await
+    }
+}
+
+impl Loader<AlbumTracks> for DbLoader {
+    type Value = Vec<TrackRow>;
+    type Error = async_graphql::Error;
+
+    async fn load(
+        &self,
+        keys: &[AlbumTracks],
+    ) -> Result<HashMap<AlbumTracks, Self::Value>, Self::Error> {
+        self.batch(keys, |db, keys| {
+            let ids: Vec<i64> = keys.iter().map(|k| k.0).collect();
+            let mut by_album = queries::batch::tracks_for_albums(&db.conn, &ids)
+                .map_err(|e| internal_error("db", e))?;
+            Ok(keys
+                .into_iter()
+                .map(|k| {
+                    let tracks = by_album.remove(&k.0).unwrap_or_default();
+                    (k, tracks)
+                })
+                .collect())
+        })
+        .await
+    }
+}
+
+impl Loader<AlbumStatsOf> for DbLoader {
+    type Value = AlbumStats;
+    type Error = async_graphql::Error;
+
+    async fn load(
+        &self,
+        keys: &[AlbumStatsOf],
+    ) -> Result<HashMap<AlbumStatsOf, Self::Value>, Self::Error> {
+        self.batch(keys, |db, keys| {
+            let ids: Vec<i64> = keys.iter().map(|k| k.0).collect();
+            let stats =
+                queries::batch::album_stats(&db.conn, &ids).map_err(|e| internal_error("db", e))?;
+            Ok(keys
+                .into_iter()
+                .map(|k| {
+                    let s = stats.get(&k.0).copied().unwrap_or_default();
+                    (k, s)
+                })
+                .collect())
+        })
+        .await
+    }
+}
+
+impl Loader<FavouritePath> for DbLoader {
+    type Value = bool;
+    type Error = async_graphql::Error;
+
+    async fn load(
+        &self,
+        keys: &[FavouritePath],
+    ) -> Result<HashMap<FavouritePath, Self::Value>, Self::Error> {
+        self.batch(keys, |db, keys| {
+            let paths: Vec<String> = keys.iter().map(|k| k.0.clone()).collect();
+            let starred = queries::batch::favourite_paths(&db.conn, &paths)
+                .map_err(|e| internal_error("db", e))?;
+            Ok(keys
+                .into_iter()
+                .map(|k| {
+                    let hit = starred.contains(&k.0);
+                    (k, hit)
+                })
+                .collect())
+        })
+        .await
+    }
+}

--- a/crates/koan-server/src/graphql/mod.rs
+++ b/crates/koan-server/src/graphql/mod.rs
@@ -1,15 +1,21 @@
 mod helpers;
+mod jobs;
+mod loaders;
 mod mutations;
 mod queries;
 mod server;
 mod subscriptions;
 mod types;
 
+use std::ops::Deref;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::time::Duration;
 
+use async_graphql::dataloader::DataLoader;
 use async_graphql::{Context, Schema};
-use crossbeam_channel::Sender;
+use crossbeam_channel::{Sender, TrySendError};
 use koan_core::audio::viz::VizSnapshot;
 use koan_core::db::connection::Database;
 use koan_core::player::commands::PlayerCommand;
@@ -17,6 +23,7 @@ use koan_core::player::state::{QueueItemId, SharedPlayerState};
 use uuid::Uuid;
 
 use koan_core::auth::Role;
+use loaders::DbLoader;
 use mutations::MutationRoot;
 use queries::QueryRoot;
 pub use server::{
@@ -27,18 +34,216 @@ use subscriptions::SubscriptionRoot;
 use crate::auth::AuthUser;
 
 // ---------------------------------------------------------------------------
+// Connection pool
+// ---------------------------------------------------------------------------
+
+/// How long the dataloader gathers keys before running a batch.
+///
+/// The default 1ms closes the window while a wide selection set is still
+/// registering keys, splitting one query into several.
+const BATCH_WINDOW: Duration = Duration::from_millis(10);
+
+/// How long a resolver waits for a free connection before giving up. Long
+/// enough to ride out a scan chunk, short enough that a wedged writer surfaces
+/// as an error rather than a hung request.
+const ACQUIRE_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// A fixed set of SQLite connections handed out per query, not per field.
+///
+/// `Database::open` runs the DDL batch, the migrations and a WAL checkpoint, so
+/// opening one per resolver field costs tens of statements before the actual
+/// query runs. Connections are opened lazily up to `max` and returned on drop.
+/// Deliberately not a single `Mutex<Connection>`: WAL gives concurrent readers,
+/// and one slow query must not block every other client.
+struct DbPool {
+    path: PathBuf,
+    /// Returned connections wait here. Bounded at `max`, so `try_send` on the
+    /// return path cannot block or fail for lack of room.
+    idle_tx: Sender<Database>,
+    idle_rx: crossbeam_channel::Receiver<Database>,
+    /// Connections in existence (idle plus checked out).
+    live: AtomicUsize,
+    /// Total connections ever opened. Instrumentation only — the fan-out tests
+    /// assert this stays bounded as a query's breadth grows.
+    opens: AtomicUsize,
+    /// Dataloader batches run. Instrumentation only — the N+1 tests assert one
+    /// batch serves a whole selection set.
+    batches: AtomicUsize,
+    /// Whether the schema and migrations have been applied to this path.
+    initialised: AtomicBool,
+    max: usize,
+}
+
+impl DbPool {
+    fn new(path: PathBuf) -> Arc<Self> {
+        // SQLite readers scale with cores; past that they only queue on the OS.
+        let max = std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(4)
+            .clamp(4, 16);
+        let (idle_tx, idle_rx) = crossbeam_channel::bounded(max);
+        Arc::new(Self {
+            path,
+            idle_tx,
+            idle_rx,
+            live: AtomicUsize::new(0),
+            opens: AtomicUsize::new(0),
+            batches: AtomicUsize::new(0),
+            initialised: AtomicBool::new(false),
+            max,
+        })
+    }
+
+    /// The first connection applies the schema; every later one skips it.
+    fn open_new(&self) -> Result<Database, koan_core::db::connection::DbError> {
+        self.opens.fetch_add(1, Ordering::Relaxed);
+        if self.initialised.load(Ordering::Acquire) {
+            Database::open_existing(&self.path)
+        } else {
+            let db = Database::open(&self.path)?;
+            self.initialised.store(true, Ordering::Release);
+            Ok(db)
+        }
+    }
+
+    fn acquire(self: &Arc<Self>) -> async_graphql::Result<PooledDb> {
+        if let Ok(db) = self.idle_rx.try_recv() {
+            return Ok(PooledDb {
+                db: Some(db),
+                pool: self.clone(),
+            });
+        }
+
+        let mut live = self.live.load(Ordering::Relaxed);
+        while live < self.max {
+            match self.live.compare_exchange_weak(
+                live,
+                live + 1,
+                Ordering::AcqRel,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => {
+                    return match self.open_new() {
+                        Ok(db) => Ok(PooledDb {
+                            db: Some(db),
+                            pool: self.clone(),
+                        }),
+                        Err(e) => {
+                            self.live.fetch_sub(1, Ordering::AcqRel);
+                            Err(internal_error("db open", e))
+                        }
+                    };
+                }
+                Err(actual) => live = actual,
+            }
+        }
+
+        self.idle_rx
+            .recv_timeout(ACQUIRE_TIMEOUT)
+            .map(|db| PooledDb {
+                db: Some(db),
+                pool: self.clone(),
+            })
+            .map_err(|_| async_graphql::Error::new("database busy"))
+    }
+}
+
+/// A connection checked out of the pool, returned when the guard drops.
+struct PooledDb {
+    db: Option<Database>,
+    pool: Arc<DbPool>,
+}
+
+impl Deref for PooledDb {
+    type Target = Database;
+
+    fn deref(&self) -> &Database {
+        self.db.as_ref().expect("connection taken before drop")
+    }
+}
+
+impl Drop for PooledDb {
+    fn drop(&mut self) {
+        if let Some(db) = self.db.take()
+            && let Err(TrySendError::Full(_) | TrySendError::Disconnected(_)) =
+                self.pool.idle_tx.try_send(db)
+        {
+            self.pool.live.fetch_sub(1, Ordering::AcqRel);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // DB handle wrapper (so we can put it in Context)
 // ---------------------------------------------------------------------------
 
 #[derive(Clone)]
 struct DbHandle {
-    path: PathBuf,
+    pool: Arc<DbPool>,
 }
 
 impl DbHandle {
-    fn open(&self) -> async_graphql::Result<Database> {
-        Database::open(&self.path).map_err(|e| internal_error("db open", e))
+    fn new(path: PathBuf) -> Self {
+        Self {
+            pool: DbPool::new(path),
+        }
     }
+
+    fn acquire(&self) -> async_graphql::Result<PooledDb> {
+        self.pool.acquire()
+    }
+
+    /// A connection outside the pool, for work that runs for minutes and must
+    /// not deny a connection to request-path resolvers.
+    fn open_detached(&self) -> Result<Database, koan_core::db::connection::DbError> {
+        self.pool.open_new()
+    }
+
+    fn note_batch(&self) {
+        self.pool.batches.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Connections opened since the schema was built.
+    #[cfg_attr(not(test), allow(dead_code))]
+    fn open_count(&self) -> usize {
+        self.pool.opens.load(Ordering::Relaxed)
+    }
+
+    /// Dataloader batches run since the schema was built.
+    #[cfg_attr(not(test), allow(dead_code))]
+    fn batch_count(&self) -> usize {
+        self.pool.batches.load(Ordering::Relaxed)
+    }
+}
+
+/// Run a rusqlite closure on the blocking pool with a pooled connection.
+///
+/// rusqlite is blocking start to finish. Calling it inline in an `async fn`
+/// parks a tokio worker for the duration, and enough of those at once starve
+/// the runtime — including the `ReaderStream`s feeding in-flight audio.
+async fn with_db<T, F>(ctx: &Context<'_>, f: F) -> async_graphql::Result<T>
+where
+    F: FnOnce(&Database) -> async_graphql::Result<T> + Send + 'static,
+    T: Send + 'static,
+{
+    let handle = ctx.data::<DbHandle>()?.clone();
+    blocking(move || {
+        let db = handle.acquire()?;
+        f(&db)
+    })
+    .await
+}
+
+/// Run any other blocking work (HTTP fetches, file decoding, tag reads) off the
+/// async workers.
+async fn blocking<T, F>(f: F) -> async_graphql::Result<T>
+where
+    F: FnOnce() -> async_graphql::Result<T> + Send + 'static,
+    T: Send + 'static,
+{
+    tokio::task::spawn_blocking(f)
+        .await
+        .map_err(|e| internal_error("blocking task", e))?
 }
 
 /// Log the detail, return a generic message.
@@ -62,8 +267,24 @@ pub fn build_schema(
     db_path: PathBuf,
     viz: Option<Arc<VizSnapshot>>,
 ) -> KoanSchema {
+    build_schema_with(DbHandle::new(db_path), state, cmd_tx, viz)
+}
+
+fn build_schema_with(
+    handle: DbHandle,
+    state: Arc<SharedPlayerState>,
+    cmd_tx: Sender<PlayerCommand>,
+    viz: Option<Arc<VizSnapshot>>,
+) -> KoanSchema {
+    // Batching only, no caching: a schema-wide loader outlives the request, and
+    // favourites and library contents change under it.
+    let loader = DataLoader::new(DbLoader::new(handle.clone()), tokio::spawn).delay(BATCH_WINDOW);
+    loader.enable_all_cache(false);
+
     let mut builder = Schema::build(QueryRoot, MutationRoot, SubscriptionRoot)
-        .data(DbHandle { path: db_path })
+        .data(handle)
+        .data(loader)
+        .data(jobs::JobRegistry::default())
         .data(state)
         .data(cmd_tx);
     if let Some(viz) = viz {
@@ -84,10 +305,22 @@ fn parse_queue_item_id(s: &str) -> async_graphql::Result<QueueItemId> {
         .map_err(|e| async_graphql::Error::new(format!("invalid queue item ID '{}': {}", s, e)))
 }
 
+/// How long to wait for room on the player command channel.
+///
+/// The channel is bounded(16) and the player can sit inside `start_playback`
+/// for about a second during a device sample-rate change. A blocking `send`
+/// there parks a tokio worker; this gives the player a moment to drain and
+/// then reports back rather than holding the thread.
+const CMD_SEND_TIMEOUT: Duration = Duration::from_millis(250);
+
 fn send_cmd(ctx: &Context<'_>, cmd: PlayerCommand) -> async_graphql::Result<()> {
     let tx = ctx.data::<Sender<PlayerCommand>>()?;
-    tx.send(cmd)
-        .map_err(|e| async_graphql::Error::new(format!("send error: {}", e)))
+    send_cmd_via(tx, cmd)
+}
+
+fn send_cmd_via(tx: &Sender<PlayerCommand>, cmd: PlayerCommand) -> async_graphql::Result<()> {
+    tx.send_timeout(cmd, CMD_SEND_TIMEOUT)
+        .map_err(|_| async_graphql::Error::new("player busy — command not accepted"))
 }
 
 /// Extract the authenticated user from GraphQL context.
@@ -141,6 +374,60 @@ mod tests {
 
         let schema = build_schema(state, tx, db_path, None);
         (schema, rx, tmp)
+    }
+
+    /// Same schema, but keeping the `DbHandle` so tests can read its counters.
+    fn instrumented_schema() -> (
+        KoanSchema,
+        DbHandle,
+        crossbeam_channel::Receiver<PlayerCommand>,
+        TempDir,
+    ) {
+        let tmp = TempDir::new().unwrap();
+        let db_path = tmp.path().join("test.db");
+        let db = Database::open(&db_path).unwrap();
+        koan_core::db::schema::create_tables(&db.conn).unwrap();
+
+        let state = SharedPlayerState::new();
+        let ch = CommandChannel::new();
+        let handle = DbHandle::new(db_path);
+        let schema = build_schema_with(handle.clone(), state, ch.tx.clone(), None);
+        (schema, handle, ch.rx.clone(), tmp)
+    }
+
+    /// Seed a library on one connection — the per-track helper opens its own.
+    fn seed_library(db_path: &std::path::Path, artists: usize, albums: usize, tracks: usize) {
+        let db = Database::open(db_path).unwrap();
+        for a in 0..artists {
+            for al in 0..albums {
+                for t in 0..tracks {
+                    let meta = queries::TrackMeta {
+                        title: format!("Track {:03}-{}-{:03}", a, al, t),
+                        artist: format!("Artist {:03}", a),
+                        album_artist: Some(format!("Artist {:03}", a)),
+                        album: format!("Album {:03}-{}", a, al),
+                        track_number: Some(t as i32),
+                        disc: Some(1),
+                        date: Some("2024".into()),
+                        genre: Some("Electronic".into()),
+                        duration_ms: Some(240_000),
+                        path: Some(format!("/tmp/koan-test/{}/{}/{}.flac", a, al, t)),
+                        codec: Some("FLAC".into()),
+                        sample_rate: Some(44100),
+                        bit_depth: Some(16),
+                        channels: Some(2),
+                        bitrate: Some(1411),
+                        size_bytes: Some(42_000_000),
+                        mtime: Some(1700000000),
+                        source: "local".into(),
+                        remote_id: None,
+                        remote_url: None,
+                        label: None,
+                    };
+                    queries::upsert_track(&db.conn, &meta).unwrap();
+                }
+            }
+        }
     }
 
     fn insert_test_track(db_path: &std::path::Path, title: &str, artist: &str, album: &str) -> i64 {
@@ -580,5 +867,174 @@ mod tests {
             "missing queueUpdated subscription"
         );
         assert!(names.contains(&"vizFrame"), "missing vizFrame subscription");
+    }
+    // -- Fan-out and pagination --
+
+    #[tokio::test]
+    async fn nested_fan_out_opens_a_bounded_number_of_connections() {
+        let (schema, handle, _rx, tmp) = instrumented_schema();
+        seed_library(&tmp.path().join("test.db"), 10, 3, 4);
+
+        let before = handle.open_count();
+        let resp = schema
+            .execute(
+                "{ artists(first: 10) { edges { node { name albumCount trackCount \
+                   albums(first: 10) { edges { node { title trackCount totalDurationMs \
+                   tracks(first: 10) { edges { node { title isFavourite } } } } } } } } } }",
+            )
+            .await;
+        assert!(resp.errors.is_empty(), "errors: {:?}", resp.errors);
+
+        let data = resp.data.into_json().unwrap();
+        let artists = data["artists"]["edges"].as_array().unwrap();
+        assert_eq!(artists.len(), 10, "query did not actually fan out");
+        assert_eq!(artists[0]["node"]["albumCount"], 3);
+        assert_eq!(artists[0]["node"]["trackCount"], 12);
+
+        // Before pooling this was one full `Database::open` — DDL batch,
+        // migrations and a WAL checkpoint — per resolver field.
+        let opened = handle.open_count() - before;
+        assert!(opened <= 16, "opened {} connections", opened);
+    }
+
+    #[tokio::test]
+    async fn is_favourite_batches_into_one_query() {
+        let (schema, handle, _rx, tmp) = instrumented_schema();
+        seed_library(&tmp.path().join("test.db"), 1, 1, 100);
+
+        let before = handle.batch_count();
+        let resp = schema
+            .execute("{ tracks(first: 100) { edges { node { title isFavourite } } } }")
+            .await;
+        assert!(resp.errors.is_empty(), "errors: {:?}", resp.errors);
+        let data = resp.data.into_json().unwrap();
+        assert_eq!(data["tracks"]["edges"].as_array().unwrap().len(), 100);
+
+        // One batch for all 100 tracks, not one full `favourites` scan each.
+        // Allow a second in case the gather window closes mid-selection under
+        // load; what must not happen is a count that tracks the row count.
+        let batches = handle.batch_count() - before;
+        assert!(batches <= 2, "{} batches for 100 tracks", batches);
+    }
+
+    #[tokio::test]
+    async fn tracks_without_first_returns_the_default_page() {
+        let (schema, _handle, _rx, tmp) = instrumented_schema();
+        seed_library(
+            &tmp.path().join("test.db"),
+            1,
+            1,
+            helpers::DEFAULT_PAGE + 20,
+        );
+
+        let resp = schema
+            .execute("{ tracks { edges { node { title } } pageInfo { hasNextPage } } }")
+            .await;
+        assert!(resp.errors.is_empty(), "errors: {:?}", resp.errors);
+        let data = resp.data.into_json().unwrap();
+        assert_eq!(
+            data["tracks"]["edges"].as_array().unwrap().len(),
+            helpers::DEFAULT_PAGE
+        );
+        assert_eq!(data["tracks"]["pageInfo"]["hasNextPage"], true);
+    }
+
+    #[tokio::test]
+    async fn first_is_clamped_to_the_maximum_page() {
+        let (schema, _handle, _rx, tmp) = instrumented_schema();
+        seed_library(&tmp.path().join("test.db"), 1, 1, 10);
+
+        let resp = schema
+            .execute("{ tracks(first: 100000) { edges { node { title } } } }")
+            .await;
+        assert!(resp.errors.is_empty(), "errors: {:?}", resp.errors);
+        let data = resp.data.into_json().unwrap();
+        assert_eq!(data["tracks"]["edges"].as_array().unwrap().len(), 10);
+    }
+
+    #[tokio::test]
+    async fn negative_first_is_empty_not_a_panic() {
+        let (schema, _handle, _rx, tmp) = instrumented_schema();
+        seed_library(&tmp.path().join("test.db"), 2, 1, 3);
+
+        for query in [
+            "{ tracks(first: -1) { edges { node { title } } } }",
+            "{ artists(first: -1) { edges { node { name } } } }",
+            "{ albums(first: -1) { edges { node { title } } } }",
+        ] {
+            let resp = schema.execute(query).await;
+            assert!(resp.errors.is_empty(), "{}: {:?}", query, resp.errors);
+        }
+    }
+
+    #[tokio::test]
+    async fn sort_arguments_are_honoured() {
+        let (schema, _handle, _rx, tmp) = instrumented_schema();
+        seed_library(&tmp.path().join("test.db"), 3, 1, 2);
+
+        let resp = schema
+            .execute(
+                "{ tracks(first: 100, sortBy: TITLE, sortDir: DESC) { edges { node { title } } } }",
+            )
+            .await;
+        assert!(resp.errors.is_empty(), "errors: {:?}", resp.errors);
+        let data = resp.data.into_json().unwrap();
+        let titles: Vec<String> = data["tracks"]["edges"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|e| e["node"]["title"].as_str().unwrap().to_string())
+            .collect();
+        let mut sorted = titles.clone();
+        sorted.sort();
+        sorted.reverse();
+        assert_eq!(titles, sorted, "sortBy/sortDir were ignored");
+    }
+
+    /// A blocking resolver must not hold the runtime. On a single-threaded
+    /// runtime, anything running inline would freeze every other task for the
+    /// whole query — which is what stalled in-flight audio streams.
+    #[test]
+    fn a_slow_query_does_not_stall_other_tasks() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_time()
+            .build()
+            .unwrap();
+        let (schema, _handle, _rx, tmp) = instrumented_schema();
+        seed_library(&tmp.path().join("test.db"), 20, 5, 8);
+
+        rt.block_on(async move {
+            let ticks = Arc::new(AtomicUsize::new(0));
+            let counter = ticks.clone();
+            let ticker = tokio::spawn(async move {
+                loop {
+                    tokio::time::sleep(Duration::from_millis(1)).await;
+                    counter.fetch_add(1, Ordering::Relaxed);
+                }
+            });
+
+            // fuzzySearch loads the library and builds a whole Nucleo matcher.
+            let mut running = Vec::new();
+            for _ in 0..4 {
+                let schema = schema.clone();
+                running.push(tokio::spawn(async move {
+                    schema
+                        .execute("{ fuzzySearch(query: \"track\") { id } }")
+                        .await
+                }));
+            }
+            for handle in running {
+                let resp = handle.await.unwrap();
+                assert!(resp.errors.is_empty(), "errors: {:?}", resp.errors);
+            }
+
+            ticker.abort();
+            assert!(
+                ticks.load(Ordering::Relaxed) >= 2,
+                "no other task ran while the queries were in flight"
+            );
+        });
     }
 }

--- a/crates/koan-server/src/graphql/mutations.rs
+++ b/crates/koan-server/src/graphql/mutations.rs
@@ -6,14 +6,14 @@ use koan_core::config::Config;
 use koan_core::db::queries;
 use koan_core::db::queries::playback_state::PersistedQueueItem;
 use koan_core::player::commands::PlayerCommand;
-use koan_core::player::state::{PlaybackState, QueueItemId, SharedPlayerState};
-use uuid::Uuid;
+use koan_core::player::state::{PlaybackState, PlaylistItem, QueueItemId, SharedPlayerState};
 
 use koan_core::auth::Role;
 
 use super::helpers::{spawn_downloads, sync_favourite_to_remote, track_to_playlist_item};
+use super::jobs::{JobRegistry, JobState};
 use super::types::*;
-use super::{DbHandle, parse_queue_item_id, require_role, send_cmd};
+use super::{DbHandle, parse_queue_item_id, require_role, send_cmd, send_cmd_via, with_db};
 
 /// The `organize*` mutations physically move files, so admin alone is not the
 /// bar — the deployment has to have opted in.
@@ -25,6 +25,40 @@ fn require_organize() -> async_graphql::Result<()> {
             "organize is disabled — set [graphql] allow_organize = true to enable it",
         ))
     }
+}
+
+/// Tracks resolved into queue items, plus the remote ones needing a download.
+struct ResolvedQueue {
+    items: Vec<PlaylistItem>,
+    pending_downloads: Vec<(i64, QueueItemId)>,
+}
+
+/// Resolve track IDs into playlist items on the blocking pool.
+async fn resolve_tracks(
+    ctx: &Context<'_>,
+    track_ids: Vec<i64>,
+) -> async_graphql::Result<ResolvedQueue> {
+    with_db(ctx, move |db| {
+        let mut items = Vec::new();
+        let mut pending_downloads = Vec::new();
+        for tid in track_ids {
+            if let Ok(Some(track)) = queries::get_track_row(&db.conn, tid) {
+                let item = track_to_playlist_item(&track, db);
+                if matches!(
+                    item.load_state,
+                    koan_core::player::state::LoadState::Pending
+                ) {
+                    pending_downloads.push((tid, item.id));
+                }
+                items.push(item);
+            }
+        }
+        Ok(ResolvedQueue {
+            items,
+            pending_downloads,
+        })
+    })
+    .await
 }
 
 // ---------------------------------------------------------------------------
@@ -92,43 +126,28 @@ impl MutationRoot {
         track_ids: Vec<i64>,
     ) -> async_graphql::Result<GqlQueueMutationResult> {
         require_role(ctx, Role::User)?;
-        let db = ctx.data::<DbHandle>()?.open()?;
+        let resolved = resolve_tracks(ctx, track_ids).await?;
         let state = ctx.data::<Arc<SharedPlayerState>>()?;
         let tx = ctx.data::<Sender<PlayerCommand>>()?;
 
-        let mut items = Vec::new();
-        let mut queue_item_ids = Vec::new();
-        let mut pending_downloads: Vec<(i64, QueueItemId)> = Vec::new();
-        for &tid in &track_ids {
-            if let Ok(Some(track)) = queries::get_track_row(&db.conn, tid) {
-                let item = track_to_playlist_item(&track, &db);
-                queue_item_ids.push(item.id.0.to_string());
-                if matches!(
-                    item.load_state,
-                    koan_core::player::state::LoadState::Pending
-                ) {
-                    pending_downloads.push((tid, item.id));
-                }
-                items.push(item);
-            }
-        }
+        let queue_item_ids: Vec<String> =
+            resolved.items.iter().map(|i| i.id.0.to_string()).collect();
+        let first_id = resolved.items.first().map(|i| i.id);
+        let count = resolved.items.len() as i32;
 
-        let count = items.len() as i32;
-        if !items.is_empty() {
-            tx.send(PlayerCommand::AddToPlaylist(items))
-                .map_err(|e| async_graphql::Error::new(format!("send error: {}", e)))?;
+        if !resolved.items.is_empty() {
+            send_cmd_via(tx, PlayerCommand::AddToPlaylist(resolved.items))?;
 
             // Auto-play if stopped
             if state.playback_state() == PlaybackState::Stopped
-                && let Some(first_id) = queue_item_ids.first()
-                && let Ok(id) = Uuid::parse_str(first_id).map(QueueItemId)
+                && let Some(id) = first_id
             {
-                let _ = tx.send(PlayerCommand::Play(id));
+                send_cmd_via(tx, PlayerCommand::Play(id))?;
             }
 
             // Kick off downloads for remote tracks.
-            if !pending_downloads.is_empty() {
-                spawn_downloads(pending_downloads, tx.clone(), state.clone());
+            if !resolved.pending_downloads.is_empty() {
+                spawn_downloads(resolved.pending_downloads, tx.clone(), state.clone());
             }
         }
 
@@ -146,42 +165,26 @@ impl MutationRoot {
         track_ids: Vec<i64>,
     ) -> async_graphql::Result<GqlQueueMutationResult> {
         require_role(ctx, Role::User)?;
-        let db = ctx.data::<DbHandle>()?.open()?;
+        let resolved = resolve_tracks(ctx, track_ids).await?;
+        let state = ctx.data::<Arc<SharedPlayerState>>()?;
         let tx = ctx.data::<Sender<PlayerCommand>>()?;
 
-        tx.send(PlayerCommand::ClearPlaylist)
-            .map_err(|e| async_graphql::Error::new(format!("send error: {}", e)))?;
+        send_cmd_via(tx, PlayerCommand::ClearPlaylist)?;
 
-        let state = ctx.data::<Arc<SharedPlayerState>>()?;
-        let mut items = Vec::new();
-        let mut queue_item_ids = Vec::new();
-        let mut pending_downloads: Vec<(i64, QueueItemId)> = Vec::new();
-        for &tid in &track_ids {
-            if let Ok(Some(track)) = queries::get_track_row(&db.conn, tid) {
-                let item = track_to_playlist_item(&track, &db);
-                queue_item_ids.push(item.id.0.to_string());
-                if matches!(
-                    item.load_state,
-                    koan_core::player::state::LoadState::Pending
-                ) {
-                    pending_downloads.push((tid, item.id));
-                }
-                items.push(item);
-            }
-        }
+        let queue_item_ids: Vec<String> =
+            resolved.items.iter().map(|i| i.id.0.to_string()).collect();
+        let first_id = resolved.items.first().map(|i| i.id);
+        let count = resolved.items.len() as i32;
 
-        let count = items.len() as i32;
-        let first_id = items.first().map(|i| i.id);
-        if !items.is_empty() {
-            tx.send(PlayerCommand::AddToPlaylist(items))
-                .map_err(|e| async_graphql::Error::new(format!("send error: {}", e)))?;
+        if !resolved.items.is_empty() {
+            send_cmd_via(tx, PlayerCommand::AddToPlaylist(resolved.items))?;
 
             if let Some(id) = first_id {
-                let _ = tx.send(PlayerCommand::Play(id));
+                send_cmd_via(tx, PlayerCommand::Play(id))?;
             }
 
-            if !pending_downloads.is_empty() {
-                spawn_downloads(pending_downloads, tx.clone(), state.clone());
+            if !resolved.pending_downloads.is_empty() {
+                spawn_downloads(resolved.pending_downloads, tx.clone(), state.clone());
             }
         }
 
@@ -271,19 +274,7 @@ impl MutationRoot {
 
     async fn favourite(&self, ctx: &Context<'_>, track_id: i64) -> async_graphql::Result<GqlTrack> {
         require_role(ctx, Role::User)?;
-        let db = ctx.data::<DbHandle>()?.open()?;
-        let track = queries::get_track_row(&db.conn, track_id)
-            .map_err(|e| super::internal_error("db", e))?
-            .ok_or_else(|| async_graphql::Error::new(format!("track {} not found", track_id)))?;
-        let path = track
-            .path
-            .as_ref()
-            .or(track.cached_path.as_ref())
-            .ok_or_else(|| async_graphql::Error::new(format!("track {} has no path", track_id)))?;
-        queries::add_favourite(&db.conn, std::path::Path::new(path))
-            .map_err(|e| super::internal_error("db", e))?;
-        sync_favourite_to_remote(&db, path, true);
-        Ok(GqlTrack { row: track })
+        set_favourite(ctx, track_id, Some(true)).await
     }
 
     async fn unfavourite(
@@ -292,19 +283,7 @@ impl MutationRoot {
         track_id: i64,
     ) -> async_graphql::Result<GqlTrack> {
         require_role(ctx, Role::User)?;
-        let db = ctx.data::<DbHandle>()?.open()?;
-        let track = queries::get_track_row(&db.conn, track_id)
-            .map_err(|e| super::internal_error("db", e))?
-            .ok_or_else(|| async_graphql::Error::new(format!("track {} not found", track_id)))?;
-        let path = track
-            .path
-            .as_ref()
-            .or(track.cached_path.as_ref())
-            .ok_or_else(|| async_graphql::Error::new(format!("track {} has no path", track_id)))?;
-        queries::remove_favourite(&db.conn, std::path::Path::new(path))
-            .map_err(|e| super::internal_error("db", e))?;
-        sync_favourite_to_remote(&db, path, false);
-        Ok(GqlTrack { row: track })
+        set_favourite(ctx, track_id, Some(false)).await
     }
 
     async fn toggle_favourite(
@@ -313,35 +292,17 @@ impl MutationRoot {
         track_id: i64,
     ) -> async_graphql::Result<GqlTrack> {
         require_role(ctx, Role::User)?;
-        let db = ctx.data::<DbHandle>()?.open()?;
-        let track = queries::get_track_row(&db.conn, track_id)
-            .map_err(|e| super::internal_error("db", e))?
-            .ok_or_else(|| async_graphql::Error::new(format!("track {} not found", track_id)))?;
-        let path = track
-            .path
-            .as_ref()
-            .or(track.cached_path.as_ref())
-            .ok_or_else(|| async_graphql::Error::new(format!("track {} has no path", track_id)))?;
-        let is_now_fav = queries::toggle_favourite(&db.conn, std::path::Path::new(path))
-            .map_err(|e| super::internal_error("db", e))?;
-        sync_favourite_to_remote(&db, path, is_now_fav);
-        Ok(GqlTrack { row: track })
+        set_favourite(ctx, track_id, None).await
     }
 
     // -- Playback state persistence --
 
     async fn save_playback_state(&self, ctx: &Context<'_>) -> async_graphql::Result<GqlStatus> {
         require_role(ctx, Role::User)?;
-        let db = ctx.data::<DbHandle>()?.open()?;
         let state = ctx.data::<Arc<SharedPlayerState>>()?;
 
         let (items, cursor) = state.snapshot_playlist();
-        if items.is_empty() {
-            queries::playback_state::clear_playback_state(&db.conn)
-                .map_err(|e| super::internal_error("db", e))?;
-            return Ok(GqlStatus::success("playback state cleared (empty queue)"));
-        }
-
+        let position_ms = state.position_ms();
         let persisted: Vec<PersistedQueueItem> = items
             .iter()
             .map(PersistedQueueItem::from_playlist_item)
@@ -352,25 +313,33 @@ impl MutationRoot {
                 .find(|i| i.id == cid)
                 .map(|i| i.path.to_string_lossy().into_owned())
         });
-        let position_ms = state.position_ms();
 
-        queries::playback_state::save_playback_state(
-            &db.conn,
-            &persisted,
-            cursor_path.as_deref(),
-            position_ms,
-        )
-        .map_err(|e| super::internal_error("db", e))?;
-
-        Ok(GqlStatus::success("playback state saved"))
+        with_db(ctx, move |db| {
+            if persisted.is_empty() {
+                queries::playback_state::clear_playback_state(&db.conn)
+                    .map_err(|e| super::internal_error("db", e))?;
+                return Ok(GqlStatus::success("playback state cleared (empty queue)"));
+            }
+            queries::playback_state::save_playback_state(
+                &db.conn,
+                &persisted,
+                cursor_path.as_deref(),
+                position_ms,
+            )
+            .map_err(|e| super::internal_error("db", e))?;
+            Ok(GqlStatus::success("playback state saved"))
+        })
+        .await
     }
 
     async fn clear_playback_state(&self, ctx: &Context<'_>) -> async_graphql::Result<GqlStatus> {
         require_role(ctx, Role::User)?;
-        let db = ctx.data::<DbHandle>()?.open()?;
-        queries::playback_state::clear_playback_state(&db.conn)
-            .map_err(|e| super::internal_error("db", e))?;
-        Ok(GqlStatus::success("playback state cleared"))
+        with_db(ctx, |db| {
+            queries::playback_state::clear_playback_state(&db.conn)
+                .map_err(|e| super::internal_error("db", e))?;
+            Ok(GqlStatus::success("playback state cleared"))
+        })
+        .await
     }
 
     // -- Snapshots --
@@ -381,7 +350,6 @@ impl MutationRoot {
         name: String,
     ) -> async_graphql::Result<GqlStatus> {
         require_role(ctx, Role::User)?;
-        let db = ctx.data::<DbHandle>()?.open()?;
         let state = ctx.data::<Arc<SharedPlayerState>>()?;
         let (items, cursor) = state.snapshot_playlist();
         let position_ms = state.position_ms();
@@ -397,16 +365,18 @@ impl MutationRoot {
                 .map(|i| i.path.to_string_lossy().into_owned())
         });
 
-        queries::save_snapshot(
-            &db.conn,
-            &name,
-            &persisted,
-            cursor_path.as_deref(),
-            position_ms,
-        )
-        .map_err(|e| super::internal_error("db", e))?;
-
-        Ok(GqlStatus::success(format!("saved snapshot '{}'", name)))
+        with_db(ctx, move |db| {
+            queries::save_snapshot(
+                &db.conn,
+                &name,
+                &persisted,
+                cursor_path.as_deref(),
+                position_ms,
+            )
+            .map_err(|e| super::internal_error("db", e))?;
+            Ok(GqlStatus::success(format!("saved snapshot '{}'", name)))
+        })
+        .await
     }
 
     async fn restore_snapshot(
@@ -415,62 +385,75 @@ impl MutationRoot {
         name: String,
     ) -> async_graphql::Result<GqlStatus> {
         require_role(ctx, Role::User)?;
-        let db = ctx.data::<DbHandle>()?.open()?;
-        let tx = ctx.data::<Sender<PlayerCommand>>()?;
-
-        let snap = queries::load_snapshot(&db.conn, &name)
-            .map_err(|e| super::internal_error("db", e))?
-            .ok_or_else(|| async_graphql::Error::new(format!("snapshot '{}' not found", name)))?;
-
-        let state = ctx.data::<Arc<SharedPlayerState>>()?;
 
         // Resolve each snapshot item through the same path resolution as
         // addToQueue — ensures correct cache paths and triggers downloads.
-        let mut items = Vec::new();
-        let mut pending_downloads: Vec<(i64, QueueItemId)> = Vec::new();
-        for snap_item in &snap.items {
-            if let Ok(Some(tid)) = queries::track_id_by_path(&db.conn, &snap_item.path)
-                && let Ok(Some(track)) = queries::get_track_row(&db.conn, tid)
-            {
-                let item = track_to_playlist_item(&track, &db);
-                if matches!(
-                    item.load_state,
-                    koan_core::player::state::LoadState::Pending
-                ) {
-                    pending_downloads.push((tid, item.id));
+        let label = name.clone();
+        let (resolved, cursor_path, position_ms) = with_db(ctx, move |db| {
+            let snap = queries::load_snapshot(&db.conn, &name)
+                .map_err(|e| super::internal_error("db", e))?
+                .ok_or_else(|| {
+                    async_graphql::Error::new(format!("snapshot '{}' not found", name))
+                })?;
+
+            let mut items = Vec::new();
+            let mut pending_downloads: Vec<(i64, QueueItemId)> = Vec::new();
+            for snap_item in &snap.items {
+                if let Ok(Some(tid)) = queries::track_id_by_path(&db.conn, &snap_item.path)
+                    && let Ok(Some(track)) = queries::get_track_row(&db.conn, tid)
+                {
+                    let item = track_to_playlist_item(&track, db);
+                    if matches!(
+                        item.load_state,
+                        koan_core::player::state::LoadState::Pending
+                    ) {
+                        pending_downloads.push((tid, item.id));
+                    }
+                    items.push(item);
+                } else {
+                    // Track not in DB — use snapshot's stored data.
+                    items.push(snap_item.to_playlist_item());
                 }
-                items.push(item);
-            } else {
-                // Track not in DB — use snapshot's stored data.
-                items.push(snap_item.to_playlist_item());
             }
-        }
 
-        tx.send(PlayerCommand::ClearPlaylist)
-            .map_err(|e| async_graphql::Error::new(format!("send error: {}", e)))?;
+            Ok((
+                ResolvedQueue {
+                    items,
+                    pending_downloads,
+                },
+                snap.cursor_path,
+                snap.position_ms,
+            ))
+        })
+        .await?;
 
-        let cursor_item_id = snap.cursor_path.as_ref().and_then(|cp| {
-            items
+        let state = ctx.data::<Arc<SharedPlayerState>>()?;
+        let tx = ctx.data::<Sender<PlayerCommand>>()?;
+
+        let cursor_item_id = cursor_path.as_ref().and_then(|cp| {
+            resolved
+                .items
                 .iter()
                 .find(|i| i.path.to_string_lossy() == cp.as_str())
                 .map(|i| i.id)
         });
 
-        if !items.is_empty() {
-            let first_id = cursor_item_id.unwrap_or(items[0].id);
-            tx.send(PlayerCommand::AddToPlaylist(items))
-                .map_err(|e| async_graphql::Error::new(format!("send error: {}", e)))?;
-            let _ = tx.send(PlayerCommand::Play(first_id));
-            if snap.position_ms > 0 {
-                let _ = tx.send(PlayerCommand::Seek(snap.position_ms));
+        send_cmd_via(tx, PlayerCommand::ClearPlaylist)?;
+
+        if !resolved.items.is_empty() {
+            let first_id = cursor_item_id.unwrap_or(resolved.items[0].id);
+            send_cmd_via(tx, PlayerCommand::AddToPlaylist(resolved.items))?;
+            send_cmd_via(tx, PlayerCommand::Play(first_id))?;
+            if position_ms > 0 {
+                send_cmd_via(tx, PlayerCommand::Seek(position_ms))?;
             }
 
-            if !pending_downloads.is_empty() {
-                spawn_downloads(pending_downloads, tx.clone(), state.clone());
+            if !resolved.pending_downloads.is_empty() {
+                spawn_downloads(resolved.pending_downloads, tx.clone(), state.clone());
             }
         }
 
-        Ok(GqlStatus::success(format!("restored snapshot '{}'", name)))
+        Ok(GqlStatus::success(format!("restored snapshot '{}'", label)))
     }
 
     async fn delete_snapshot(
@@ -479,17 +462,19 @@ impl MutationRoot {
         name: String,
     ) -> async_graphql::Result<GqlStatus> {
         require_role(ctx, Role::User)?;
-        let db = ctx.data::<DbHandle>()?.open()?;
-        let deleted = queries::delete_snapshot(&db.conn, &name)
-            .map_err(|e| super::internal_error("db", e))?;
-        if deleted {
-            Ok(GqlStatus::success(format!("deleted snapshot '{}'", name)))
-        } else {
-            Err(async_graphql::Error::new(format!(
-                "snapshot '{}' not found",
-                name
-            )))
-        }
+        with_db(ctx, move |db| {
+            let deleted = queries::delete_snapshot(&db.conn, &name)
+                .map_err(|e| super::internal_error("db", e))?;
+            if deleted {
+                Ok(GqlStatus::success(format!("deleted snapshot '{}'", name)))
+            } else {
+                Err(async_graphql::Error::new(format!(
+                    "snapshot '{}' not found",
+                    name
+                )))
+            }
+        })
+        .await
     }
 
     // -- Radio --
@@ -517,32 +502,34 @@ impl MutationRoot {
         track_ids: Option<Vec<i64>>,
     ) -> async_graphql::Result<GqlOrganizePreview> {
         require_role(ctx, Role::Admin)?;
-        require_organize()?;
-        let db = ctx.data::<DbHandle>()?.open()?;
-        let result = if let Some(ids) = track_ids {
-            koan_core::organize::preview_for_tracks(&db, &ids, &pattern, None)
-        } else {
-            koan_core::organize::preview(&db, &pattern, None)
-        }
-        .map_err(|e| super::internal_error("organize", e))?;
+        with_db(ctx, move |db| {
+            require_organize()?;
+            let result = if let Some(ids) = track_ids {
+                koan_core::organize::preview_for_tracks(db, &ids, &pattern, None)
+            } else {
+                koan_core::organize::preview(db, &pattern, None)
+            }
+            .map_err(|e| super::internal_error("organize", e))?;
 
-        Ok(GqlOrganizePreview {
-            moves: result
-                .moves
-                .iter()
-                .map(|m| GqlFileMove {
-                    track_id: m.track_id,
-                    from_path: m.from.to_string_lossy().into_owned(),
-                    to_path: m.to.to_string_lossy().into_owned(),
-                })
-                .collect(),
-            errors: result
-                .errors
-                .iter()
-                .map(|(p, e)| format!("{}: {}", p.display(), e))
-                .collect(),
-            skipped: result.skipped as i32,
+            Ok(GqlOrganizePreview {
+                moves: result
+                    .moves
+                    .iter()
+                    .map(|m| GqlFileMove {
+                        track_id: m.track_id,
+                        from_path: m.from.to_string_lossy().into_owned(),
+                        to_path: m.to.to_string_lossy().into_owned(),
+                    })
+                    .collect(),
+                errors: result
+                    .errors
+                    .iter()
+                    .map(|(p, e)| format!("{}: {}", p.display(), e))
+                    .collect(),
+                skipped: result.skipped as i32,
+            })
         })
+        .await
     }
 
     async fn organize_execute(
@@ -552,46 +539,50 @@ impl MutationRoot {
         track_ids: Option<Vec<i64>>,
     ) -> async_graphql::Result<GqlOrganizeResult> {
         require_role(ctx, Role::Admin)?;
-        require_organize()?;
-        let db = ctx.data::<DbHandle>()?.open()?;
-        let result = if let Some(ids) = track_ids {
-            koan_core::organize::execute_for_tracks(&db, &ids, &pattern, None)
-        } else {
-            koan_core::organize::execute(&db, &pattern, None)
-        }
-        .map_err(|e| super::internal_error("organize", e))?;
+        with_db(ctx, move |db| {
+            require_organize()?;
+            let result = if let Some(ids) = track_ids {
+                koan_core::organize::execute_for_tracks(db, &ids, &pattern, None)
+            } else {
+                koan_core::organize::execute(db, &pattern, None)
+            }
+            .map_err(|e| super::internal_error("organize", e))?;
 
-        Ok(GqlOrganizeResult {
-            moved_count: result.moves.len() as i32,
-            errors: result
-                .errors
-                .iter()
-                .map(|(p, e)| format!("{}: {}", p.display(), e))
-                .collect(),
-            skipped: result.skipped as i32,
+            Ok(GqlOrganizeResult {
+                moved_count: result.moves.len() as i32,
+                errors: result
+                    .errors
+                    .iter()
+                    .map(|(p, e)| format!("{}: {}", p.display(), e))
+                    .collect(),
+                skipped: result.skipped as i32,
+            })
         })
+        .await
     }
 
     async fn organize_undo(&self, ctx: &Context<'_>) -> async_graphql::Result<GqlStatus> {
         require_role(ctx, Role::Admin)?;
-        require_organize()?;
-        let db = ctx.data::<DbHandle>()?.open()?;
-        let result =
-            koan_core::organize::undo(&db).map_err(|e| super::internal_error("organize", e))?;
-        let mut message = format!("undone {} moves", result.restored);
-        if !result.errors.is_empty() {
-            message.push_str(&format!(
-                "; {} left in place: {}",
-                result.errors.len(),
-                result
-                    .errors
-                    .iter()
-                    .map(|(p, e)| format!("{}: {}", p.display(), e))
-                    .collect::<Vec<_>>()
-                    .join("; ")
-            ));
-        }
-        Ok(GqlStatus::success(message))
+        with_db(ctx, |db| {
+            require_organize()?;
+            let result =
+                koan_core::organize::undo(db).map_err(|e| super::internal_error("organize", e))?;
+            let mut message = format!("undone {} moves", result.restored);
+            if !result.errors.is_empty() {
+                message.push_str(&format!(
+                    "; {} left in place: {}",
+                    result.errors.len(),
+                    result
+                        .errors
+                        .iter()
+                        .map(|(p, e)| format!("{}: {}", p.display(), e))
+                        .collect::<Vec<_>>()
+                        .join("; ")
+                ));
+            }
+            Ok(GqlStatus::success(message))
+        })
+        .await
     }
 
     // -- Config --
@@ -620,102 +611,112 @@ impl MutationRoot {
             ));
         }
 
-        Config::update_base(|cfg| {
-            if let Some(ref mode) = input.replaygain_mode {
-                cfg.playback.replaygain = match mode.to_lowercase().as_str() {
-                    "track" => ReplayGainMode::Track,
-                    "album" => ReplayGainMode::Album,
-                    _ => ReplayGainMode::Off,
-                };
-            }
-            if let Some(pre_amp) = input.pre_amp_db {
-                cfg.playback.pre_amp_db = pre_amp;
-            }
-            if let Some(ref device) = input.output_device {
-                cfg.playback.output_device = if device.is_empty() {
-                    None
-                } else {
-                    Some(device.clone())
-                };
-            }
-            if let Some(fps) = input.target_fps {
-                cfg.playback.target_fps = fps as u8;
-            }
-            if let Some(size) = input.art_size {
-                cfg.playback.art_size = size as u16;
-            }
-            if let Some(enabled) = input.remote_enabled {
-                cfg.remote.enabled = enabled;
-            }
-            if let Some(ref username) = input.remote_username {
-                cfg.remote.username = username.clone();
-            }
-            if let Some(ref quality) = input.transcode_quality {
-                cfg.remote.transcode_quality = quality.clone();
-            }
-            if let Some(ref limit) = input.cache_limit {
-                cfg.remote.cache_limit = if limit.is_empty() {
-                    None
-                } else {
-                    Some(limit.clone())
-                };
-            }
-            if let Some(fps) = input.visualizer_fps {
-                cfg.visualizer.fps = fps as u8;
-            }
-            if let Some(port) = input.graphql_port {
-                cfg.graphql.port = port as u16;
-            }
-            if let Some(pg) = input.graphql_playground {
-                cfg.graphql.playground = pg;
-            }
-        })
-        .map_err(|e| super::internal_error("config write", e))?;
+        super::blocking(move || {
+            Config::update_base(|cfg| {
+                if let Some(ref mode) = input.replaygain_mode {
+                    cfg.playback.replaygain = match mode.to_lowercase().as_str() {
+                        "track" => ReplayGainMode::Track,
+                        "album" => ReplayGainMode::Album,
+                        _ => ReplayGainMode::Off,
+                    };
+                }
+                if let Some(pre_amp) = input.pre_amp_db {
+                    cfg.playback.pre_amp_db = pre_amp;
+                }
+                if let Some(ref device) = input.output_device {
+                    cfg.playback.output_device = if device.is_empty() {
+                        None
+                    } else {
+                        Some(device.clone())
+                    };
+                }
+                if let Some(fps) = input.target_fps {
+                    cfg.playback.target_fps = fps as u8;
+                }
+                if let Some(size) = input.art_size {
+                    cfg.playback.art_size = size as u16;
+                }
+                if let Some(enabled) = input.remote_enabled {
+                    cfg.remote.enabled = enabled;
+                }
+                if let Some(ref username) = input.remote_username {
+                    cfg.remote.username = username.clone();
+                }
+                if let Some(ref quality) = input.transcode_quality {
+                    cfg.remote.transcode_quality = quality.clone();
+                }
+                if let Some(ref limit) = input.cache_limit {
+                    cfg.remote.cache_limit = if limit.is_empty() {
+                        None
+                    } else {
+                        Some(limit.clone())
+                    };
+                }
+                if let Some(fps) = input.visualizer_fps {
+                    cfg.visualizer.fps = fps as u8;
+                }
+                if let Some(port) = input.graphql_port {
+                    cfg.graphql.port = port as u16;
+                }
+                if let Some(pg) = input.graphql_playground {
+                    cfg.graphql.playground = pg;
+                }
+            })
+            .map_err(|e| super::internal_error("config write", e))?;
 
-        Ok(GqlStatus::success("config updated"))
+            Ok(GqlStatus::success("config updated"))
+        })
+        .await
     }
 
     // -- Library management --
 
-    async fn trigger_scan(&self, ctx: &Context<'_>) -> async_graphql::Result<GqlScanResult> {
+    /// Start a library scan and return immediately.
+    ///
+    /// A full scan walks the filesystem and writes for minutes. Run inline it
+    /// held a runtime worker for the whole time, which stalled every in-flight
+    /// audio stream on the same process.
+    async fn trigger_scan(&self, ctx: &Context<'_>) -> async_graphql::Result<GqlJob> {
         require_role(ctx, Role::Admin)?;
-        let db = ctx.data::<DbHandle>()?.open()?;
-        let cfg = Config::load().unwrap_or_default();
-        let result = koan_core::index::scanner::full_scan(
-            &db,
-            &cfg.library.folders,
-            koan_core::index::scanner::ScanOptions::default(),
-            None,
-        );
-        Ok(GqlScanResult {
-            tracks_added: result.added as i64,
-            tracks_updated: result.updated as i64,
-            tracks_unchanged: result.skipped as i64,
+        spawn_job(ctx, "scan", |db| {
+            let cfg = Config::load().unwrap_or_default();
+            let result = koan_core::index::scanner::full_scan(
+                &db,
+                &cfg.library.folders,
+                koan_core::index::scanner::ScanOptions::default(),
+                None,
+            );
+            Ok(format!(
+                "{} added, {} updated, {} unchanged",
+                result.added, result.updated, result.skipped
+            ))
         })
     }
 
-    async fn trigger_remote_sync(&self, ctx: &Context<'_>) -> async_graphql::Result<GqlStatus> {
+    /// Start a remote library sync and return immediately.
+    async fn trigger_remote_sync(&self, ctx: &Context<'_>) -> async_graphql::Result<GqlJob> {
         require_role(ctx, Role::Admin)?;
-        let db = ctx.data::<DbHandle>()?.open()?;
-        let cfg = Config::load().unwrap_or_default();
-        let client = koan_core::helpers::subsonic_client(&cfg)
-            .ok_or_else(|| async_graphql::Error::new("remote not configured"))?;
-        let result = koan_core::remote::sync::sync_library(
-            &db,
-            &client,
-            false,
-            &cfg.remote.url,
-            &cfg.remote.username,
-        )
-        .map_err(|e| super::internal_error("remote sync", e))?;
-        if result.is_complete() {
-            Ok(GqlStatus::success("remote sync complete"))
-        } else {
-            Ok(GqlStatus::success(format!(
-                "remote sync incomplete: {} album(s) failed and will be retried next sync",
-                result.albums_failed
-            )))
-        }
+        spawn_job(ctx, "remoteSync", |db| {
+            let cfg = Config::load().unwrap_or_default();
+            let client = koan_core::helpers::subsonic_client(&cfg)
+                .ok_or_else(|| "remote not configured".to_string())?;
+            let result = koan_core::remote::sync::sync_library(
+                &db,
+                &client,
+                false,
+                &cfg.remote.url,
+                &cfg.remote.username,
+            )
+            .map_err(|e| e.to_string())?;
+            if result.is_complete() {
+                Ok("remote sync complete".to_string())
+            } else {
+                Ok(format!(
+                    "remote sync incomplete: {} album(s) failed and will be retried next sync",
+                    result.albums_failed
+                ))
+            }
+        })
     }
 
     // -- Sharing --
@@ -727,35 +728,122 @@ impl MutationRoot {
         description: Option<String>,
     ) -> async_graphql::Result<GqlShare> {
         require_role(ctx, Role::User)?;
-        let db = ctx.data::<DbHandle>()?.open()?;
-        let cfg = Config::load().unwrap_or_default();
-        let client = koan_core::helpers::subsonic_client(&cfg)
-            .ok_or_else(|| async_graphql::Error::new("remote not configured"))?;
+        with_db(ctx, move |db| {
+            let cfg = Config::load().unwrap_or_default();
+            let client = koan_core::helpers::subsonic_client(&cfg)
+                .ok_or_else(|| async_graphql::Error::new("remote not configured"))?;
 
-        // Resolve track IDs to remote IDs.
-        let mut remote_ids = Vec::new();
-        for &tid in &track_ids {
-            if let Ok(Some(track)) = queries::get_track_row(&db.conn, tid)
-                && let Some(rid) = track.remote_id
-            {
-                remote_ids.push(rid);
+            // Resolve track IDs to remote IDs.
+            let mut remote_ids = Vec::new();
+            for tid in track_ids {
+                if let Ok(Some(track)) = queries::get_track_row(&db.conn, tid)
+                    && let Some(rid) = track.remote_id
+                {
+                    remote_ids.push(rid);
+                }
             }
-        }
 
-        if remote_ids.is_empty() {
-            return Err(async_graphql::Error::new(
-                "none of the tracks have remote IDs (local-only tracks can't be shared)",
-            ));
-        }
+            if remote_ids.is_empty() {
+                return Err(async_graphql::Error::new(
+                    "none of the tracks have remote IDs (local-only tracks can't be shared)",
+                ));
+            }
 
-        let id_refs: Vec<&str> = remote_ids.iter().map(|s| s.as_str()).collect();
-        let share = client
-            .create_share(&id_refs, description.as_deref())
-            .map_err(|e| super::internal_error("share", e))?;
+            let id_refs: Vec<&str> = remote_ids.iter().map(|s| s.as_str()).collect();
+            let share = client
+                .create_share(&id_refs, description.as_deref())
+                .map_err(|e| super::internal_error("share", e))?;
 
-        Ok(GqlShare {
-            url: share.url,
-            id: share.id,
+            Ok(GqlShare {
+                url: share.url,
+                id: share.id,
+            })
         })
+        .await
     }
+}
+
+/// Star, unstar, or toggle — the three differ only in which write they run.
+async fn set_favourite(
+    ctx: &Context<'_>,
+    track_id: i64,
+    star: Option<bool>,
+) -> async_graphql::Result<GqlTrack> {
+    with_db(ctx, move |db| {
+        let track = queries::get_track_row(&db.conn, track_id)
+            .map_err(|e| super::internal_error("db", e))?
+            .ok_or_else(|| async_graphql::Error::new(format!("track {} not found", track_id)))?;
+        let path = track
+            .path
+            .as_ref()
+            .or(track.cached_path.as_ref())
+            .ok_or_else(|| async_graphql::Error::new(format!("track {} has no path", track_id)))?;
+        let fs_path = std::path::Path::new(path);
+
+        let now_starred = match star {
+            Some(true) => {
+                queries::add_favourite(&db.conn, fs_path)
+                    .map_err(|e| super::internal_error("db", e))?;
+                true
+            }
+            Some(false) => {
+                queries::remove_favourite(&db.conn, fs_path)
+                    .map_err(|e| super::internal_error("db", e))?;
+                false
+            }
+            None => queries::toggle_favourite(&db.conn, fs_path)
+                .map_err(|e| super::internal_error("db", e))?,
+        };
+
+        sync_favourite_to_remote(db, path, now_starred);
+        Ok(GqlTrack { row: track })
+    })
+    .await
+}
+
+/// Run `work` on a detached thread with its own connection, returning a job
+/// handle. A job of the same kind already running is returned as-is rather than
+/// started twice.
+fn spawn_job<F>(ctx: &Context<'_>, kind: &'static str, work: F) -> async_graphql::Result<GqlJob>
+where
+    F: FnOnce(koan_core::db::connection::Database) -> Result<String, String> + Send + 'static,
+{
+    let registry = ctx.data::<JobRegistry>()?.clone();
+    let handle = ctx.data::<DbHandle>()?.clone();
+
+    let job = match registry.start(kind) {
+        Ok(job) => job,
+        Err(running) => return Ok(running.into()),
+    };
+
+    let id = job.id.clone();
+    let finisher = registry.clone();
+    let spawned = std::thread::Builder::new()
+        .name(format!("koan-job-{}", kind))
+        .spawn(move || {
+            // Deliberately outside the pool: this connection is held for
+            // minutes and must not deny one to request-path resolvers.
+            let outcome = match handle.open_detached() {
+                Ok(db) => work(db),
+                Err(e) => Err(e.to_string()),
+            };
+            match outcome {
+                Ok(message) => registry.finish(&id, JobState::Succeeded, message),
+                Err(message) => {
+                    log::error!("{} job failed: {}", kind, message);
+                    registry.finish(&id, JobState::Failed, message)
+                }
+            }
+        });
+
+    if spawned.is_err() {
+        finisher.finish(
+            &job.id,
+            JobState::Failed,
+            "failed to spawn worker thread".into(),
+        );
+        return Err(async_graphql::Error::new("failed to start job"));
+    }
+
+    Ok(job.into())
 }

--- a/crates/koan-server/src/graphql/queries.rs
+++ b/crates/koan-server/src/graphql/queries.rs
@@ -5,11 +5,13 @@ use koan_core::audio;
 use koan_core::audio::viz::VizSnapshot;
 use koan_core::config::Config;
 use koan_core::db::queries;
-use koan_core::player::state::{PlaybackState, SharedPlayerState};
+use koan_core::db::queries::batch::{TrackFilter, TrackOrder};
+use koan_core::player::state::SharedPlayerState;
 
-use super::DbHandle;
-use super::helpers::{album_year, paginate, track_year};
+use super::helpers::{MAX_PAGE, album_year, page_offset, page_size, paginate, paginate_window};
+use super::jobs::JobRegistry;
 use super::types::*;
+use super::{blocking, with_db};
 
 // ---------------------------------------------------------------------------
 // Query root
@@ -29,40 +31,66 @@ impl QueryRoot {
         #[graphql(default = false)] favourites_only: bool,
         after: Option<String>,
         first: Option<i32>,
-        #[graphql(default_with = "ArtistSortField::Name")] _sort_by: ArtistSortField,
-        #[graphql(default_with = "SortDirection::Asc")] _sort_dir: SortDirection,
+        #[graphql(default_with = "ArtistSortField::Name")] sort_by: ArtistSortField,
+        #[graphql(default_with = "SortDirection::Asc")] sort_dir: SortDirection,
     ) -> async_graphql::Result<Conn<GqlArtist>> {
-        let db = ctx.data::<DbHandle>()?.open()?;
-        let mut artists = if let Some(ref query) = search {
-            queries::find_artists(&db.conn, query).map_err(|e| super::internal_error("db", e))?
-        } else {
-            queries::all_artists(&db.conn).map_err(|e| super::internal_error("db", e))?
-        };
+        let rows = with_db(ctx, move |db| {
+            let mut artists = if let Some(ref query) = search {
+                queries::find_artists(&db.conn, query)
+                    .map_err(|e| super::internal_error("db", e))?
+            } else {
+                queries::all_artists(&db.conn).map_err(|e| super::internal_error("db", e))?
+            };
 
-        if let Some(ref id_list) = ids {
-            artists.retain(|a| id_list.contains(&a.id));
-        }
+            if let Some(ref id_list) = ids {
+                artists.retain(|a| id_list.contains(&a.id));
+            }
 
-        if let Some(ref g) = genre {
-            let g_lower = g.to_lowercase();
-            let artist_ids: Vec<i64> = artists.iter().map(|a| a.id).collect();
-            let genre_map = queries::genres_by_artist_ids(&db.conn, &artist_ids)
-                .map_err(|e| super::internal_error("db", e))?;
-            artists.retain(|a| {
-                genre_map
-                    .get(&a.id)
-                    .is_some_and(|genres| genres.iter().any(|ag| ag.contains(&g_lower)))
-            });
-        }
+            if let Some(ref g) = genre {
+                let g_lower = g.to_lowercase();
+                let artist_ids: Vec<i64> = artists.iter().map(|a| a.id).collect();
+                let genre_map = queries::genres_by_artist_ids(&db.conn, &artist_ids)
+                    .map_err(|e| super::internal_error("db", e))?;
+                artists.retain(|a| {
+                    genre_map
+                        .get(&a.id)
+                        .is_some_and(|genres| genres.iter().any(|ag| ag.contains(&g_lower)))
+                });
+            }
 
-        if favourites_only {
-            let fav_ids = queries::favourite_artist_ids_batch(&db.conn)
-                .map_err(|e| super::internal_error("db", e))?;
-            artists.retain(|a| fav_ids.contains(&a.id));
-        }
+            if favourites_only {
+                let fav_ids = queries::favourite_artist_ids_batch(&db.conn)
+                    .map_err(|e| super::internal_error("db", e))?;
+                artists.retain(|a| fav_ids.contains(&a.id));
+            }
+
+            match sort_by {
+                ArtistSortField::Name => artists.sort_by(|a, b| a.name.cmp(&b.name)),
+                ArtistSortField::AlbumCount | ArtistSortField::TrackCount => {
+                    let ids: Vec<i64> = artists.iter().map(|a| a.id).collect();
+                    let stats = queries::batch::artist_stats(&db.conn, &ids)
+                        .map_err(|e| super::internal_error("db", e))?;
+                    let key = |id: i64| {
+                        let s = stats.get(&id).copied().unwrap_or_default();
+                        if sort_by == ArtistSortField::AlbumCount {
+                            s.album_count
+                        } else {
+                            s.track_count
+                        }
+                    };
+                    artists.sort_by(|a, b| key(a.id).cmp(&key(b.id)).then(a.name.cmp(&b.name)));
+                }
+            }
+            if sort_dir == SortDirection::Desc {
+                artists.reverse();
+            }
+
+            Ok(artists)
+        })
+        .await?;
 
         paginate(
-            artists.into_iter().map(|row| GqlArtist { row }).collect(),
+            rows.into_iter().map(|row| GqlArtist { row }).collect(),
             after,
             first,
         )
@@ -85,94 +113,123 @@ impl QueryRoot {
         #[graphql(default = false)] favourites_only: bool,
         after: Option<String>,
         first: Option<i32>,
-        #[graphql(default_with = "AlbumSortField::ArtistThenDate")] _sort_by: AlbumSortField,
-        #[graphql(default_with = "SortDirection::Asc")] _sort_dir: SortDirection,
+        #[graphql(default_with = "AlbumSortField::ArtistThenDate")] sort_by: AlbumSortField,
+        #[graphql(default_with = "SortDirection::Asc")] sort_dir: SortDirection,
     ) -> async_graphql::Result<Conn<GqlAlbum>> {
-        let db = ctx.data::<DbHandle>()?.open()?;
+        let rows = with_db(ctx, move |db| {
+            let mut albums = if let Some(aid) = artist_id {
+                queries::albums_for_artist(&db.conn, aid)
+                    .map_err(|e| super::internal_error("db", e))?
+            } else if let Some(ref aids) = artist_ids {
+                queries::batch::albums_for_artists(&db.conn, aids)
+                    .map_err(|e| super::internal_error("db", e))?
+                    .into_values()
+                    .flatten()
+                    .collect()
+            } else {
+                queries::all_albums(&db.conn).map_err(|e| super::internal_error("db", e))?
+            };
 
-        let mut albums = if let Some(aid) = artist_id {
-            queries::albums_for_artist(&db.conn, aid).map_err(|e| super::internal_error("db", e))?
-        } else if let Some(ref aids) = artist_ids {
-            let mut all = Vec::new();
-            for &aid in aids {
-                let mut a = queries::albums_for_artist(&db.conn, aid)
-                    .map_err(|e| super::internal_error("db", e))?;
-                all.append(&mut a);
+            if let Some(ref id_list) = ids {
+                albums.retain(|a| id_list.contains(&a.id));
             }
-            all
-        } else {
-            queries::all_albums(&db.conn).map_err(|e| super::internal_error("db", e))?
-        };
 
-        if let Some(ref id_list) = ids {
-            albums.retain(|a| id_list.contains(&a.id));
-        }
+            if let Some(ref query) = search {
+                let q = query.to_lowercase();
+                albums.retain(|a| {
+                    a.title.to_lowercase().contains(&q) || a.artist_name.to_lowercase().contains(&q)
+                });
+            }
 
-        if let Some(ref query) = search {
-            let q = query.to_lowercase();
-            albums.retain(|a| {
-                a.title.to_lowercase().contains(&q) || a.artist_name.to_lowercase().contains(&q)
-            });
-        }
+            if let Some(ref t) = title {
+                let t_lower = t.to_lowercase();
+                albums.retain(|a| a.title.to_lowercase().contains(&t_lower));
+            }
 
-        if let Some(ref t) = title {
-            let t_lower = t.to_lowercase();
-            albums.retain(|a| a.title.to_lowercase().contains(&t_lower));
-        }
+            if let Some(ys) = year_start {
+                albums.retain(|a| album_year(a).map(|y| y >= ys).unwrap_or(false));
+            }
 
-        if let Some(ys) = year_start {
-            albums.retain(|a| album_year(a).map(|y| y >= ys).unwrap_or(false));
-        }
+            if let Some(ye) = year_end {
+                albums.retain(|a| album_year(a).map(|y| y <= ye).unwrap_or(false));
+            }
 
-        if let Some(ye) = year_end {
-            albums.retain(|a| album_year(a).map(|y| y <= ye).unwrap_or(false));
-        }
+            if let Some(ref c) = codec {
+                let c_lower = c.to_lowercase();
+                albums.retain(|a| {
+                    a.codec
+                        .as_ref()
+                        .map(|ac| ac.to_lowercase().contains(&c_lower))
+                        .unwrap_or(false)
+                });
+            }
 
-        if let Some(ref c) = codec {
-            let c_lower = c.to_lowercase();
-            albums.retain(|a| {
-                a.codec
-                    .as_ref()
-                    .map(|ac| ac.to_lowercase().contains(&c_lower))
-                    .unwrap_or(false)
-            });
-        }
+            if let Some(ref l) = label {
+                let l_lower = l.to_lowercase();
+                albums.retain(|a| {
+                    a.label
+                        .as_ref()
+                        .map(|al| al.to_lowercase().contains(&l_lower))
+                        .unwrap_or(false)
+                });
+            }
 
-        if let Some(ref l) = label {
-            let l_lower = l.to_lowercase();
-            albums.retain(|a| {
-                a.label
-                    .as_ref()
-                    .map(|al| al.to_lowercase().contains(&l_lower))
-                    .unwrap_or(false)
-            });
-        }
+            if let Some(ref g) = genre {
+                let g_lower = g.to_lowercase();
+                let album_ids: Vec<i64> = albums.iter().map(|a| a.id).collect();
+                let genre_map = queries::genres_by_album_ids(&db.conn, &album_ids)
+                    .map_err(|e| super::internal_error("db", e))?;
+                albums.retain(|a| {
+                    genre_map
+                        .get(&a.id)
+                        .is_some_and(|genres| genres.iter().any(|ag| ag.contains(&g_lower)))
+                });
+            }
 
-        if let Some(ref g) = genre {
-            let g_lower = g.to_lowercase();
-            let album_ids: Vec<i64> = albums.iter().map(|a| a.id).collect();
-            let genre_map = queries::genres_by_album_ids(&db.conn, &album_ids)
-                .map_err(|e| super::internal_error("db", e))?;
-            albums.retain(|a| {
-                genre_map
-                    .get(&a.id)
-                    .is_some_and(|genres| genres.iter().any(|ag| ag.contains(&g_lower)))
-            });
-        }
+            if favourites_only {
+                let fav_ids = queries::favourite_album_ids_batch(&db.conn)
+                    .map_err(|e| super::internal_error("db", e))?;
+                albums.retain(|a| fav_ids.contains(&a.id));
+            }
 
-        if favourites_only {
-            let fav_ids = queries::favourite_album_ids_batch(&db.conn)
-                .map_err(|e| super::internal_error("db", e))?;
-            albums.retain(|a| fav_ids.contains(&a.id));
-        }
+            match sort_by {
+                AlbumSortField::Title => albums.sort_by(|a, b| a.title.cmp(&b.title)),
+                AlbumSortField::Date => {
+                    albums.sort_by(|a, b| a.date.cmp(&b.date).then(a.title.cmp(&b.title)))
+                }
+                AlbumSortField::ArtistThenDate => albums.sort_by(|a, b| {
+                    a.artist_name
+                        .cmp(&b.artist_name)
+                        .then(a.date.cmp(&b.date))
+                        .then(a.title.cmp(&b.title))
+                }),
+                AlbumSortField::TrackCount => {
+                    let album_ids: Vec<i64> = albums.iter().map(|a| a.id).collect();
+                    let stats = queries::batch::album_stats(&db.conn, &album_ids)
+                        .map_err(|e| super::internal_error("db", e))?;
+                    let key = |id: i64| stats.get(&id).map(|s| s.track_count).unwrap_or(0);
+                    albums.sort_by(|a, b| key(a.id).cmp(&key(b.id)).then(a.title.cmp(&b.title)));
+                }
+            }
+            if sort_dir == SortDirection::Desc {
+                albums.reverse();
+            }
+
+            Ok(albums)
+        })
+        .await?;
 
         paginate(
-            albums.into_iter().map(|row| GqlAlbum { row }).collect(),
+            rows.into_iter().map(|row| GqlAlbum { row }).collect(),
             after,
             first,
         )
     }
 
+    /// Tracks matching the given filters.
+    ///
+    /// Every filter is a SQL predicate and the window is a `LIMIT`/`OFFSET`, so
+    /// the cost of a page is the page, not the library.
     #[allow(clippy::too_many_arguments)]
     async fn tracks(
         &self,
@@ -198,139 +255,69 @@ impl QueryRoot {
         #[graphql(default = false)] favourites_only: bool,
         after: Option<String>,
         first: Option<i32>,
-        #[graphql(default_with = "TrackSortField::ArtistAlbumDiscTrack")] _sort_by: TrackSortField,
-        #[graphql(default_with = "SortDirection::Asc")] _sort_dir: SortDirection,
+        #[graphql(default_with = "TrackSortField::ArtistAlbumDiscTrack")] sort_by: TrackSortField,
+        #[graphql(default_with = "SortDirection::Asc")] sort_dir: SortDirection,
     ) -> async_graphql::Result<Conn<GqlTrack>> {
-        let db = ctx.data::<DbHandle>()?.open()?;
-
-        let mut tracks = if let Some(ref query) = search {
-            queries::search_tracks_paged(&db.conn, query, 10000, 0)
-                .map_err(|e| super::internal_error("db", e))?
-        } else if let Some(album) = album_id {
-            queries::tracks_for_album(&db.conn, album)
-                .map_err(|e| super::internal_error("db", e))?
-        } else if let Some(ref aids) = artist_ids {
-            let mut all = Vec::new();
-            for &aid in aids {
-                let mut t = queries::tracks_for_artist(&db.conn, aid)
-                    .map_err(|e| super::internal_error("db", e))?;
-                all.append(&mut t);
-            }
-            all
-        } else if let Some(aid) = artist_id {
-            queries::tracks_for_artist(&db.conn, aid).map_err(|e| super::internal_error("db", e))?
-        } else {
-            queries::all_tracks(&db.conn).map_err(|e| super::internal_error("db", e))?
+        let artist_ids = match (artist_ids, artist_id) {
+            (Some(list), _) => Some(list),
+            (None, Some(one)) => Some(vec![one]),
+            (None, None) => None,
+        };
+        let filter = TrackFilter {
+            ids,
+            search,
+            album_id,
+            artist_ids,
+            title,
+            artist_name,
+            album_title,
+            genre,
+            codec,
+            source: source.map(|s| s.as_db_value().to_string()),
+            year_start,
+            year_end,
+            min_sample_rate,
+            min_bit_depth,
+            channels,
+            min_duration_ms,
+            max_duration_ms,
+            favourites_only,
         };
 
-        if let Some(ref id_list) = ids {
-            tracks.retain(|t| id_list.contains(&t.id));
-        }
+        let offset = page_offset(after.as_deref());
+        let limit = page_size(first);
+        let order = TrackOrder::from(sort_by);
+        let descending = sort_dir == SortDirection::Desc;
 
-        if let Some(ref t) = title {
-            let t_lower = t.to_lowercase();
-            tracks.retain(|tr| tr.title.to_lowercase().contains(&t_lower));
-        }
+        let rows = with_db(ctx, move |db| {
+            // One row past the page tells us whether a next page exists without
+            // a second COUNT(*) over the same predicate.
+            queries::batch::filter_tracks(
+                &db.conn,
+                &filter,
+                order,
+                descending,
+                limit as u32 + 1,
+                offset as u32,
+            )
+            .map_err(|e| super::internal_error("db", e))
+        })
+        .await?;
 
-        if let Some(ref a) = artist_name {
-            let a_lower = a.to_lowercase();
-            tracks.retain(|tr| {
-                tr.artist_name.to_lowercase().contains(&a_lower)
-                    || tr.album_artist_name.to_lowercase().contains(&a_lower)
-            });
-        }
-
-        if let Some(ref al) = album_title {
-            let al_lower = al.to_lowercase();
-            tracks.retain(|tr| tr.album_title.to_lowercase().contains(&al_lower));
-        }
-
-        if let Some(ref g) = genre {
-            let g_lower = g.to_lowercase();
-            tracks.retain(|tr| {
-                tr.genre
-                    .as_ref()
-                    .map(|tg| tg.to_lowercase().contains(&g_lower))
-                    .unwrap_or(false)
-            });
-        }
-
-        if let Some(ref c) = codec {
-            let c_lower = c.to_lowercase();
-            tracks.retain(|tr| {
-                tr.codec
-                    .as_ref()
-                    .map(|tc| tc.to_lowercase().contains(&c_lower))
-                    .unwrap_or(false)
-            });
-        }
-
-        if let Some(src) = source {
-            let src_str = match src {
-                TrackSource::Local => "local",
-                TrackSource::Remote => "remote",
-                TrackSource::Cached => "cached",
-            };
-            tracks.retain(|t| t.source == src_str);
-        }
-
-        if year_start.is_some() || year_end.is_some() {
-            tracks.retain(|t| {
-                let y = track_year(&db, t);
-                match y {
-                    Some(year) => {
-                        year_start.is_none_or(|ys| year >= ys)
-                            && year_end.is_none_or(|ye| year <= ye)
-                    }
-                    None => false,
-                }
-            });
-        }
-
-        if let Some(sr) = min_sample_rate {
-            tracks.retain(|t| t.sample_rate.map(|v| v >= sr).unwrap_or(false));
-        }
-
-        if let Some(bd) = min_bit_depth {
-            tracks.retain(|t| t.bit_depth.map(|v| v >= bd).unwrap_or(false));
-        }
-
-        if let Some(ch) = channels {
-            tracks.retain(|t| t.channels == Some(ch));
-        }
-
-        if let Some(min_d) = min_duration_ms {
-            tracks.retain(|t| t.duration_ms.map(|d| d >= min_d).unwrap_or(false));
-        }
-
-        if let Some(max_d) = max_duration_ms {
-            tracks.retain(|t| t.duration_ms.map(|d| d <= max_d).unwrap_or(false));
-        }
-
-        if favourites_only {
-            let fav_paths =
-                queries::load_favourites(&db.conn).map_err(|e| super::internal_error("db", e))?;
-            tracks.retain(|t| {
-                t.path
-                    .as_ref()
-                    .or(t.cached_path.as_ref())
-                    .map(|p| fav_paths.contains(std::path::Path::new(p)))
-                    .unwrap_or(false)
-            });
-        }
-
-        paginate(
-            tracks.into_iter().map(|row| GqlTrack { row }).collect(),
-            after,
-            first,
-        )
+        Ok(paginate_window(
+            rows.into_iter().map(|row| GqlTrack { row }).collect(),
+            offset,
+            limit,
+        ))
     }
 
     async fn track(&self, ctx: &Context<'_>, id: i64) -> async_graphql::Result<Option<GqlTrack>> {
-        let db = ctx.data::<DbHandle>()?.open()?;
-        let row =
-            queries::get_track_row(&db.conn, id).map_err(|e| super::internal_error("db", e))?;
-        Ok(row.map(|row| GqlTrack { row }))
+        with_db(ctx, move |db| {
+            let row =
+                queries::get_track_row(&db.conn, id).map_err(|e| super::internal_error("db", e))?;
+            Ok(row.map(|row| GqlTrack { row }))
+        })
+        .await
     }
 
     async fn random_tracks(
@@ -340,138 +327,67 @@ impl QueryRoot {
         artist_id: Option<i64>,
         artist_ids: Option<Vec<i64>>,
     ) -> async_graphql::Result<Vec<GqlTrack>> {
-        let db = ctx.data::<DbHandle>()?.open()?;
-
-        if let Some(ref aids) = artist_ids {
-            let mut all = Vec::new();
-            let per = (count as u32 / aids.len() as u32).max(1);
-            for &aid in aids {
-                let mut t = queries::random_tracks(&db.conn, per, Some(aid))
-                    .map_err(|e| super::internal_error("db", e))?;
-                all.append(&mut t);
-            }
-            all.truncate(count as usize);
-            Ok(all.into_iter().map(|row| GqlTrack { row }).collect())
-        } else {
-            let tracks = queries::random_tracks(&db.conn, count as u32, artist_id)
-                .map_err(|e| super::internal_error("db", e))?;
+        let count = count.clamp(0, MAX_PAGE as i32) as u32;
+        with_db(ctx, move |db| {
+            let tracks = if let Some(ref aids) = artist_ids {
+                let mut all = Vec::new();
+                let per = (count / aids.len().max(1) as u32).max(1);
+                for &aid in aids {
+                    let mut t = queries::random_tracks(&db.conn, per, Some(aid))
+                        .map_err(|e| super::internal_error("db", e))?;
+                    all.append(&mut t);
+                }
+                all.truncate(count as usize);
+                all
+            } else {
+                queries::random_tracks(&db.conn, count, artist_id)
+                    .map_err(|e| super::internal_error("db", e))?
+            };
             Ok(tracks.into_iter().map(|row| GqlTrack { row }).collect())
-        }
+        })
+        .await
     }
 
     async fn now_playing(&self, ctx: &Context<'_>) -> async_graphql::Result<GqlNowPlaying> {
         let state = ctx.data::<Arc<SharedPlayerState>>()?;
-        let playback_state = match state.playback_state() {
-            PlaybackState::Stopped => PlaybackStateEnum::Stopped,
-            PlaybackState::Playing => PlaybackStateEnum::Playing,
-            PlaybackState::Paused => PlaybackStateEnum::Paused,
-        };
-        let position_ms = state.position_ms();
-        let (track, queue_item_id, duration_ms) = if let Some(info) = state.track_info() {
-            let (items, _cursor) = state.snapshot_playlist();
-            let playlist_item = items.iter().find(|i| i.id == info.id);
-            let track = GqlNowPlayingTrack {
-                title: playlist_item.map(|i| i.title.clone()).unwrap_or_default(),
-                artist: playlist_item.map(|i| i.artist.clone()).unwrap_or_default(),
-                album: playlist_item.map(|i| i.album.clone()).unwrap_or_default(),
-                codec: info.codec.clone(),
-                sample_rate: info.sample_rate,
-                bit_depth: info.bit_depth,
-                bitrate_kbps: info.bitrate_kbps,
-                channels: info.channels,
-                duration_ms: info.duration_ms,
-            };
-            (
-                Some(track),
-                Some(info.id.0.to_string()),
-                Some(info.duration_ms),
-            )
-        } else {
-            (None, None, None)
-        };
-
-        Ok(GqlNowPlaying {
-            state: playback_state,
-            position_ms,
-            duration_ms,
-            track,
-            queue_item_id,
-        })
+        Ok(GqlNowPlaying::capture(state))
     }
 
     /// The play queue with derived entry statuses, download progress, and a version counter.
     async fn queue(&self, ctx: &Context<'_>) -> async_graphql::Result<GqlQueueSnapshot> {
         let state = ctx.data::<Arc<SharedPlayerState>>()?;
-        let version = state.playlist_version();
-        let snap = state.derive_visible_queue();
-
-        let entries = snap
-            .entries
-            .iter()
-            .map(|entry| {
-                use koan_core::player::state::QueueEntryStatus;
-
-                let status = match entry.status {
-                    QueueEntryStatus::Queued => GqlQueueEntryStatus::Queued,
-                    QueueEntryStatus::Playing => GqlQueueEntryStatus::Playing,
-                    QueueEntryStatus::Played => GqlQueueEntryStatus::Played,
-                    QueueEntryStatus::Downloading => GqlQueueEntryStatus::Downloading,
-                    QueueEntryStatus::PriorityPending => GqlQueueEntryStatus::PriorityPending,
-                    QueueEntryStatus::Failed => GqlQueueEntryStatus::Failed,
-                };
-
-                let download_progress = entry
-                    .download_progress
-                    .map(|(downloaded, total)| GqlDownloadProgress { downloaded, total });
-
-                GqlQueueEntry {
-                    queue_item_id: entry.id.0.to_string(),
-                    title: entry.title.clone(),
-                    artist: entry.artist.clone(),
-                    album: entry.album.clone(),
-                    codec: entry.codec.clone(),
-                    track_number: entry.track_number,
-                    disc: entry.disc,
-                    duration_ms: entry.duration_ms,
-                    is_current: entry.status == QueueEntryStatus::Playing,
-                    status,
-                    download_progress,
-                }
-            })
-            .collect();
-
-        Ok(GqlQueueSnapshot {
-            version,
-            entries,
-            finished_count: snap.finished_count as i32,
-            has_playing: snap.has_playing,
-            queue_count: snap.queue_count as i32,
-        })
+        Ok(GqlQueueSnapshot::capture(state))
     }
 
     async fn library_stats(&self, ctx: &Context<'_>) -> async_graphql::Result<GqlLibraryStats> {
-        let db = ctx.data::<DbHandle>()?.open()?;
-        let stats = queries::library_stats(&db.conn).map_err(|e| super::internal_error("db", e))?;
-        Ok(GqlLibraryStats {
-            total_tracks: stats.total_tracks,
-            local_tracks: stats.local_tracks,
-            remote_tracks: stats.remote_tracks,
-            cached_tracks: stats.cached_tracks,
-            total_albums: stats.total_albums,
-            total_artists: stats.total_artists,
+        with_db(ctx, |db| {
+            let stats =
+                queries::library_stats(&db.conn).map_err(|e| super::internal_error("db", e))?;
+            Ok(GqlLibraryStats {
+                total_tracks: stats.total_tracks,
+                local_tracks: stats.local_tracks,
+                remote_tracks: stats.remote_tracks,
+                cached_tracks: stats.cached_tracks,
+                total_albums: stats.total_albums,
+                total_artists: stats.total_artists,
+            })
         })
+        .await
     }
 
     async fn devices(&self) -> async_graphql::Result<Vec<GqlDevice>> {
-        let devices =
-            audio::list_output_devices().map_err(|e| super::internal_error("device", e))?;
-        Ok(devices
-            .iter()
-            .map(|d| GqlDevice {
-                name: d.name.clone(),
-                sample_rates: d.sample_rates.clone(),
-            })
-            .collect())
+        blocking(|| {
+            let devices =
+                audio::list_output_devices().map_err(|e| super::internal_error("device", e))?;
+            Ok(devices
+                .iter()
+                .map(|d| GqlDevice {
+                    name: d.name.clone(),
+                    sample_rates: d.sample_rates.clone(),
+                })
+                .collect())
+        })
+        .await
     }
 
     async fn favourites(
@@ -480,33 +396,47 @@ impl QueryRoot {
         after: Option<String>,
         first: Option<i32>,
     ) -> async_graphql::Result<Conn<GqlTrack>> {
-        let db = ctx.data::<DbHandle>()?.open()?;
-        let fav_paths =
-            queries::load_favourites(&db.conn).map_err(|e| super::internal_error("db", e))?;
-        let mut tracks = Vec::new();
-        for path in &fav_paths {
-            let path_str = path.to_string_lossy();
-            if let Ok(Some(tid)) = queries::track_id_by_path(&db.conn, &path_str)
-                && let Ok(Some(row)) = queries::get_track_row(&db.conn, tid)
-            {
-                tracks.push(GqlTrack { row });
-            }
-        }
-        paginate(tracks, after, first)
+        let offset = page_offset(after.as_deref());
+        let limit = page_size(first);
+        let rows = with_db(ctx, move |db| {
+            let filter = TrackFilter {
+                favourites_only: true,
+                ..Default::default()
+            };
+            queries::batch::filter_tracks(
+                &db.conn,
+                &filter,
+                TrackOrder::ArtistAlbumDiscTrack,
+                false,
+                limit as u32 + 1,
+                offset as u32,
+            )
+            .map_err(|e| super::internal_error("db", e))
+        })
+        .await?;
+
+        Ok(paginate_window(
+            rows.into_iter().map(|row| GqlTrack { row }).collect(),
+            offset,
+            limit,
+        ))
     }
 
     async fn snapshots(&self, ctx: &Context<'_>) -> async_graphql::Result<Vec<GqlSnapshot>> {
-        let db = ctx.data::<DbHandle>()?.open()?;
-        let list = queries::list_snapshots(&db.conn).map_err(|e| super::internal_error("db", e))?;
-        Ok(list
-            .into_iter()
-            .map(|s| GqlSnapshot {
-                name: s.name,
-                track_count: s.track_count as i32,
-                position_ms: s.position_ms,
-                created_at: s.created_at,
-            })
-            .collect())
+        with_db(ctx, |db| {
+            let list =
+                queries::list_snapshots(&db.conn).map_err(|e| super::internal_error("db", e))?;
+            Ok(list
+                .into_iter()
+                .map(|s| GqlSnapshot {
+                    name: s.name,
+                    track_count: s.track_count as i32,
+                    position_ms: s.position_ms,
+                    created_at: s.created_at,
+                })
+                .collect())
+        })
+        .await
     }
 
     async fn radio_status(&self, ctx: &Context<'_>) -> async_graphql::Result<GqlRadioStatus> {
@@ -521,21 +451,23 @@ impl QueryRoot {
         ctx: &Context<'_>,
         artist_id: i64,
     ) -> async_graphql::Result<Vec<GqlSimilarArtist>> {
-        let db = ctx.data::<DbHandle>()?.open()?;
-        let entries = queries::get_similar_artists_detailed(&db.conn, artist_id)
-            .map_err(|e| super::internal_error("db", e))?;
-        Ok(entries
-            .into_iter()
-            .map(|e| GqlSimilarArtist {
-                artist: GqlSimilarArtistInfo {
-                    id: e.artist.id,
-                    name: e.artist.name,
-                },
-                score: e.score,
-                source: e.source,
-                relationship: e.relationship,
-            })
-            .collect())
+        with_db(ctx, move |db| {
+            let entries = queries::get_similar_artists_detailed(&db.conn, artist_id)
+                .map_err(|e| super::internal_error("db", e))?;
+            Ok(entries
+                .into_iter()
+                .map(|e| GqlSimilarArtist {
+                    artist: GqlSimilarArtistInfo {
+                        id: e.artist.id,
+                        name: e.artist.name,
+                    },
+                    score: e.score,
+                    source: e.source,
+                    relationship: e.relationship,
+                })
+                .collect())
+        })
+        .await
     }
 
     async fn play_history(
@@ -544,28 +476,33 @@ impl QueryRoot {
         #[graphql(default = 50)] limit: i32,
         #[graphql(default = 0)] offset: i32,
     ) -> async_graphql::Result<Vec<GqlPlayHistoryEntry>> {
-        let db = ctx.data::<DbHandle>()?.open()?;
-        let entries = queries::get_play_history(&db.conn, limit as u32, offset as u32)
-            .map_err(|e| super::internal_error("db", e))?;
-        Ok(entries
-            .into_iter()
-            .map(|e| {
-                let track = queries::get_track_row(&db.conn, e.track_id)
-                    .ok()
-                    .flatten()
-                    .map(|t| GqlPlayHistoryTrack {
-                        title: t.title,
-                        artist: t.artist_name,
-                        album: t.album_title,
+        let limit = limit.clamp(0, MAX_PAGE as i32) as u32;
+        let offset = offset.max(0) as u32;
+        with_db(ctx, move |db| {
+            let entries = queries::get_play_history(&db.conn, limit, offset)
+                .map_err(|e| super::internal_error("db", e))?;
+            // One lookup for the whole page rather than one per entry.
+            let ids: Vec<i64> = entries.iter().map(|e| e.track_id).collect();
+            let by_id = tracks_by_id(db, ids)?;
+
+            Ok(entries
+                .into_iter()
+                .map(|e| {
+                    let track = by_id.get(&e.track_id).map(|t| GqlPlayHistoryTrack {
+                        title: t.title.clone(),
+                        artist: t.artist_name.clone(),
+                        album: t.album_title.clone(),
                     });
-                GqlPlayHistoryEntry {
-                    track_id: e.track_id,
-                    played_at: e.played_at,
-                    duration_ms: e.duration_ms,
-                    track,
-                }
-            })
-            .collect())
+                    GqlPlayHistoryEntry {
+                        track_id: e.track_id,
+                        played_at: e.played_at,
+                        duration_ms: e.duration_ms,
+                        track,
+                    }
+                })
+                .collect())
+        })
+        .await
     }
 
     async fn fuzzy_search(
@@ -575,78 +512,80 @@ impl QueryRoot {
         #[graphql(default_with = "FuzzySearchKind::Track")] kind: FuzzySearchKind,
         #[graphql(default = 50)] limit: i32,
     ) -> async_graphql::Result<Vec<GqlFuzzyMatch>> {
-        use nucleo::pattern::{CaseMatching, Normalization};
-        use nucleo::{Config, Nucleo};
+        let limit = limit.clamp(0, MAX_PAGE as i32) as usize;
+        with_db(ctx, move |db| {
+            use nucleo::pattern::{CaseMatching, Normalization};
+            use nucleo::{Config, Nucleo};
 
-        let db = ctx.data::<DbHandle>()?.open()?;
+            // Build (id, match_text) pairs based on kind.
+            let items: Vec<(i64, String)> = match kind {
+                FuzzySearchKind::Track => {
+                    let tracks = queries::all_tracks(&db.conn)
+                        .map_err(|e| super::internal_error("db", e))?;
+                    tracks
+                        .into_iter()
+                        .map(|t| {
+                            (
+                                t.id,
+                                format!("{} — {} — {}", t.artist_name, t.album_title, t.title),
+                            )
+                        })
+                        .collect()
+                }
+                FuzzySearchKind::Album => {
+                    let albums = queries::all_albums(&db.conn)
+                        .map_err(|e| super::internal_error("db", e))?;
+                    albums
+                        .into_iter()
+                        .map(|a| (a.id, format!("{} — {}", a.artist_name, a.title)))
+                        .collect()
+                }
+                FuzzySearchKind::Artist => {
+                    let artists = queries::all_artists(&db.conn)
+                        .map_err(|e| super::internal_error("db", e))?;
+                    artists.into_iter().map(|a| (a.id, a.name)).collect()
+                }
+            };
 
-        // Build (id, match_text) pairs based on kind.
-        let items: Vec<(i64, String)> = match kind {
-            FuzzySearchKind::Track => {
-                let tracks =
-                    queries::all_tracks(&db.conn).map_err(|e| super::internal_error("db", e))?;
-                tracks
-                    .into_iter()
-                    .map(|t| {
-                        (
-                            t.id,
-                            format!("{} — {} — {}", t.artist_name, t.album_title, t.title),
-                        )
-                    })
-                    .collect()
+            // Run nucleo fuzzy matching.
+            let mut nucleo: Nucleo<u32> =
+                Nucleo::new(Config::DEFAULT, std::sync::Arc::new(|| {}), None, 1);
+            let injector = nucleo.injector();
+            for (i, (_id, text)) in items.iter().enumerate() {
+                let text = text.clone();
+                injector.push(i as u32, |_val, cols| {
+                    cols[0] = text.into();
+                });
             }
-            FuzzySearchKind::Album => {
-                let albums =
-                    queries::all_albums(&db.conn).map_err(|e| super::internal_error("db", e))?;
-                albums
-                    .into_iter()
-                    .map(|a| (a.id, format!("{} — {}", a.artist_name, a.title)))
-                    .collect()
+
+            // Parse pattern and tick until matching settles.
+            nucleo
+                .pattern
+                .reparse(0, &query, CaseMatching::Smart, Normalization::Smart, false);
+            // Tick enough times for matching to complete on the dataset.
+            for _ in 0..20 {
+                nucleo.tick(10);
             }
-            FuzzySearchKind::Artist => {
-                let artists =
-                    queries::all_artists(&db.conn).map_err(|e| super::internal_error("db", e))?;
-                artists.into_iter().map(|a| (a.id, a.name)).collect()
-            }
-        };
 
-        // Run nucleo fuzzy matching.
-        let mut nucleo: Nucleo<u32> =
-            Nucleo::new(Config::DEFAULT, std::sync::Arc::new(|| {}), None, 1);
-        let injector = nucleo.injector();
-        for (i, (_id, text)) in items.iter().enumerate() {
-            let text = text.clone();
-            injector.push(i as u32, |_val, cols| {
-                cols[0] = text.into();
-            });
-        }
-
-        // Parse pattern and tick until matching settles.
-        nucleo
-            .pattern
-            .reparse(0, &query, CaseMatching::Smart, Normalization::Smart, false);
-        // Tick enough times for matching to complete on the dataset.
-        for _ in 0..20 {
-            nucleo.tick(10);
-        }
-
-        let snap = nucleo.snapshot();
-        let count = (snap.matched_item_count() as usize).min(limit as usize);
-        let mut results = Vec::with_capacity(count);
-        for i in 0..count as u32 {
-            if let Some(item) = snap.get_matched_item(i) {
-                let idx = *item.data as usize;
-                if idx < items.len() {
-                    results.push(GqlFuzzyMatch {
-                        id: items[idx].0,
-                        name: items[idx].1.clone(),
-                        rank: i as i32,
-                        kind,
-                    });
+            let snap = nucleo.snapshot();
+            let count = (snap.matched_item_count() as usize).min(limit);
+            let mut results = Vec::with_capacity(count);
+            for i in 0..count as u32 {
+                if let Some(item) = snap.get_matched_item(i) {
+                    let idx = *item.data as usize;
+                    if idx < items.len() {
+                        results.push(GqlFuzzyMatch {
+                            id: items[idx].0,
+                            name: items[idx].1.clone(),
+                            rank: i as i32,
+                            kind,
+                        });
+                    }
                 }
             }
-        }
-        Ok(results)
+            Ok(results)
+        })
+        .await
     }
 
     async fn lyrics(
@@ -654,26 +593,31 @@ impl QueryRoot {
         ctx: &Context<'_>,
         track_id: i64,
     ) -> async_graphql::Result<Option<GqlLyrics>> {
-        let db = ctx.data::<DbHandle>()?.open()?;
-        let track = queries::get_track_row(&db.conn, track_id)
-            .map_err(|e| super::internal_error("db", e))?
-            .ok_or_else(|| async_graphql::Error::new(format!("track {} not found", track_id)))?;
-        let duration_secs = track.duration_ms.map(|d| d as u64 / 1000).unwrap_or(0);
-        match koan_core::lyrics::fetch_lyrics(
-            &db.conn,
-            track_id,
-            &track.artist_name,
-            &track.title,
-            &track.album_title,
-            duration_secs,
-        ) {
-            Ok(lyrics) => Ok(Some(GqlLyrics {
-                content: lyrics.content,
-                synced: lyrics.synced,
-                source: format!("{:?}", lyrics.source),
-            })),
-            Err(_) => Ok(None),
-        }
+        with_db(ctx, move |db| {
+            let track = queries::get_track_row(&db.conn, track_id)
+                .map_err(|e| super::internal_error("db", e))?
+                .ok_or_else(|| {
+                    async_graphql::Error::new(format!("track {} not found", track_id))
+                })?;
+            let duration_secs = track.duration_ms.map(|d| d as u64 / 1000).unwrap_or(0);
+            // Falls through to a blocking LRCLIB fetch when nothing is cached.
+            match koan_core::lyrics::fetch_lyrics(
+                &db.conn,
+                track_id,
+                &track.artist_name,
+                &track.title,
+                &track.album_title,
+                duration_secs,
+            ) {
+                Ok(lyrics) => Ok(Some(GqlLyrics {
+                    content: lyrics.content,
+                    synced: lyrics.synced,
+                    source: format!("{:?}", lyrics.source),
+                })),
+                Err(_) => Ok(None),
+            }
+        })
+        .await
     }
 
     async fn similar_tracks(
@@ -682,19 +626,23 @@ impl QueryRoot {
         track_id: i64,
         #[graphql(default = 20)] limit: i32,
     ) -> async_graphql::Result<Vec<GqlSimilarTrack>> {
-        let db = ctx.data::<DbHandle>()?.open()?;
-        let results = queries::find_similar(&db.conn, track_id, limit as usize)
-            .map_err(|e| super::internal_error("db", e))?;
-        let mut out = Vec::with_capacity(results.len());
-        for (tid, dist) in results {
-            if let Ok(Some(row)) = queries::get_track_row(&db.conn, tid) {
-                out.push(GqlSimilarTrack {
-                    row,
-                    distance: dist as f64,
-                });
-            }
-        }
-        Ok(out)
+        let limit = limit.clamp(0, MAX_PAGE as i32) as usize;
+        with_db(ctx, move |db| {
+            let results = queries::find_similar(&db.conn, track_id, limit)
+                .map_err(|e| super::internal_error("db", e))?;
+            let by_id = tracks_by_id(db, results.iter().map(|(tid, _)| *tid).collect())?;
+
+            Ok(results
+                .into_iter()
+                .filter_map(|(tid, dist)| {
+                    by_id.get(&tid).map(|row| GqlSimilarTrack {
+                        row: row.clone(),
+                        distance: dist as f64,
+                    })
+                })
+                .collect())
+        })
+        .await
     }
 
     async fn cover_art(
@@ -702,35 +650,42 @@ impl QueryRoot {
         ctx: &Context<'_>,
         track_id: i64,
     ) -> async_graphql::Result<Option<GqlCoverArt>> {
-        use base64::Engine;
+        with_db(ctx, move |db| {
+            use base64::Engine;
 
-        let db = ctx.data::<DbHandle>()?.open()?;
-        let track = queries::get_track_row(&db.conn, track_id)
-            .map_err(|e| super::internal_error("db", e))?
-            .ok_or_else(|| async_graphql::Error::new(format!("track {} not found", track_id)))?;
-        let path = track
-            .path
-            .as_ref()
-            .or(track.cached_path.as_ref())
-            .ok_or_else(|| async_graphql::Error::new(format!("track {} has no path", track_id)))?;
+            let track = queries::get_track_row(&db.conn, track_id)
+                .map_err(|e| super::internal_error("db", e))?
+                .ok_or_else(|| {
+                    async_graphql::Error::new(format!("track {} not found", track_id))
+                })?;
+            let path = track
+                .path
+                .as_ref()
+                .or(track.cached_path.as_ref())
+                .ok_or_else(|| {
+                    async_graphql::Error::new(format!("track {} has no path", track_id))
+                })?;
 
-        match koan_core::index::metadata::extract_cover_art(std::path::Path::new(path)) {
-            Some(data) => {
-                let mime = if data.starts_with(&[0x89, 0x50, 0x4E, 0x47]) {
-                    "image/png"
-                } else if data.starts_with(&[0xFF, 0xD8]) {
-                    "image/jpeg"
-                } else {
-                    "application/octet-stream"
-                };
-                let encoded = base64::engine::general_purpose::STANDARD.encode(&data);
-                Ok(Some(GqlCoverArt {
-                    data_base64: encoded,
-                    mime: mime.into(),
-                }))
+            // Reads and parses the whole media file.
+            match koan_core::index::metadata::extract_cover_art(std::path::Path::new(path)) {
+                Some(data) => {
+                    let mime = if data.starts_with(&[0x89, 0x50, 0x4E, 0x47]) {
+                        "image/png"
+                    } else if data.starts_with(&[0xFF, 0xD8]) {
+                        "image/jpeg"
+                    } else {
+                        "application/octet-stream"
+                    };
+                    let encoded = base64::engine::general_purpose::STANDARD.encode(&data);
+                    Ok(Some(GqlCoverArt {
+                        data_base64: encoded,
+                        mime: mime.into(),
+                    }))
+                }
+                None => Ok(None),
             }
-            None => Ok(None),
-        }
+        })
+        .await
     }
 
     /// Current visualizer frame — spectrum, peaks, VU levels, beat energy, waveform.
@@ -762,37 +717,79 @@ impl QueryRoot {
         }))
     }
 
+    /// A background job started by `triggerScan` or `triggerRemoteSync`.
+    async fn job(&self, ctx: &Context<'_>, id: String) -> async_graphql::Result<Option<GqlJob>> {
+        let registry = ctx.data::<JobRegistry>()?;
+        Ok(registry.get(&id).map(GqlJob::from))
+    }
+
+    /// Background jobs started by this process, oldest first.
+    async fn jobs(&self, ctx: &Context<'_>) -> async_graphql::Result<Vec<GqlJob>> {
+        let registry = ctx.data::<JobRegistry>()?;
+        Ok(registry.list().into_iter().map(GqlJob::from).collect())
+    }
+
     /// Current configuration.
     async fn config(&self, ctx: &Context<'_>) -> async_graphql::Result<GqlConfig> {
-        let cfg = Config::load().unwrap_or_default();
-        let state = ctx.data::<Arc<SharedPlayerState>>()?;
-        Ok(GqlConfig {
-            library_folders: cfg
-                .library
-                .folders
-                .iter()
-                .map(|p| p.to_string_lossy().into_owned())
-                .collect(),
-            replaygain_mode: format!("{:?}", cfg.playback.replaygain).to_lowercase(),
-            pre_amp_db: cfg.playback.pre_amp_db,
-            output_device: cfg.playback.output_device.clone(),
-            target_fps: cfg.playback.target_fps as i32,
-            art_size: cfg.playback.art_size as i32,
-            remote_enabled: cfg.remote.enabled,
-            remote_url: cfg.remote.url.clone(),
-            remote_username: cfg.remote.username.clone(),
-            transcode_quality: cfg.remote.transcode_quality.clone(),
-            cache_limit: cfg.remote.cache_limit.clone(),
-            visualizer_fps: cfg.visualizer.fps as i32,
-            radio_enabled: state.radio_mode(),
-            graphql_port: cfg.graphql.port as i32,
-            graphql_playground: cfg.graphql.playground,
+        let radio_enabled = ctx.data::<Arc<SharedPlayerState>>()?.radio_mode();
+        blocking(move || {
+            let cfg = Config::load().unwrap_or_default();
+            Ok(GqlConfig {
+                library_folders: cfg
+                    .library
+                    .folders
+                    .iter()
+                    .map(|p| p.to_string_lossy().into_owned())
+                    .collect(),
+                replaygain_mode: format!("{:?}", cfg.playback.replaygain).to_lowercase(),
+                pre_amp_db: cfg.playback.pre_amp_db,
+                output_device: cfg.playback.output_device.clone(),
+                target_fps: cfg.playback.target_fps as i32,
+                art_size: cfg.playback.art_size as i32,
+                remote_enabled: cfg.remote.enabled,
+                remote_url: cfg.remote.url.clone(),
+                remote_username: cfg.remote.username.clone(),
+                transcode_quality: cfg.remote.transcode_quality.clone(),
+                cache_limit: cfg.remote.cache_limit.clone(),
+                visualizer_fps: cfg.visualizer.fps as i32,
+                radio_enabled,
+                graphql_port: cfg.graphql.port as i32,
+                graphql_playground: cfg.graphql.playground,
+            })
         })
+        .await
     }
 
     /// Playlist version counter — bumped on every mutation. Use for change detection.
     async fn playlist_version(&self, ctx: &Context<'_>) -> async_graphql::Result<u64> {
         let state = ctx.data::<Arc<SharedPlayerState>>()?;
         Ok(state.playlist_version())
+    }
+}
+
+/// Fetch a set of tracks by ID in one statement.
+fn tracks_by_id(
+    db: &koan_core::db::connection::Database,
+    ids: Vec<i64>,
+) -> async_graphql::Result<std::collections::HashMap<i64, queries::TrackRow>> {
+    let count = ids.len().max(1) as u32;
+    let filter = TrackFilter {
+        ids: Some(ids),
+        ..Default::default()
+    };
+    let rows = queries::batch::filter_tracks(&db.conn, &filter, TrackOrder::Title, false, count, 0)
+        .map_err(|e| super::internal_error("db", e))?;
+    Ok(rows.into_iter().map(|t| (t.id, t)).collect())
+}
+
+impl From<TrackSortField> for TrackOrder {
+    fn from(field: TrackSortField) -> Self {
+        match field {
+            TrackSortField::Title => TrackOrder::Title,
+            TrackSortField::Artist => TrackOrder::Artist,
+            TrackSortField::Album => TrackOrder::Album,
+            TrackSortField::Duration => TrackOrder::Duration,
+            TrackSortField::ArtistAlbumDiscTrack => TrackOrder::ArtistAlbumDiscTrack,
+        }
     }
 }

--- a/crates/koan-server/src/graphql/server.rs
+++ b/crates/koan-server/src/graphql/server.rs
@@ -50,6 +50,56 @@ pub fn cmd_serve(
 // Shared API server logic — used by both headless and TUI+API modes
 // ---------------------------------------------------------------------------
 
+/// Ceiling on a single GraphQL query. Anything genuinely longer than this —
+/// a library scan, a remote sync — runs as a job instead.
+const REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// Queries executing at once. Resolvers now do their SQLite and HTTP work on
+/// the blocking pool, so this bounds concurrent work rather than protecting the
+/// runtime's workers from it.
+const MAX_INFLIGHT_QUERIES: usize = 64;
+
+/// Timeout, panic catch and load shed for the query route.
+///
+/// Not applied to `/graphql/ws`: a subscription is meant to outlive any request
+/// timeout.
+fn load_perimeter<S>(router: axum::Router<S>) -> axum::Router<S>
+where
+    S: Clone + Send + Sync + 'static,
+{
+    router
+        // Innermost so it is inside the timeout: a panicking resolver becomes a
+        // 500 rather than a silently dropped connection.
+        .layer(tower_http::catch_panic::CatchPanicLayer::new())
+        .layer(tower_http::timeout::TimeoutLayer::with_status_code(
+            axum::http::StatusCode::REQUEST_TIMEOUT,
+            REQUEST_TIMEOUT,
+        ))
+        // Shed rather than queue. A concurrency limit on its own parks callers
+        // on a semaphore, so an overloaded server answers every client slowly
+        // instead of telling the surplus to come back.
+        .layer(
+            tower::ServiceBuilder::new()
+                .layer(axum::error_handling::HandleErrorLayer::new(
+                    |err: tower::BoxError| async move {
+                        if err.is::<tower::load_shed::error::Overloaded>() {
+                            (
+                                axum::http::StatusCode::SERVICE_UNAVAILABLE,
+                                "server at capacity",
+                            )
+                        } else {
+                            (
+                                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                                "internal error",
+                            )
+                        }
+                    },
+                ))
+                .load_shed()
+                .concurrency_limit(MAX_INFLIGHT_QUERIES),
+        )
+}
+
 /// Options for the API server — avoids too-many-arguments.
 pub struct ApiServerOpts {
     pub state: Arc<SharedPlayerState>,
@@ -163,8 +213,13 @@ fn run_api_blocking(opts: ApiServerOpts) -> Result<(), String> {
     let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
     rt.block_on(async {
         // GraphQL routes — protected by auth middleware.
+        //
+        // The query route carries the load perimeter; the WebSocket route does
+        // not, because a subscription is meant to outlive any request timeout.
+        let query_route = load_perimeter(axum::Router::new().route("/graphql", post(graphql_handler)));
+
         let gql_app = axum::Router::new()
-            .route("/graphql", post(graphql_handler))
+            .merge(query_route)
             .route("/graphql/ws", get(graphql_ws_handler))
             .layer(axum::middleware::from_fn_with_state(
                 auth_state.clone(),
@@ -176,7 +231,6 @@ fn run_api_blocking(opts: ApiServerOpts) -> Result<(), String> {
                 browser_policy.clone(),
                 browser_guard,
             ))
-            .layer(tower::limit::ConcurrencyLimitLayer::new(10))
             .with_state(schema);
 
         // Auth routes — always accessible (no auth middleware).
@@ -764,6 +818,34 @@ mod tests {
     async fn post_without_content_type_is_rejected() {
         let req = HttpRequest::post("/graphql").body(Body::empty()).unwrap();
         assert_eq!(run_browser(req).await, StatusCode::UNSUPPORTED_MEDIA_TYPE);
+    }
+
+    // -- Load perimeter --
+
+    #[tokio::test]
+    async fn load_perimeter_passes_requests_and_turns_panics_into_500s() {
+        async fn boom() -> &'static str {
+            panic!("resolver exploded");
+        }
+
+        let app = load_perimeter(
+            axum::Router::new()
+                .route("/graphql", post(ok))
+                .route("/boom", post(boom)),
+        );
+
+        let req = json_post("/graphql").body(Body::empty()).unwrap();
+        assert_eq!(
+            app.clone().oneshot(req).await.unwrap().status(),
+            StatusCode::OK
+        );
+
+        // Without CatchPanicLayer this drops the connection with nothing logged.
+        let req = json_post("/boom").body(Body::empty()).unwrap();
+        assert_eq!(
+            app.oneshot(req).await.unwrap().status(),
+            StatusCode::INTERNAL_SERVER_ERROR
+        );
     }
 
     #[tokio::test]

--- a/crates/koan-server/src/graphql/subscriptions.rs
+++ b/crates/koan-server/src/graphql/subscriptions.rs
@@ -5,7 +5,7 @@ use async_graphql::{Context, Subscription};
 use tokio_stream::Stream;
 
 use koan_core::audio::viz::VizSnapshot;
-use koan_core::player::state::{PlaybackState, QueueEntryStatus, SharedPlayerState};
+use koan_core::player::state::SharedPlayerState;
 
 use super::types::*;
 
@@ -38,54 +38,21 @@ impl SubscriptionRoot {
             let mut last_queue_item: Option<String> = None;
 
             loop {
-                let playback_state = state.playback_state();
+                let playback_state = state.playback_state() as u8;
                 let position_ms = state.position_ms();
-
-                let state_u8 = playback_state as u8;
                 let queue_item_id = state.track_info().map(|ti| ti.id.0.to_string());
 
                 // Emit on any change: state, position, or track.
-                let changed = state_u8 != last_state
+                let changed = playback_state != last_state
                     || position_ms != last_position
                     || queue_item_id != last_queue_item;
 
                 if changed {
-                    last_state = state_u8;
+                    last_state = playback_state;
                     last_position = position_ms;
-                    last_queue_item = queue_item_id.clone();
+                    last_queue_item = queue_item_id;
 
-                    let playback_enum = match playback_state {
-                        PlaybackState::Stopped => PlaybackStateEnum::Stopped,
-                        PlaybackState::Playing => PlaybackStateEnum::Playing,
-                        PlaybackState::Paused => PlaybackStateEnum::Paused,
-                    };
-
-                    let (track, duration_ms) = if let Some(info) = state.track_info() {
-                        let (items, _cursor) = state.snapshot_playlist();
-                        let playlist_item = items.iter().find(|i| i.id == info.id);
-                        let track = GqlNowPlayingTrack {
-                            title: playlist_item.map(|i| i.title.clone()).unwrap_or_default(),
-                            artist: playlist_item.map(|i| i.artist.clone()).unwrap_or_default(),
-                            album: playlist_item.map(|i| i.album.clone()).unwrap_or_default(),
-                            codec: info.codec.clone(),
-                            sample_rate: info.sample_rate,
-                            bit_depth: info.bit_depth,
-                            bitrate_kbps: info.bitrate_kbps,
-                            channels: info.channels,
-                            duration_ms: info.duration_ms,
-                        };
-                        (Some(track), Some(info.duration_ms))
-                    } else {
-                        (None, None)
-                    };
-
-                    yield GqlNowPlaying {
-                        state: playback_enum,
-                        position_ms,
-                        duration_ms,
-                        track,
-                        queue_item_id,
-                    };
+                    yield GqlNowPlaying::capture(&state);
                 }
 
                 tokio::time::sleep(interval).await;
@@ -111,49 +78,7 @@ impl SubscriptionRoot {
 
                 if version != last_version {
                     last_version = version;
-
-                    let snap = state.derive_visible_queue();
-                    let entries = snap
-                        .entries
-                        .iter()
-                        .map(|entry| {
-                            let status = match entry.status {
-                                QueueEntryStatus::Queued => GqlQueueEntryStatus::Queued,
-                                QueueEntryStatus::Playing => GqlQueueEntryStatus::Playing,
-                                QueueEntryStatus::Played => GqlQueueEntryStatus::Played,
-                                QueueEntryStatus::Downloading => GqlQueueEntryStatus::Downloading,
-                                QueueEntryStatus::PriorityPending => GqlQueueEntryStatus::PriorityPending,
-                                QueueEntryStatus::Failed => GqlQueueEntryStatus::Failed,
-                            };
-
-                            let download_progress =
-                                entry.download_progress.map(|(downloaded, total)| {
-                                    GqlDownloadProgress { downloaded, total }
-                                });
-
-                            GqlQueueEntry {
-                                queue_item_id: entry.id.0.to_string(),
-                                title: entry.title.clone(),
-                                artist: entry.artist.clone(),
-                                album: entry.album.clone(),
-                                codec: entry.codec.clone(),
-                                track_number: entry.track_number,
-                                disc: entry.disc,
-                                duration_ms: entry.duration_ms,
-                                is_current: entry.status == QueueEntryStatus::Playing,
-                                status,
-                                download_progress,
-                            }
-                        })
-                        .collect();
-
-                    yield GqlQueueSnapshot {
-                        version,
-                        entries,
-                        finished_count: snap.finished_count as i32,
-                        has_playing: snap.has_playing,
-                        queue_count: snap.queue_count as i32,
-                    };
+                    yield GqlQueueSnapshot::capture(&state);
                 }
 
                 tokio::time::sleep(interval).await;

--- a/crates/koan-server/src/graphql/types.rs
+++ b/crates/koan-server/src/graphql/types.rs
@@ -1,9 +1,16 @@
+use std::sync::Arc;
+
 use async_graphql::connection::{DisableNodesField, EmptyFields};
+use async_graphql::dataloader::DataLoader;
 use async_graphql::{Context, Enum, InputObject, Object, SimpleObject};
 use koan_core::db::queries;
+use koan_core::player::state::{PlaybackState, QueueEntryStatus, SharedPlayerState};
 
-use super::DbHandle;
 use super::helpers::paginate;
+use super::jobs::{Job, JobState};
+use super::loaders::{
+    AlbumStatsOf, AlbumTracks, ArtistAlbums, ArtistStatsOf, ArtistTracks, DbLoader, FavouritePath,
+};
 
 /// Connection type alias — standard async-graphql Connection with `nodes` field disabled.
 /// Exposes `edges` + `pageInfo` only (proper Relay spec).
@@ -33,6 +40,16 @@ pub(super) enum TrackSource {
     Local,
     Remote,
     Cached,
+}
+
+impl TrackSource {
+    pub(super) fn as_db_value(self) -> &'static str {
+        match self {
+            TrackSource::Local => "local",
+            TrackSource::Remote => "remote",
+            TrackSource::Cached => "cached",
+        }
+    }
 }
 
 #[derive(Enum, Copy, Clone, Eq, PartialEq)]
@@ -114,9 +131,10 @@ impl GqlArtist {
         after: Option<String>,
         first: Option<i32>,
     ) -> async_graphql::Result<Conn<GqlAlbum>> {
-        let db = ctx.data::<DbHandle>()?.open()?;
-        let all = queries::albums_for_artist(&db.conn, self.row.id)
-            .map_err(|e| super::internal_error("db", e))?;
+        let all = loader(ctx)?
+            .load_one(ArtistAlbums(self.row.id))
+            .await?
+            .unwrap_or_default();
         paginate(
             all.into_iter().map(|row| GqlAlbum { row }).collect(),
             after,
@@ -130,9 +148,10 @@ impl GqlArtist {
         after: Option<String>,
         first: Option<i32>,
     ) -> async_graphql::Result<Conn<GqlTrack>> {
-        let db = ctx.data::<DbHandle>()?.open()?;
-        let all = queries::tracks_for_artist(&db.conn, self.row.id)
-            .map_err(|e| super::internal_error("db", e))?;
+        let all = loader(ctx)?
+            .load_one(ArtistTracks(self.row.id))
+            .await?
+            .unwrap_or_default();
         paginate(
             all.into_iter().map(|row| GqlTrack { row }).collect(),
             after,
@@ -141,17 +160,19 @@ impl GqlArtist {
     }
 
     async fn album_count(&self, ctx: &Context<'_>) -> async_graphql::Result<i32> {
-        let db = ctx.data::<DbHandle>()?.open()?;
-        let albums = queries::albums_for_artist(&db.conn, self.row.id)
-            .map_err(|e| super::internal_error("db", e))?;
-        Ok(albums.len() as i32)
+        let stats = loader(ctx)?
+            .load_one(ArtistStatsOf(self.row.id))
+            .await?
+            .unwrap_or_default();
+        Ok(stats.album_count as i32)
     }
 
     async fn track_count(&self, ctx: &Context<'_>) -> async_graphql::Result<i32> {
-        let db = ctx.data::<DbHandle>()?.open()?;
-        let tracks = queries::tracks_for_artist(&db.conn, self.row.id)
-            .map_err(|e| super::internal_error("db", e))?;
-        Ok(tracks.len() as i32)
+        let stats = loader(ctx)?
+            .load_one(ArtistStatsOf(self.row.id))
+            .await?
+            .unwrap_or_default();
+        Ok(stats.track_count as i32)
     }
 }
 
@@ -199,9 +220,10 @@ impl GqlAlbum {
         after: Option<String>,
         first: Option<i32>,
     ) -> async_graphql::Result<Conn<GqlTrack>> {
-        let db = ctx.data::<DbHandle>()?.open()?;
-        let all = queries::tracks_for_album(&db.conn, self.row.id)
-            .map_err(|e| super::internal_error("db", e))?;
+        let all = loader(ctx)?
+            .load_one(AlbumTracks(self.row.id))
+            .await?
+            .unwrap_or_default();
         paginate(
             all.into_iter().map(|row| GqlTrack { row }).collect(),
             after,
@@ -210,17 +232,19 @@ impl GqlAlbum {
     }
 
     async fn track_count(&self, ctx: &Context<'_>) -> async_graphql::Result<i32> {
-        let db = ctx.data::<DbHandle>()?.open()?;
-        let tracks = queries::tracks_for_album(&db.conn, self.row.id)
-            .map_err(|e| super::internal_error("db", e))?;
-        Ok(tracks.len() as i32)
+        let stats = loader(ctx)?
+            .load_one(AlbumStatsOf(self.row.id))
+            .await?
+            .unwrap_or_default();
+        Ok(stats.track_count as i32)
     }
 
     async fn total_duration_ms(&self, ctx: &Context<'_>) -> async_graphql::Result<i64> {
-        let db = ctx.data::<DbHandle>()?.open()?;
-        let tracks = queries::tracks_for_album(&db.conn, self.row.id)
-            .map_err(|e| super::internal_error("db", e))?;
-        Ok(tracks.iter().filter_map(|t| t.duration_ms).sum())
+        let stats = loader(ctx)?
+            .load_one(AlbumStatsOf(self.row.id))
+            .await?
+            .unwrap_or_default();
+        Ok(stats.total_duration_ms)
     }
 }
 
@@ -315,17 +339,18 @@ impl GqlTrack {
     }
 
     async fn is_favourite(&self, ctx: &Context<'_>) -> async_graphql::Result<bool> {
-        let db = ctx.data::<DbHandle>()?.open()?;
-        let favs = queries::load_favourites(&db.conn)
-            .map_err(|e| async_graphql::Error::new(e.to_string()))?;
-        let path = self
-            .row
-            .path
-            .as_ref()
-            .or(self.row.cached_path.as_ref())
-            .map(std::path::PathBuf::from);
-        Ok(path.map(|p| favs.contains(&p)).unwrap_or(false))
+        let Some(path) = self.row.path.as_ref().or(self.row.cached_path.as_ref()) else {
+            return Ok(false);
+        };
+        Ok(loader(ctx)?
+            .load_one(FavouritePath(path.clone()))
+            .await?
+            .unwrap_or(false))
     }
+}
+
+fn loader<'a>(ctx: &'a Context<'_>) -> async_graphql::Result<&'a DataLoader<DbLoader>> {
+    ctx.data::<DataLoader<DbLoader>>()
 }
 
 #[derive(SimpleObject)]
@@ -350,6 +375,49 @@ pub(super) struct GqlNowPlayingTrack {
     pub bitrate_kbps: Option<u32>,
     pub channels: u16,
     pub duration_ms: u64,
+}
+
+impl GqlNowPlaying {
+    /// Read the player's current track. Shared by the `nowPlaying` query and
+    /// the subscription of the same name, which must not drift apart.
+    pub(super) fn capture(state: &Arc<SharedPlayerState>) -> Self {
+        let playback_state = match state.playback_state() {
+            PlaybackState::Stopped => PlaybackStateEnum::Stopped,
+            PlaybackState::Playing => PlaybackStateEnum::Playing,
+            PlaybackState::Paused => PlaybackStateEnum::Paused,
+        };
+        let position_ms = state.position_ms();
+
+        let Some(info) = state.track_info() else {
+            return Self {
+                state: playback_state,
+                position_ms,
+                duration_ms: None,
+                track: None,
+                queue_item_id: None,
+            };
+        };
+
+        let (items, _cursor) = state.snapshot_playlist();
+        let playlist_item = items.iter().find(|i| i.id == info.id);
+        Self {
+            state: playback_state,
+            position_ms,
+            duration_ms: Some(info.duration_ms),
+            track: Some(GqlNowPlayingTrack {
+                title: playlist_item.map(|i| i.title.clone()).unwrap_or_default(),
+                artist: playlist_item.map(|i| i.artist.clone()).unwrap_or_default(),
+                album: playlist_item.map(|i| i.album.clone()).unwrap_or_default(),
+                codec: info.codec.clone(),
+                sample_rate: info.sample_rate,
+                bit_depth: info.bit_depth,
+                bitrate_kbps: info.bitrate_kbps,
+                channels: info.channels,
+                duration_ms: info.duration_ms,
+            }),
+            queue_item_id: Some(info.id.0.to_string()),
+        }
+    }
 }
 
 pub(super) struct GqlQueueEntry {
@@ -530,12 +598,27 @@ pub(super) struct GqlOrganizeResult {
     pub skipped: i32,
 }
 
+/// A handle to work running on a detached thread. Poll it with the `job` query.
 #[derive(SimpleObject)]
-#[graphql(name = "ScanResult")]
-pub(super) struct GqlScanResult {
-    pub tracks_added: i64,
-    pub tracks_updated: i64,
-    pub tracks_unchanged: i64,
+#[graphql(name = "Job")]
+pub(super) struct GqlJob {
+    pub id: String,
+    /// What the job is doing — `scan` or `remoteSync`.
+    pub kind: String,
+    pub state: JobState,
+    /// Human-readable progress or outcome.
+    pub message: String,
+}
+
+impl From<Job> for GqlJob {
+    fn from(job: Job) -> Self {
+        Self {
+            id: job.id,
+            kind: job.kind,
+            state: job.state,
+            message: job.message,
+        }
+    }
 }
 
 #[derive(SimpleObject)]
@@ -631,6 +714,53 @@ pub(super) struct GqlQueueSnapshot {
     pub has_playing: bool,
     /// Number of entries after the cursor (queued).
     pub queue_count: i32,
+}
+
+impl GqlQueueSnapshot {
+    /// Read the derived queue. Shared by the `queue` query and the
+    /// `queueUpdated` subscription, which must not drift apart.
+    pub(super) fn capture(state: &Arc<SharedPlayerState>) -> Self {
+        let version = state.playlist_version();
+        let snap = state.derive_visible_queue();
+
+        let entries = snap
+            .entries
+            .iter()
+            .map(|entry| {
+                let status = match entry.status {
+                    QueueEntryStatus::Queued => GqlQueueEntryStatus::Queued,
+                    QueueEntryStatus::Playing => GqlQueueEntryStatus::Playing,
+                    QueueEntryStatus::Played => GqlQueueEntryStatus::Played,
+                    QueueEntryStatus::Downloading => GqlQueueEntryStatus::Downloading,
+                    QueueEntryStatus::PriorityPending => GqlQueueEntryStatus::PriorityPending,
+                    QueueEntryStatus::Failed => GqlQueueEntryStatus::Failed,
+                };
+                GqlQueueEntry {
+                    queue_item_id: entry.id.0.to_string(),
+                    title: entry.title.clone(),
+                    artist: entry.artist.clone(),
+                    album: entry.album.clone(),
+                    codec: entry.codec.clone(),
+                    track_number: entry.track_number,
+                    disc: entry.disc,
+                    duration_ms: entry.duration_ms,
+                    is_current: entry.status == QueueEntryStatus::Playing,
+                    status,
+                    download_progress: entry
+                        .download_progress
+                        .map(|(downloaded, total)| GqlDownloadProgress { downloaded, total }),
+                }
+            })
+            .collect();
+
+        Self {
+            version,
+            entries,
+            finished_count: snap.finished_count as i32,
+            has_playing: snap.has_playing,
+            queue_count: snap.queue_count as i32,
+        }
+    }
 }
 
 /// A single frame of visualizer data.

--- a/docs/guide/graphql-api.md
+++ b/docs/guide/graphql-api.md
@@ -132,7 +132,50 @@ Every query supports rich filtering:
 - **Tracks**: genre, codec, sample rate, bit depth, duration
 - **Artists**: genre
 
-All string filters are case-insensitive substrings. Relay-style cursor pagination is available on all collection queries.
+All string filters are case-insensitive substrings. `%` and `_` in a filter value are literal, not
+wildcards.
+
+### Pagination and sorting
+
+Collections are Relay connections (`edges` + `pageInfo`). **A collection with no `first` returns 50
+rows, and `first` is capped at 500** — the API will not hand back a whole library in one response.
+Page with the cursor from `pageInfo.endCursor`:
+
+```graphql
+{
+  tracks(first: 200, after: "199", sortBy: TITLE, sortDir: DESC) {
+    edges { cursor node { title } }
+    pageInfo { hasNextPage endCursor }
+  }
+}
+```
+
+`sortBy` accepts `TITLE`, `ARTIST`, `ALBUM`, `DURATION` or `ARTIST_ALBUM_DISC_TRACK` for tracks;
+`NAME`, `ALBUM_COUNT` or `TRACK_COUNT` for artists; `TITLE`, `DATE`, `ARTIST_THEN_DATE` or
+`TRACK_COUNT` for albums.
+
+### Long-running work
+
+`triggerScan` and `triggerRemoteSync` run for minutes, so they return a job handle immediately and
+do the work on a detached thread:
+
+```graphql
+mutation { triggerScan { id kind state } }
+{ job(id: "0199...") { state message } }
+```
+
+`state` is `RUNNING`, `SUCCEEDED` or `FAILED`; `message` carries the outcome. Only one job of each
+kind runs at a time — calling again while one is live returns the running job rather than starting a
+second.
+
+### Limits
+
+Requests are refused rather than queued when the server is saturated, so a slow client cannot make
+every other client slow:
+
+- query depth 12, complexity 2000
+- 30 second timeout on a query (`408`); subscriptions are exempt
+- 64 queries in flight, beyond which further requests get `503` immediately
 
 ## Available operations
 


### PR DESCRIPTION
## What breaks today

A GraphQL query stalls audio in every connected Subsonic client.

rusqlite is blocking end to end and there was not one `spawn_blocking` in the workspace, so every
resolver ran its SQLite work directly on a tokio worker. On a 4-core box, four concurrent
`{ fuzzySearch(query:"a") { id } }` take all four workers; the `ReaderStream` feeding every in-flight
`/rest/stream` response then stops producing bytes and clients drop the connection mid-track. One
`triggerScan` — a full walkdir + rayon + SQLite scan, inline in an `async fn` — does it single-handedly
for the length of the scan.

Underneath that, `DbHandle::open()` called `Database::open` **per resolver field**: `create_dir_all`, a
`chmod(0o600)`, four pragmas, a WAL checkpoint, a ~70-statement DDL batch and three migrations that are
expected to fail and are matched by string comparison on the error message.

## Before / after

Nested `artists { albumCount trackCount albums { trackCount totalDurationMs tracks { isFavourite } } } }`
over 10 artists / 30 albums / 120 tracks:

| | before | after |
|---|---|---|
| `Database::open` cycles | 241 (1 + 3/artist + 3/album + 1/track) | **2** |
| SQL statements from opening alone | ~17,000 | ~140 |
| WAL checkpoint attempts | 241 | 2 |
| `chmod` syscalls | 241 | 1 |
| queries for the child edges | 241 | **5 dataloader batches** |

`{ tracks(first: 500) { isFavourite } }` was 500 connection opens and 500 unfiltered
`SELECT track_path FROM favourites` table scans; it is now one batched query.

`{ tracks(...) }` with no `albumId`/`artistId` loaded every row via `all_tracks()` and filtered in Rust,
running `SELECT date FROM albums WHERE id = ?` once per track in the library for a year filter. Filters,
ordering and the page window are now SQL with bound parameters.

## What changed

**Runtime**
- Small SQLite connection pool sized to the core count (4–16), lazily filled. Not a `Mutex<Connection>` —
  WAL gives concurrent readers and one slow query must not block every client.
- `Database::open_existing` applies pragmas only; the DDL and migrations run once at startup.
- `with_db` / `blocking` put every rusqlite call, LRCLIB fetch, cover-art decode and device enumeration
  on the blocking pool. No lock guard is held across an `.await`.
- `send_cmd` uses `send_timeout(250ms)` and returns "player busy" rather than parking a worker on the
  bounded(16) player channel.

**N+1**
- `async_graphql` dataloaders for artist→albums, artist→tracks, album→tracks and favourites, batching
  only (cache disabled — a schema-wide loader outlives the request and the library changes under it).
- `Album.trackCount`/`totalDurationMs` and `Artist.albumCount`/`trackCount` are `COUNT(*)`/`SUM(...)`
  in SQLite instead of materialising every row.

**Pagination** — `DEFAULT_PAGE = 50`, `MAX_PAGE = 500`, `first` clamped with `f.max(0)`.
`first: -1` overflowed the arithmetic: a panic in debug, the whole library in release.

**Perimeter** — the query route (not `/graphql/ws`, which must outlive a request) gets a 30s
`TimeoutLayer`, `CatchPanicLayer`, and `LoadShedLayer` so surplus load gets a `503` instead of queueing
behind a shared semaphore. Concurrency raised 10 → 64 now that resolvers do not hold workers.

**Long-running work** — `triggerScan` and `triggerRemoteSync` return a `Job` and run on a detached
thread with a connection taken outside the pool. Polled with `job(id:)` / `jobs`. One job per kind at a
time; a second call returns the running one.

**`sortBy` / `sortDir`** were declared, published in the SDL and to MCP, and dropped on the floor. They
are implemented — in SQL for tracks, in Rust for artists/albums.

### Breaking

- Collections with no `first` return 50 rows, not everything.
- `triggerScan`/`triggerRemoteSync` return `Job`, not `ScanResult`/`Status`. Counts arrive in the
  finished job's `message`. No in-repo client consumes these; the TUI's remote bridge does not use them.

## How to check it

`cargo test --workspace` — 759 passing (743 on main). The tests that would have caught this:

- `a_slow_query_does_not_stall_other_tasks` — four concurrent `fuzzySearch` calls on a **single-threaded**
  runtime alongside a 1ms ticker; asserts other tasks still ran. Verified it fails with the message
  "no other task ran while the queries were in flight" when `spawn_blocking` is removed.
- `nested_fan_out_opens_a_bounded_number_of_connections` — 10 artists × 3 albums × 4 tracks through the
  full nested query, asserts ≤ 16 connection opens off an instrumented pool counter. The existing
  `nested_artist_albums_tracks` uses one artist and one album, which is why it passed in milliseconds.
- `is_favourite_batches_into_one_query` — 100 tracks, asserts the batch count does not track the row count.
- `tracks_without_first_returns_the_default_page`, `first_is_clamped_to_the_maximum_page`,
  `negative_first_is_empty_not_a_panic`, `sort_arguments_are_honoured`.
- `load_perimeter_passes_requests_and_turns_panics_into_500s` — exercises the real layer stack, extracted
  into `load_perimeter()` so the test cannot drift from the server.
- `db::queries::batch` — SQL filtering pushes `LIMIT` down, escapes `%`/`_` in user substrings, composes
  FTS with the other predicates, and the aggregates match materialised counts.

## Dependencies

No new crates. Enabled `async-graphql/dataloader` (pulls `lru`, `futures-channel`) and
`tower-http/{catch-panic,timeout}`. `cargo audit` exits 0.

## Not in scope

`crates/koan-server/src/subsonic.rs` is owned by another agent and untouched. It opens a `Database` per
request on the same blocking-in-async pattern and would benefit from the same pool — worth a follow-up
once both land.
