### PR TITLE
fix(release): ship a universal, statically linked app — and verify it

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -233,6 +233,7 @@ jobs:
       # and Apple silicon from a single download.
       - run: just macos-ffi "aarch64-apple-darwin x86_64-apple-darwin"
       - run: cd apps/macos && swift build -c release --arch arm64 --arch x86_64
+      - run: just macos-verify arm64 x86_64
       - run: just macos-dmg
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -263,6 +263,32 @@ jobs:
           tag_name: v${{ needs.check-version.outputs.version }}
           name: v${{ needs.check-version.outputs.version }}
           generate_release_notes: true
+          # Prepended to the generated notes. Every direct download of the app
+          # hits Gatekeeper, and the dialog it shows offers only "Move to Trash"
+          # — so the way out belongs where people are already standing.
+          body: |
+            ## Install
+
+            ```bash
+            brew install radiosilence/koan/koan            # the CLI and TUI
+            brew install --cask radiosilence/koan/koan-app # the macOS app
+            ```
+
+            ### Opening `Koan.dmg` directly
+
+            The app is signed but not notarised, so macOS refuses it on first
+            open with "Apple could not verify koan is free of malware" and
+            offers only **Move to Trash**. Drag it to Applications, then:
+
+            ```bash
+            xattr -dr com.apple.quarantine /Applications/Koan.app
+            ```
+
+            It opens normally from then on. The Homebrew cask does this for you.
+            Notarising properly needs a paid Apple Developer account, which this
+            project does not have.
+
+            ---
           files: |
             artifacts/**/*.tar.gz
             artifacts/**/*.dmg

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -341,13 +341,30 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
+          set -euo pipefail
           if [ -z "$GITHUB_TOKEN" ]; then
             echo "RELEASE_TOKEN not set, skipping"
             exit 0
           fi
           VERSION="${{ needs.check-version.outputs.version }}"
-          ARM_SHA=$(sha256sum artifacts/koan-macos-arm64/koan-macos-arm64.tar.gz | awk '{print $1}')
-          INTEL_SHA=$(sha256sum artifacts/koan-macos-x86_64/koan-macos-x86_64.tar.gz | awk '{print $1}')
+          # Locate rather than assume, and stop if anything is missing.
+          #
+          # These were bare `sha256sum <path>` calls whose failure went nowhere:
+          # the DMG landed at a path this did not expect, sha256sum wrote its
+          # error to stderr, and the cask was published with `sha256 ""` — which
+          # Homebrew cannot install and nothing in the run flagged.
+          shasum_of() {
+            local file
+            file=$(find artifacts -type f -name "$1" | head -1)
+            if [ -z "$file" ]; then
+              echo "release artifact $1 not found under artifacts/" >&2
+              find artifacts -type f | sed 's/^/  /' >&2
+              exit 1
+            fi
+            sha256sum "$file" | awk '{print $1}'
+          }
+          ARM_SHA=$(shasum_of koan-macos-arm64.tar.gz)
+          INTEL_SHA=$(shasum_of koan-macos-x86_64.tar.gz)
           git clone "https://x-access-token:${GITHUB_TOKEN}@github.com/radiosilence/homebrew-koan.git" /tmp/tap
           cd /tmp/tap
           cat > Formula/koan.rb <<FORMULA
@@ -375,7 +392,7 @@ jobs:
           sed -i 's/^          //' Formula/koan.rb
           # The GUI ships as a cask beside the CLI formula. Named koan-app so
           # `brew install koan` stays unambiguously the command-line player.
-          DMG_SHA=$(sha256sum artifacts/koan-macos-app/Koan.dmg | awk '{print $1}')
+          DMG_SHA=$(shasum_of Koan.dmg)
           mkdir -p Casks
           cat > Casks/koan-app.rb <<CASK
           cask "koan-app" do

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ Pure Rust, Ratatui TUI. Bit-perfect playback, gapless transitions, fast library 
 
 ## Install
 
+Downloading `Koan.dmg` from the releases page rather than using the cask? The app
+is signed but not notarised — Apple charges for that — so macOS refuses the first
+open and offers only "Move to Trash". Drag it to Applications and run
+`xattr -dr com.apple.quarantine /Applications/Koan.app` once. The cask does this
+for you.
+
 ```bash
 # homebrew (recommended)
 brew install radiosilence/koan/koan

--- a/justfile
+++ b/justfile
@@ -109,7 +109,7 @@ macos-build: macos-ffi
     # the old engine. Dropping the product when the library is newer forces the
     # relink.
     product={{app_dir}}/.build/release/Koan
-    for lib in target/release/libkoan_ffi.a target/universal/release/libkoan_ffi.a; do
+    for lib in target/swift-link/libkoan_ffi.a; do
         if [ -f "$lib" ] && [ -f "$product" ] && [ "$lib" -nt "$product" ]; then
             echo "koan-ffi is newer than the built app — forcing a relink"
             rm -f "$product"
@@ -125,7 +125,17 @@ macos-bundle: macos-build
     app="{{app_dir}}/.build/pkg/Koan.app"
     rm -rf "$app"
     mkdir -p "$app/Contents/MacOS" "$app/Contents/Resources"
-    cp {{app_dir}}/.build/release/Koan "$app/Contents/MacOS/koan-app"
+    # A multi-arch `swift build --arch a --arch b` puts its lipo'd product under
+    # .build/apple/Products, and leaves .build/release pointing at a single
+    # slice — so copying the latter shipped an arm64-only app from a build that
+    # had just compiled x86_64 as well.
+    universal={{app_dir}}/.build/apple/Products/Release/Koan
+    if [ -f "$universal" ]; then
+        cp "$universal" "$app/Contents/MacOS/koan-app"
+    else
+        cp {{app_dir}}/.build/release/Koan "$app/Contents/MacOS/koan-app"
+    fi
+    echo "app binary: $(lipo -archs "$app/Contents/MacOS/koan-app")"
     [ -f {{app_dir}}/Resources/AppIcon.icns ] && cp {{app_dir}}/Resources/AppIcon.icns "$app/Contents/Resources/" || true
     # The accent colour. macOS paints list selection, focus rings and controls
     # from the app's accent, and reads it from a compiled asset catalog — there
@@ -186,6 +196,36 @@ macos-bundle: macos-build
     # the Homebrew cask does it in a postflight.
     codesign --force --deep --sign "${KOAN_SIGN_IDENTITY:--}" "$app"
     echo "built $app"
+
+# Check a built Koan.app is actually shippable.
+#
+# Two ways the bundle has gone out broken, both of which built and signed
+# cleanly and neither of which showed until someone downloaded it:
+#   - linked against cargo's dylib by absolute path, so it died in dyld on any
+#     machine but the one that built it
+#   - arm64 only, from a build that had compiled x86_64 as well
+#
+# ARCHES is what the binary must contain, e.g. "arm64 x86_64".
+macos-verify *ARCHES:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    bin="{{app_dir}}/.build/pkg/Koan.app/Contents/MacOS/koan-app"
+    [ -f "$bin" ] || { echo "no app bundle at $bin"; exit 1; }
+
+    if otool -L "$bin" | grep -q koan_ffi; then
+        echo "app links koan_ffi dynamically — it will not run off this machine:"
+        otool -L "$bin" | grep koan_ffi
+        exit 1
+    fi
+
+    have=$(lipo -archs "$bin")
+    for want in {{ARCHES}}; do
+        case " $have " in
+            *" $want "*) ;;
+            *) echo "app binary is [$have], missing $want"; exit 1 ;;
+        esac
+    done
+    echo "app binary: [$have], statically linked"
 
 # Build and launch the app bundle.
 #

--- a/justfile
+++ b/justfile
@@ -178,6 +178,12 @@ macos-bundle: macos-build
     # removable volumes, files and folders — has to be given again. Set
     # KOAN_SIGN_IDENTITY to a stable certificate (a self-signed one in your
     # login keychain is enough) and the grants stick across rebuilds.
+    #
+    # It does nothing for Gatekeeper. A downloaded app is refused unless it is
+    # signed with a Developer ID certificate *and* notarised by Apple, which
+    # needs a paid developer account — a self-signed certificate is no more
+    # trusted than ad-hoc. Direct downloads clear the quarantine flag by hand;
+    # the Homebrew cask does it in a postflight.
     codesign --force --deep --sign "${KOAN_SIGN_IDENTITY:--}" "$app"
     echo "built $app"
 


### PR DESCRIPTION
Three things the v0.25.0 and v0.25.1 releases got wrong, and a check so they cannot recur.

## The app was arm64 only

`swift build --arch arm64 --arch x86_64` puts its lipo'd product under `.build/apple/Products`, leaving `.build/release` pointing at a single slice — so `macos-bundle` copied the arm64 slice out of a build that had just compiled x86_64 as well. v0.25.1's DMG does not run on Intel.

## The cask went out with an empty checksum

```ruby
cask "koan-app" do
  version "0.25.0"
  sha256 ""
```

The shas came from bare `sha256sum <path>` calls whose output was captured and whose failure was not — the DMG was not where the path expected, sha256sum wrote to stderr, and the heredoc interpolated an empty string. Paths are found rather than assumed now, a missing artifact fails the step and lists what was downloaded, and the block runs under `set -euo pipefail`.

## Gatekeeper had no way out

Downloading the DMG gets "Apple could not verify koan is free of malware", and the dialog offers only **Move to Trash**. The cask already clears the quarantine flag in a postflight; direct downloads had nothing. The `xattr -dr com.apple.quarantine` line now leads the release notes and the README install section.

Also records next to `codesign` what signing buys — a stable identity keeps TCC grants across rebuilds, and does nothing for Gatekeeper, which wants a Developer ID certificate and notarisation. Worth writing down so a self-signed certificate isn't mistaken for a fix.

## The check

`just macos-verify <arches>` asserts the binary contains every requested architecture and does not link `koan_ffi` dynamically. Both broken bundles built, signed and packaged without complaint; neither is visible without inspecting the product. CI runs it between the build and the DMG.

```
$ just macos-verify arm64 x86_64      # against the local arm64-only build
app binary is [arm64], missing x86_64
error: recipe `macos-verify` failed with exit code 1
```