### PR TITLE
fix(audio): drop the mutex from the Linux audio callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,15 @@
 
 ### Fixed
 
+- **The Linux audio callback took a mutex on every buffer.** The rtrb consumer was wrapped in a
+  `std::sync::Mutex` so it could move into cpal's `FnMut` callback — but `rtrb::Consumer` is already
+  `Send` and the callback bound is `FnMut + Send`, so a by-value capture was always enough. The lock
+  cost an atomic read-modify-write per callback on the real-time thread, and its `try_lock` failure
+  path filled the buffer with silence: an audible dropout reachable only through a contention that
+  could not occur.
+- **A panicking background job poisoned the job registry** for every later lookup, and a poisoned
+  decode cursor silently stopped the gapless lookahead — stalling the queue with no error rather than
+  failing loudly. Both now use `parking_lot`, which the project's own primitive table specifies.
 - **A GraphQL query could stall audio in every connected Subsonic client.** rusqlite is blocking and
   nothing in the server ran it off the async runtime, so resolvers occupied tokio workers directly.
   Four concurrent `fuzzySearch` calls on a 4-core box took every worker, the `ReaderStream` feeding

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2586,6 +2586,7 @@ dependencies = [
  "log",
  "md5",
  "nucleo",
+ "parking_lot",
  "reqwest",
  "rmcp",
  "rusqlite",

--- a/crates/koan-core/src/audio/cpal_backend.rs
+++ b/crates/koan-core/src/audio/cpal_backend.rs
@@ -187,11 +187,9 @@ impl AudioBackend for CpalBackend {
         let running = Arc::new(AtomicBool::new(false));
         let running_cb = running.clone();
 
-        // Wrap consumer in a Mutex so we can move it into the FnMut callback.
-        // RT safety: use try_lock() only — never block the audio thread.
-        // Contention is effectively zero (only this callback touches it),
-        // but try_lock guarantees we never block even if the OS preempts us.
-        let consumer = std::sync::Mutex::new(consumer);
+        // The consumer is owned outright by the callback: rtrb::Consumer is Send,
+        // and cpal's data callback is FnMut, so a by-value capture is enough.
+        let mut consumer = consumer;
 
         let stream = suppress_stderr(|| {
             dev.build_output_stream(
@@ -201,13 +199,6 @@ impl AudioBackend for CpalBackend {
                         data.fill(0.0);
                         return;
                     }
-
-                    let Ok(mut consumer) = consumer.try_lock() else {
-                        // Lock contested — output silence rather than blocking
-                        // the real-time audio thread.
-                        data.fill(0.0);
-                        return;
-                    };
 
                     let total_samples = data.len();
                     let available = consumer.slots();

--- a/crates/koan-core/src/player/mod.rs
+++ b/crates/koan-core/src/player/mod.rs
@@ -351,13 +351,12 @@ impl Player {
         // (separate from the UI cursor) so it can look ahead through the
         // playlist without affecting what the UI shows as "now playing".
         let advance_state = self.shared_state.clone();
-        let decode_cursor = std::sync::Mutex::new(Some(id));
+        let decode_cursor = parking_lot::Mutex::new(Some(id));
         let next_track = move || {
-            let current = decode_cursor.lock().ok()?.take()?;
+            let current = decode_cursor.lock().take()?;
             let next = advance_state.peek_next_ready_after(current);
-            if let Some((next_id, _)) = &next
-                && let Ok(mut guard) = decode_cursor.lock()
-            {
+            if let Some((next_id, _)) = &next {
+                let mut guard = decode_cursor.lock();
                 *guard = Some(*next_id);
             }
             next
@@ -581,13 +580,12 @@ impl Player {
 
         // Gapless lookahead after streaming: next track uses normal file path.
         let advance_state = self.shared_state.clone();
-        let decode_cursor = std::sync::Mutex::new(Some(id));
+        let decode_cursor = parking_lot::Mutex::new(Some(id));
         let next_track = move || {
-            let current = decode_cursor.lock().ok()?.take()?;
+            let current = decode_cursor.lock().take()?;
             let next = advance_state.peek_next_ready_after(current);
-            if let Some((next_id, _)) = &next
-                && let Ok(mut guard) = decode_cursor.lock()
-            {
+            if let Some((next_id, _)) = &next {
+                let mut guard = decode_cursor.lock();
                 *guard = Some(*next_id);
             }
             next

--- a/crates/koan-server/Cargo.toml
+++ b/crates/koan-server/Cargo.toml
@@ -20,6 +20,7 @@ image = { version = "0.25", default-features = false, features = ["jpeg", "png",
 koan-core = { workspace = true }
 log = "0.4"
 nucleo = "0.5"
+parking_lot = "0.12"
 md5 = "0.8"
 reqwest = { workspace = true, features = ["stream"] }
 rmcp = { version = "3.1", features = ["server", "macros", "transport-async-rw", "transport-io"] }

--- a/crates/koan-server/src/graphql/jobs.rs
+++ b/crates/koan-server/src/graphql/jobs.rs
@@ -6,7 +6,9 @@
 //! on the same process is unaffected.
 
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+
+use parking_lot::Mutex;
 
 use async_graphql::Enum;
 use uuid::Uuid;
@@ -42,7 +44,7 @@ impl JobRegistry {
     /// Two concurrent scans of the same library fight over the same rows, so
     /// the second caller gets the first job's handle instead of a second scan.
     pub(super) fn start(&self, kind: &str) -> Result<Job, Job> {
-        let mut jobs = self.inner.lock().expect("job registry poisoned");
+        let mut jobs = self.inner.lock();
         if let Some(running) = jobs
             .values()
             .find(|j| j.kind == kind && j.state == JobState::Running)
@@ -70,7 +72,7 @@ impl JobRegistry {
     }
 
     pub(super) fn finish(&self, id: &str, state: JobState, message: String) {
-        let mut jobs = self.inner.lock().expect("job registry poisoned");
+        let mut jobs = self.inner.lock();
         if let Some(job) = jobs.get_mut(id) {
             job.state = state;
             job.message = message;
@@ -78,21 +80,11 @@ impl JobRegistry {
     }
 
     pub(super) fn get(&self, id: &str) -> Option<Job> {
-        self.inner
-            .lock()
-            .expect("job registry poisoned")
-            .get(id)
-            .cloned()
+        self.inner.lock().get(id).cloned()
     }
 
     pub(super) fn list(&self) -> Vec<Job> {
-        let mut jobs: Vec<Job> = self
-            .inner
-            .lock()
-            .expect("job registry poisoned")
-            .values()
-            .cloned()
-            .collect();
+        let mut jobs: Vec<Job> = self.inner.lock().values().cloned().collect();
         jobs.sort_by(|a, b| a.id.cmp(&b.id));
         jobs
     }


### PR DESCRIPTION
## The real-time one

`cpal_backend.rs` wrapped the rtrb consumer in a `std::sync::Mutex`, with this justification:

> Wrap consumer in a Mutex so we can move it into the FnMut callback.

That isn't true. `rtrb::Consumer<f32>` is `Send` (`rtrb/src/lib.rs` — `unsafe impl<T: Send> Send for Consumer<T>`), and cpal's data callback is `FnMut(&mut [f32], &_) + Send + 'static`, which a by-value `mut` capture satisfies. The consumer can simply be owned by the closure.

Two costs, on the one thread in this codebase that must never block:

- an atomic read-modify-write on **every** audio callback
- a `try_lock` failure path that fills the buffer with **silence** — an audible dropout reachable only through contention that cannot occur, since nothing else ever touches the consumer

The CoreAudio backend never had this; it owns its consumer directly. This brings the two backends into line.

## The poison ones

`graphql/jobs.rs` used `.expect("job registry poisoned")`, so a single panicking background job would take **every subsequent job lookup** down with it. The decode-thread cursor in `player/mod.rs` fails the other way: `.lock().ok()?` means a poisoned cursor silently stops the gapless lookahead, stalling the queue with no error at all.

Both now use `parking_lot`, which has no poisoning and which the project's own sync-primitive table in `CLAUDE.md` already specifies. `auth/routes.rs` is left alone — it already handles poison correctly with `unwrap_or_else(|e| e.into_inner())`.

An audit put the remaining `std::sync::Mutex` sites at roughly a third of all non-test panic sites in the workspace. The rest are deliberately not in this PR: `streaming.rs` pairs its mutex with a `std::sync::Condvar` and was just reworked in #205, and `helpers.rs`'s `log_buf` is part of koan-core's public signature and the `BufferedLogger` sink, so converting it ripples through four crates. Both want their own change.

## Verification, honestly

`cargo clippy --workspace --all-targets -- -D warnings` and `cargo test --workspace` are clean, and the job-registry and decode-cursor changes are covered by the existing suites.

**The cpal change is not compiled locally** — it's behind `cfg(target_os = "linux")` and I'm on macOS. I tried cross-checking with `--target x86_64-unknown-linux-gnu` and it fails at `alsa-sys` and `aws-lc-sys`, which need a Linux sysroot. **CI's ubuntu Build/Clippy/Test jobs are the verification for that hunk**, and nobody has heard audio out of it either way — the Linux backend has never been listened to in this session's work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PcSS6nwxDTpjT2BCMB18V2