### PR TITLE
fix(remote): read the quality figures OpenSubsonic reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- **Remote tracks carried no quality figures at all.** Navidrome and any other OpenSubsonic server report `samplingRate`, `bitDepth` and `channelCount` on every song; koan's client did not parse them and the sync hardcoded all three to null. Every remote-only track in a synced library therefore had no sample rate and no bit depth — 5,058 of 5,058 in the library this was found on — so the format badge had nothing to show for them. For a player whose point is bit-perfect output, that is the wrong field to be missing. A full sync fills them in; a plain Subsonic server that does not report them still leaves them absent, because a missing sample rate is not 0 Hz.
+
 ## v0.26.0 (2026-08-23)
 
 ### Added

--- a/crates/koan-core/src/remote/client.rs
+++ b/crates/koan-core/src/remote/client.rs
@@ -520,6 +520,11 @@ pub struct SubsonicSong {
     pub content_type: Option<String>,
     pub album_id: Option<String>,
     pub artist_id: Option<String>,
+    // OpenSubsonic. Absent on a plain Subsonic server, which is why they are
+    // Options rather than defaults — a missing sample rate is not 0 Hz.
+    pub sampling_rate: Option<i32>,
+    pub bit_depth: Option<i32>,
+    pub channel_count: Option<i32>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -629,6 +634,40 @@ mod tests {
         assert_eq!(song.content_type.as_deref(), Some("audio/mpeg"));
         assert_eq!(song.album_id.as_deref(), Some("7"));
         assert_eq!(song.artist_id.as_deref(), Some("3"));
+    }
+
+    /// An OpenSubsonic server reports the figures that make a track's quality
+    /// legible. Ignoring them left every remote-only track with no sample rate
+    /// and no bit depth at all.
+    #[test]
+    fn opensubsonic_quality_fields_are_read() {
+        let json = r#"{
+            "id": "000XtGC7jsWEbOjDsZi4Xw",
+            "title": "Anguish",
+            "suffix": "flac",
+            "bitRate": 913,
+            "samplingRate": 44100,
+            "bitDepth": 16,
+            "channelCount": 2
+        }"#;
+
+        let song: SubsonicSong = serde_json::from_str(json).unwrap();
+
+        assert_eq!(song.sampling_rate, Some(44100));
+        assert_eq!(song.bit_depth, Some(16));
+        assert_eq!(song.channel_count, Some(2));
+    }
+
+    /// A plain Subsonic server omits them, and a missing sample rate is not
+    /// 0 Hz — the fields have to stay absent rather than default.
+    #[test]
+    fn a_plain_subsonic_song_has_no_quality_figures() {
+        let json = r#"{"id": "1", "title": "Track", "bitRate": 320}"#;
+        let song: SubsonicSong = serde_json::from_str(json).unwrap();
+
+        assert_eq!(song.sampling_rate, None);
+        assert_eq!(song.bit_depth, None);
+        assert_eq!(song.channel_count, None);
     }
 
     #[test]

--- a/crates/koan-core/src/remote/sync.rs
+++ b/crates/koan-core/src/remote/sync.rs
@@ -257,9 +257,16 @@ fn write_albums(
                 label: None,
                 duration_ms: song.duration.map(|d| d * 1000),
                 codec: song.suffix.clone(),
-                sample_rate: None,
-                bit_depth: None,
-                channels: None,
+                // OpenSubsonic servers report these; a plain Subsonic one
+                // leaves them out and the track keeps no quality figures,
+                // which is what every remote track used to get.
+                //
+                // Zero means "not applicable", not "zero" — Navidrome reports
+                // bitDepth 0 for every lossy file. Storing it would render an
+                // MP3 as 0-bit, which is worse than saying nothing.
+                sample_rate: positive(song.sampling_rate),
+                bit_depth: positive(song.bit_depth),
+                channels: positive(song.channel_count),
                 bitrate: song.bit_rate,
                 size_bytes: None,
                 mtime: None,
@@ -284,6 +291,12 @@ fn write_albums(
         .map_err(crate::db::connection::DbError::from)?;
 
     Ok(())
+}
+
+/// Treat a non-positive figure as absent. None of sample rate, bit depth or
+/// channel count has a meaningful zero.
+fn positive(value: Option<i32>) -> Option<i32> {
+    value.filter(|v| *v > 0)
 }
 
 #[cfg(test)]
@@ -403,9 +416,9 @@ mod tests {
             label: None,
             duration_ms: Some(240_000),
             codec: Some("FLAC".into()),
-            sample_rate: None,
-            bit_depth: None,
-            channels: None,
+            sample_rate: Some(44100),
+            bit_depth: Some(16),
+            channels: Some(2),
             bitrate: Some(1000),
             size_bytes: None,
             mtime: None,
@@ -417,6 +430,31 @@ mod tests {
             artist_remote_id: Some(format!("artist-of-{remote_id}")),
             album_added_at: None,
         }
+    }
+
+    /// Navidrome reports bitDepth 0 for every lossy file. Keeping it would
+    /// render an MP3 as 0-bit; absent is the honest answer.
+    #[test]
+    fn a_zero_quality_figure_is_treated_as_absent() {
+        assert_eq!(positive(Some(0)), None);
+        assert_eq!(positive(Some(16)), Some(16));
+        assert_eq!(positive(None), None);
+    }
+
+    /// A remote track carries the quality figures an OpenSubsonic server
+    /// reports. Without them the format badge has nothing to show, which is
+    /// what every remote-only track in a synced library used to look like.
+    #[test]
+    fn a_synced_track_keeps_its_quality_figures() {
+        let (db, _dir) = test_db();
+
+        let meta = remote_track_meta("remote-200", "Anguish", "Sleep", "Volume One");
+        let id = queries::upsert_track(&db.conn, &meta).unwrap();
+
+        let row = queries::get_track_row(&db.conn, id).unwrap().unwrap();
+        assert_eq!(row.sample_rate, Some(44100));
+        assert_eq!(row.bit_depth, Some(16));
+        assert_eq!(row.channels, Some(2));
     }
 
     /// The server keys stars, shares and cover art off album and artist ids,


### PR DESCRIPTION
Every remote-only track in a synced library had no sample rate and no bit depth. Not "some" — all of them.

```
source | tracks | no_sample_rate | no_bit_depth
local  | 48087  |             34 |        26249   ← MP3s, which genuinely have none
remote |  5058  |           5058 |         5058   ← every single one
```

Navidrome — and any OpenSubsonic server — returns `samplingRate`, `bitDepth` and `channelCount` on every song. `SubsonicSong` did not parse them, and `sync.rs` hardcoded all three to `None`. So the format badge had nothing to show for a fifth of the library, in a player whose whole pitch is bit-perfect output.

## The one subtlety

**Zero means "not applicable", not "zero".** Navidrome reports `bitDepth: 0` for every lossy file. Storing it verbatim renders an MP3 as *0-bit*, which is worse than saying nothing — so all three figures are filtered to positive values. None of them has a meaningful zero.

I only caught this by syncing against a live server and looking at what actually landed; the first version of this patch happily wrote `bit_depth = 0` across 2,669 MP3s.

## How to confirm it works

`just check` — three new tests: the OpenSubsonic fields deserialize, a plain Subsonic response without them still parses to `None` (a missing sample rate is not 0 Hz), and a zero is treated as absent.

Verified against a live Navidrome 0.63.2 with a 48k-track library. After a full sync:

```
codec | rate  | depth | ch | count
mp3   | 44100 |       |  2 |  2669   ← no bit depth, correctly
flac  | 44100 |    16 |  2 |  1666
flac  | 44100 |    24 |  2 |   234
opus  | 48000 |       |  2 |   117
flac  | 96000 |    24 |  2 |   105
```

All 5,058 remote tracks now have a sample rate and channel count; only lossy ones lack bit depth. 450 local files that dedup against a server copy also gained real figures.

## Note for anyone who ran the branch before this commit

`upsert_track` merges with `meta.bit_depth.or(existing.bit_depth)`, so zeros already written are sticky and a re-sync will not clear them. No released version writes them, so there is no migration — but a branch build would need `UPDATE tracks SET bit_depth = NULL WHERE bit_depth = 0;` and the same for `sample_rate` and `channels`.

## Not in this PR

The rest of what the server offers and koan ignores — `musicBrainzId`, `sortName`, `genres[]`, `displayArtist`, and the `songLyrics` extension (server-side synced lyrics instead of the LRCLIB round trip). Those need columns or a fetch path; this one needed four lines and fixes a visible hole.