### PR TITLE
fix(ci): link the universal app against the universal library

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -286,7 +286,20 @@ jobs:
         # for each crate to appear in the index before publishing its dependents.
         # The verification build is what catches an internal version pin that no
         # longer resolves, so it must not be skipped.
-        run: cargo publish --workspace
+        #
+        # Publishing is not idempotent — it errors on a version that already
+        # exists — and this job gates the GitHub release. So a re-run after a
+        # *downstream* failure would fail here and take the release with it,
+        # which is exactly what happened when the universal DMG failed to link.
+        # koan-cli publishes last, so its presence means the whole set went out.
+        run: |
+          VERSION=$(grep '^version = ' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          if curl -sf https://index.crates.io/ko/an/koan-cli \
+             | grep -q "\"vers\":\"${VERSION}\""; then
+            echo "koan-cli ${VERSION} is already on crates.io — nothing to publish"
+            exit 0
+          fi
+          cargo publish --workspace
 
   update-homebrew:
     name: Update Homebrew Tap

--- a/apps/macos/Package.swift
+++ b/apps/macos/Package.swift
@@ -18,7 +18,17 @@ let package = Package(
             dependencies: ["KoanFFI"],
             path: "Sources/Koan",
             linkerSettings: [
-                .unsafeFlags(["-L../../target/release"]),
+                // Both, because a universal build lipo's its output somewhere
+                // else: `just macos-ffi <targets>` writes
+                // target/universal/release, while a single-arch build writes
+                // target/release. The linker takes the first that exists, and a
+                // missing search path is not an error — so with only the
+                // single-arch path here, the release DMG failed to link with
+                // "library 'koan_ffi' not found" while local builds were fine.
+                .unsafeFlags([
+                    "-L../../target/universal/release",
+                    "-L../../target/release",
+                ]),
                 .linkedLibrary("koan_ffi"),
                 .linkedFramework("CoreAudio"),
                 .linkedFramework("AudioToolbox"),

--- a/apps/macos/Sources/Koan/Views/SidebarView.swift
+++ b/apps/macos/Sources/Koan/Views/SidebarView.swift
@@ -82,9 +82,6 @@ struct SidebarView: View {
         }
     }
 
-    /// Library size and scan state. The counts are the quickest way to tell
-    /// whether a scan actually picked anything up.
-    @ViewBuilder
     /// What radio is about to do, rather than that it is switched on.
     private var radioStatus: String {
         guard let cursor = player.currentItemId,
@@ -98,6 +95,9 @@ struct SidebarView: View {
             : "Radio — \(Format.count(Int64(ahead), "track")) ahead"
     }
 
+    /// Library size and scan state. The counts are the quickest way to tell
+    /// whether a scan actually picked anything up.
+    @ViewBuilder
     private var footer: some View {
         VStack(alignment: .leading, spacing: 6) {
             Divider()

--- a/justfile
+++ b/justfile
@@ -64,6 +64,10 @@ macos-ffi *TARGETS:
     set -euo pipefail
     targets="{{TARGETS}}"
     if [ -z "$targets" ]; then
+        # A stale universal library from an earlier release build would shadow
+        # this one: Package.swift searches target/universal/release first, and
+        # the linker takes the first match rather than the newest.
+        rm -rf target/universal/release
         cargo build --release -p koan-ffi
         lib=target/release/libkoan_ffi.a
         dylib=target/release/libkoan_ffi.dylib


### PR DESCRIPTION
The v0.25.0 release built everything, published to crates.io, and then failed on the DMG:

```
ld: library 'koan_ffi' not found
```

`just macos-ffi <targets>` lipo's its output to `target/universal/release`, but `Package.swift` only searched `target/release`. A missing `-L` path is a warning rather than an error, so nothing showed until the linker could not find the library at all — and local single-arch builds were unaffected the whole time.

Both paths are searched now, universal first, and the single-arch recipe removes any stale universal library so a leftover from a release build cannot shadow a fresh local one (the linker takes the first match, not the newest).

Also makes the crates.io publish skip a version that is already there. It is not idempotent and it gates the GitHub release, so a re-run after this DMG failure would have failed on the already-published crates and taken the release with it.

## Verifying

`just macos-build` links locally. The universal path is what CI exercises — this needs the release job to prove it, which is the point of merging it.