### PR TITLE
fix(macos): link the app against the archive, not cargo's dylib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.25.1 (2026-08-23)
+
+### Fixed
+
+- **The v0.25.0 macOS app could not launch.** `-lkoan_ffi` over cargo's output directory finds the `.dylib` next to the archive and prefers it, so the shipped app referenced `/Users/runner/work/koan/koan/target/release/deps/libkoan_ffi.dylib` — a path that exists only on the CI runner — and was arm64-only, the host dylib having won over the universal archive. `just macos-ffi` now stages the right archive in a directory holding nothing else, which cannot produce either outcome. The bundled binary goes from 3.4 MB to 20 MB, which is the engine actually being in it.
+
 ## v0.25.0 (2026-08-23)
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2715,7 +2715,7 @@ dependencies = [
 
 [[package]]
 name = "koan-cli"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "chrono",
  "clap",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "koan-core"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "argon2",
  "bliss-audio",
@@ -2780,7 +2780,7 @@ dependencies = [
 
 [[package]]
 name = "koan-ffi"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "crossbeam-channel",
  "getrandom 0.4.3",
@@ -2796,7 +2796,7 @@ dependencies = [
 
 [[package]]
 name = "koan-server"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",
@@ -2829,7 +2829,7 @@ dependencies = [
 
 [[package]]
 name = "koan-tui"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "core-foundation 0.10.1",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/koan-core", "crates/koan-ffi", "crates/koan-server", "crates/koan-tui", "crates/koan-cli"]
 
 [workspace.package]
-version = "0.25.0"
+version = "0.25.1"
 edition = "2024"
 rust-version = "1.89"
 homepage = "https://github.com/radiosilence/koan"
@@ -13,9 +13,9 @@ license = "MIT"
 [workspace.dependencies]
 # Internal crates. Keep the version in step with [workspace.package] above —
 # a stale pin here publishes members that resolve against the wrong sibling.
-koan-core = { path = "crates/koan-core", version = "0.25.0" }
-koan-server = { path = "crates/koan-server", version = "0.25.0" }
-koan-tui = { path = "crates/koan-tui", version = "0.25.0" }
+koan-core = { path = "crates/koan-core", version = "0.25.1" }
+koan-server = { path = "crates/koan-server", version = "0.25.1" }
+koan-tui = { path = "crates/koan-tui", version = "0.25.1" }
 # Feature set is the union every member needs; `default-tls` is an alias for
 # `rustls`, so there is exactly one TLS stack.
 reqwest = { version = "0.13", default-features = false, features = [

--- a/apps/macos/Package.swift
+++ b/apps/macos/Package.swift
@@ -18,17 +18,13 @@ let package = Package(
             dependencies: ["KoanFFI"],
             path: "Sources/Koan",
             linkerSettings: [
-                // Both, because a universal build lipo's its output somewhere
-                // else: `just macos-ffi <targets>` writes
-                // target/universal/release, while a single-arch build writes
-                // target/release. The linker takes the first that exists, and a
-                // missing search path is not an error — so with only the
-                // single-arch path here, the release DMG failed to link with
-                // "library 'koan_ffi' not found" while local builds were fine.
-                .unsafeFlags([
-                    "-L../../target/universal/release",
-                    "-L../../target/release",
-                ]),
+                // `just macos-ffi` stages the right archive here — the host
+                // one, or the lipo'd universal one for a release — and nothing
+                // else. Pointing at cargo's own output directory instead gave
+                // the linker a .dylib alongside the .a, which it prefers: the
+                // app then referenced a library by absolute path inside the
+                // build tree and could not launch anywhere else.
+                .unsafeFlags(["-L../../target/swift-link"]),
                 .linkedLibrary("koan_ffi"),
                 .linkedFramework("CoreAudio"),
                 .linkedFramework("AudioToolbox"),

--- a/justfile
+++ b/justfile
@@ -64,10 +64,6 @@ macos-ffi *TARGETS:
     set -euo pipefail
     targets="{{TARGETS}}"
     if [ -z "$targets" ]; then
-        # A stale universal library from an earlier release build would shadow
-        # this one: Package.swift searches target/universal/release first, and
-        # the linker takes the first match rather than the newest.
-        rm -rf target/universal/release
         cargo build --release -p koan-ffi
         lib=target/release/libkoan_ffi.a
         dylib=target/release/libkoan_ffi.dylib
@@ -81,6 +77,19 @@ macos-ffi *TARGETS:
         lib=target/universal/release/libkoan_ffi.a
         dylib=target/$(echo $targets | cut -d' ' -f1)/release/libkoan_ffi.dylib
     fi
+    # Stage the archive somewhere holding nothing else, and link against that.
+    #
+    # `-lkoan_ffi` over a directory containing both a .a and a .dylib picks the
+    # .dylib, and cargo leaves one next to the archive. The release DMG shipped
+    # an app that referenced
+    # `/Users/runner/work/koan/koan/target/release/deps/libkoan_ffi.dylib` and
+    # could not launch anywhere, and it was arm64-only because the host dylib
+    # won over the universal archive. A directory with one file in it cannot
+    # produce either outcome.
+    rm -rf target/swift-link
+    mkdir -p target/swift-link
+    cp "$lib" target/swift-link/libkoan_ffi.a
+
     # Bindings are generated from the dylib's embedded metadata, not the sources.
     cargo run --release -q -p koan-ffi --bin uniffi-bindgen -- \
         generate --library "$dylib" --language swift --out-dir target/uniffi


### PR DESCRIPTION
The v0.25.0 DMG ships an app that cannot launch on any machine:

```
dyld: Library not loaded: /Users/runner/work/koan/koan/target/release/deps/libkoan_ffi.dylib
```

`-lkoan_ffi` over a directory holding both a `.a` and a `.dylib` picks the dylib, and cargo leaves one beside the archive — so the app linked dynamically against a path that only exists on the CI runner. It was arm64-only too, because that host dylib won over the lipo'd universal archive.

`just macos-ffi` now stages the archive it built into a directory containing nothing else, and `Package.swift` links against only that. A directory with one file in it cannot produce either failure.

## Verifying

```
otool -L Koan.app/Contents/MacOS/koan-app   # no koan_ffi entry — statically linked
```

Bundled binary goes 3.4 MB → 20 MB, DMG 1.5 MB → 8.1 MB, and the app launches from the mounted image. Confirmed locally; CI's universal build is what this needs to prove for real.

Releases as v0.25.1 — v0.25.0 is already published and its DMG is the broken one.