### PR TITLE
fix(ci): assemble the bundle before checking it

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -233,6 +233,11 @@ jobs:
       # and Apple silicon from a single download.
       - run: just macos-ffi "aarch64-apple-darwin x86_64-apple-darwin"
       - run: cd apps/macos && swift build -c release --arch arm64 --arch x86_64
+      # Bundle, check, then package. `macos-verify` inspects the assembled
+      # Koan.app, so it has to come after something that assembles one —
+      # `macos-dmg` does that itself via `macos-bundle`, which put the check
+      # before the thing it checks.
+      - run: just macos-bundle
       - run: just macos-verify arm64 x86_64
       - run: just macos-dmg
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
`macos-verify` inspects `.build/pkg/Koan.app`, and CI ran it *before* `just macos-dmg` — the step that assembles one. So it failed on "no app bundle" and blocked the v0.25.2 DMG. The check worked; it just had nothing to check.

Bundle, check, package. `macos-bundle` prefers the universal product under `.build/apple/Products` when it exists, so the single-arch `swift build` it depends on cannot replace what the multi-arch build produced.

## Verifying

```
$ rm -rf apps/macos/.build/pkg && just macos-verify arm64
error: recipe `macos-verify` failed with exit code 1

$ just macos-bundle && just macos-verify arm64
app binary: [arm64], statically linked
```

A green `Release (Koan.app)` on main is then the real assertion: universal and statically linked, checked before the DMG is packaged.