### PR TITLE
test(graphql): assert the dataloader invariant, not an exact batch count

### DIFF
--- a/crates/koan-server/src/graphql/mod.rs
+++ b/crates/koan-server/src/graphql/mod.rs
@@ -910,11 +910,15 @@ mod tests {
         let data = resp.data.into_json().unwrap();
         assert_eq!(data["tracks"]["edges"].as_array().unwrap().len(), 100);
 
-        // One batch for all 100 tracks, not one full `favourites` scan each.
-        // Allow a second in case the gather window closes mid-selection under
-        // load; what must not happen is a count that tracks the row count.
+        // The invariant is that the query count does not scale with the row
+        // count: without the dataloader this was one full `favourites` scan per
+        // track. The dataloader's gather window can close more than once under
+        // load, so assert the property rather than an exact batch count.
         let batches = handle.batch_count() - before;
-        assert!(batches <= 2, "{} batches for 100 tracks", batches);
+        assert!(
+            batches < 10,
+            "{batches} batches for 100 tracks — expected a handful, not one per row"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
`is_favourite_batches_into_one_query` asserted `batches <= 2` for 100 tracks and **failed on a macOS runner during #211's CI** with "3 batches for 100 tracks".

The dataloader's gather window is timing-dependent — the test's own comment already conceded a second batch was possible "in case the gather window closes mid-selection under load". Three is the same phenomenon one step further. So the test failed while demonstrating exactly the behaviour it exists to verify.

The property worth defending is that **the query count does not scale with the row count**. Before #209's dataloader, `isFavourite` ran one full `SELECT track_path FROM favourites` scan *per track* — 100 tracks meant 100 full table scans. Three batches disproves that as convincingly as one does; a hundred does not.

Bound is now `< 10`, with the reasoning in the comment. That still fails loudly on any regression to per-row querying, and stops failing on runner load.

The agent that hit this correctly declined to widen someone else's assertion on one datapoint and flagged it instead. Picking it up here because a flaky test on `main` makes release CI untrustworthy, and a release is next.

Ran 5/5 green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PcSS6nwxDTpjT2BCMB18V2