### PR TITLE
release: v0.25.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v0.25.2 (2026-08-23)
+
+### Fixed
+
+- **The macOS app is universal again.** `swift build --arch arm64 --arch x86_64` puts its lipo'd product under `.build/apple/Products` and leaves `.build/release` pointing at one slice, so the bundle shipped the arm64 slice out of a build that had just compiled x86_64 as well — v0.25.1 does not run on Intel.
+- **A broken bundle can no longer ship.** `just macos-verify <arches>` asserts the binary contains every architecture asked for and does not link `koan_ffi` dynamically, and CI runs it between the build and the DMG. Both bundles that went out broken today built, signed and packaged without complaint.
+- **The Homebrew cask is no longer published with an empty checksum.** The shas came from bare `sha256sum <path>` calls whose failure went nowhere, so a missing artifact produced `sha256 ""` — which Homebrew refuses to install — and nothing in the run said so.
+
+### Changed
+
+- **Direct downloads say how to get past Gatekeeper.** The app is signed but not notarised, so macOS refuses the first open of a downloaded copy and offers only "Move to Trash". The `xattr -dr com.apple.quarantine` line now leads the release notes and the README's install section; the Homebrew cask already did this in a postflight.
+
 ## v0.25.1 (2026-08-23)
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2715,7 +2715,7 @@ dependencies = [
 
 [[package]]
 name = "koan-cli"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "chrono",
  "clap",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "koan-core"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "argon2",
  "bliss-audio",
@@ -2780,7 +2780,7 @@ dependencies = [
 
 [[package]]
 name = "koan-ffi"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "crossbeam-channel",
  "getrandom 0.4.3",
@@ -2796,7 +2796,7 @@ dependencies = [
 
 [[package]]
 name = "koan-server"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",
@@ -2829,7 +2829,7 @@ dependencies = [
 
 [[package]]
 name = "koan-tui"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "core-foundation 0.10.1",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/koan-core", "crates/koan-ffi", "crates/koan-server", "crates/koan-tui", "crates/koan-cli"]
 
 [workspace.package]
-version = "0.25.1"
+version = "0.25.2"
 edition = "2024"
 rust-version = "1.89"
 homepage = "https://github.com/radiosilence/koan"
@@ -13,9 +13,9 @@ license = "MIT"
 [workspace.dependencies]
 # Internal crates. Keep the version in step with [workspace.package] above —
 # a stale pin here publishes members that resolve against the wrong sibling.
-koan-core = { path = "crates/koan-core", version = "0.25.1" }
-koan-server = { path = "crates/koan-server", version = "0.25.1" }
-koan-tui = { path = "crates/koan-tui", version = "0.25.1" }
+koan-core = { path = "crates/koan-core", version = "0.25.2" }
+koan-server = { path = "crates/koan-server", version = "0.25.2" }
+koan-tui = { path = "crates/koan-tui", version = "0.25.2" }
 # Feature set is the union every member needs; `default-tls` is an alias for
 # `rustls`, so there is exactly one TLS stack.
 reqwest = { version = "0.13", default-features = false, features = [


### PR DESCRIPTION
v0.25.1's DMG runs, but only on Apple silicon — the universal-binary fix and the bundle check landed just after it was cut.

## In this release

- **The app is universal again.** `swift build --arch arm64 --arch x86_64` puts its lipo'd product under `.build/apple/Products`, leaving `.build/release` pointing at one slice, so the bundle shipped arm64 out of a build that had compiled x86_64 as well.
- **A broken bundle can no longer ship.** `just macos-verify arm64 x86_64` runs between the build and the DMG, asserting the binary holds every architecture asked for and does not link `koan_ffi` dynamically.
- **The cask can no longer be published with an empty checksum.**
- **Direct downloads say how to get past Gatekeeper.**

## Verifying

The check is the point of this one — CI's `macOS App` and `Release (Koan.app)` jobs both run `macos-verify`, so a green run *is* the verification that the DMG is universal and statically linked. Worth mounting the published DMG afterwards regardless; that is what caught both earlier failures.