### PR TITLE
fix(ci): resolve release artifacts from an absolute path

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -359,12 +359,17 @@ jobs:
           # the DMG landed at a path this did not expect, sha256sum wrote its
           # error to stderr, and the cask was published with `sha256 ""` — which
           # Homebrew cannot install and nothing in the run flagged.
+          # Absolute, because this script later cds into the cloned tap. The
+          # tarball shas were taken before that cd and the DMG's after it, so
+          # only the DMG resolved to nothing — which is exactly the checksum
+          # that went out empty.
+          ARTIFACTS="$PWD/artifacts"
           shasum_of() {
             local file
-            file=$(find artifacts -type f -name "$1" | head -1)
+            file=$(find "$ARTIFACTS" -type f -name "$1" | head -1)
             if [ -z "$file" ]; then
-              echo "release artifact $1 not found under artifacts/" >&2
-              find artifacts -type f | sed 's/^/  /' >&2
+              echo "release artifact $1 not found under $ARTIFACTS" >&2
+              find "$ARTIFACTS" -type f | sed 's/^/  /' >&2
               exit 1
             fi
             sha256sum "$file" | awk '{print $1}'


### PR DESCRIPTION
The v0.25.2 tap update failed with:

```
find: 'artifacts': No such file or directory
release artifact Koan.dmg not found under artifacts/
```

The script clones the tap and `cd`s into it partway through. The tarball checksums are taken *before* that cd and the DMG's *after* it, against a relative `artifacts/` path — so only the DMG resolved to nothing. That is exactly the checksum that has been going out as `sha256 ""`.

Absolute now, captured before anything moves.

## Verifying

```
before cd: 98ea6e4f21…
after cd : 98ea6e4f21…
survives the cd
```

The previous commit's guard is what turned this from a silent empty checksum into a failed step naming the missing file.