### PR TITLE
fix(remote): stop the sync discarding metadata it already fetched

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Fixed
 
+- **The sync fetched 1,725 artists and threw the list away.** `get_artists` was called, counted, logged as "syncing 1725 artists" and then dropped — artists only ever came into being as a side effect of a track upsert, which saw nothing but a name and an id. That is why not one artist in a synced library had a MusicBrainz id or a sort name, and why the reported artist count was theatre. The list is applied now, and the count is what was actually written.
+
+- **Album and track metadata the server had already sent was discarded.** An album row is reached through a track, so it only ever saw what a file's tags said; track totals, the record label and the MusicBrainz id are properties of the release and came back in the same `getAlbumList2` response the sync already pages through. `songCount` was even parsed into `SubsonicAlbum`, covered by a test, and stored nowhere. Albums and tracks gain `mbid`, albums gain `sort_name`, and `total_tracks` and `label` are filled — all from responses koan was already making, at no extra request. Enrichment fills blanks rather than overwriting, so a locally-scanned album keeps what its tags said.
+
 - **Remote tracks carried no quality figures at all.** Navidrome and any other OpenSubsonic server report `samplingRate`, `bitDepth` and `channelCount` on every song; koan's client did not parse them and the sync hardcoded all three to null. Every remote-only track in a synced library therefore had no sample rate and no bit depth — 5,058 of 5,058 in the library this was found on — so the format badge had nothing to show for them. For a player whose point is bit-perfect output, that is the wrong field to be missing. A full sync fills them in; a plain Subsonic server that does not report them still leaves them absent, because a missing sample rate is not 0 Hz.
 
 ## v0.26.0 (2026-08-23)

--- a/crates/koan-core/src/db/queries/albums.rs
+++ b/crates/koan-core/src/db/queries/albums.rs
@@ -162,6 +162,35 @@ pub fn all_albums(conn: &Connection) -> Result<Vec<AlbumRow>, DbError> {
     Ok(rows)
 }
 
+/// Record what the server knows about an album beyond what a track carries.
+///
+/// `get_or_create_album` is reached through a track and only ever sees what a
+/// file's tags say. Track totals, the record label and the MusicBrainz id are
+/// properties of the release, and the server hands all three over in the same
+/// response the sync already paged through.
+///
+/// Fills blanks rather than overwriting, so a locally-scanned album keeps what
+/// its tags said.
+pub fn enrich_remote_album(
+    conn: &Connection,
+    remote_id: &str,
+    mbid: Option<&str>,
+    sort_name: Option<&str>,
+    total_tracks: Option<i32>,
+    label: Option<&str>,
+) -> Result<(), DbError> {
+    conn.execute(
+        "UPDATE albums SET
+             mbid         = COALESCE(mbid, ?2),
+             sort_name    = COALESCE(sort_name, ?3),
+             total_tracks = COALESCE(total_tracks, ?4),
+             label        = COALESCE(label, ?5)
+         WHERE remote_id = ?1",
+        params![remote_id, mbid, sort_name, total_tracks, label],
+    )?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/koan-core/src/db/queries/artists.rs
+++ b/crates/koan-core/src/db/queries/artists.rs
@@ -103,6 +103,27 @@ pub fn all_artists(conn: &Connection) -> Result<Vec<ArtistRow>, DbError> {
     Ok(rows)
 }
 
+/// Record what the server knows about an artist beyond its name.
+///
+/// Fills blanks rather than overwriting: a local scan may have set a sort name
+/// from tags, and the server's should not clobber it. Matched on `remote_id`,
+/// which the artist already has from the track upserts.
+pub fn enrich_remote_artist(
+    conn: &Connection,
+    remote_id: &str,
+    mbid: Option<&str>,
+    sort_name: Option<&str>,
+) -> Result<(), DbError> {
+    conn.execute(
+        "UPDATE artists SET
+             mbid      = COALESCE(mbid, ?2),
+             sort_name = COALESCE(sort_name, ?3)
+         WHERE remote_id = ?1",
+        params![remote_id, mbid, sort_name],
+    )?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/koan-core/src/db/queries/mod.rs
+++ b/crates/koan-core/src/db/queries/mod.rs
@@ -137,6 +137,9 @@ pub struct TrackMeta {
     /// albums and artists it can name but cannot refer to.
     pub album_remote_id: Option<String>,
     pub artist_remote_id: Option<String>,
+    /// MusicBrainz recording id. From the server today; a local scan could
+    /// read it from `MUSICBRAINZ_TRACKID` too.
+    pub mbid: Option<String>,
     /// When the album this track belongs to entered the library. Remote sync
     /// supplies the server's `created`; anything else leaves it and the album
     /// is stamped with the time it was first seen.
@@ -169,6 +172,7 @@ pub fn sample_meta(title: &str, artist: &str, album: &str) -> TrackMeta {
         remote_id: None,
         album_remote_id: None,
         artist_remote_id: None,
+        mbid: None,
         remote_url: None,
         album_added_at: None,
     }

--- a/crates/koan-core/src/db/queries/tracks.rs
+++ b/crates/koan-core/src/db/queries/tracks.rs
@@ -231,8 +231,9 @@ fn upsert_track_inner(conn: &Connection, meta: &TrackMeta) -> Result<(i64, bool)
             "UPDATE tracks SET album_id=?1, artist_id=?2, disc=?3, track_number=?4,
              title=?5, duration_ms=?6, codec=?7, sample_rate=?8, bit_depth=?9,
              channels=?10, bitrate=?11, size_bytes=?12, mtime=?13, genre=?14,
-             source=?15, remote_id=?16, remote_url=?17, path=?18
-             WHERE id=?19",
+             source=?15, remote_id=?16, remote_url=?17, path=?18,
+             mbid=COALESCE(mbid, ?19)
+             WHERE id=?20",
             params![
                 album_id,
                 track_artist_id,
@@ -252,6 +253,7 @@ fn upsert_track_inner(conn: &Connection, meta: &TrackMeta) -> Result<(i64, bool)
                 merged_remote_id,
                 merged_remote_url,
                 merged_path,
+                meta.mbid,
                 id
             ],
         )?;
@@ -280,8 +282,8 @@ fn upsert_track_inner(conn: &Connection, meta: &TrackMeta) -> Result<(i64, bool)
         conn.execute(
             "INSERT INTO tracks (album_id, artist_id, disc, track_number, title,
              duration_ms, path, codec, sample_rate, bit_depth, channels, bitrate,
-             size_bytes, mtime, genre, source, remote_id, remote_url)
-             VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18)",
+             size_bytes, mtime, genre, source, remote_id, remote_url, mbid)
+             VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19)",
             params![
                 album_id,
                 track_artist_id,
@@ -300,7 +302,8 @@ fn upsert_track_inner(conn: &Connection, meta: &TrackMeta) -> Result<(i64, bool)
                 meta.genre,
                 source,
                 meta.remote_id,
-                meta.remote_url
+                meta.remote_url,
+                meta.mbid
             ],
         )?;
 

--- a/crates/koan-core/src/db/schema.rs
+++ b/crates/koan-core/src/db/schema.rs
@@ -248,6 +248,14 @@ const ADDED_COLUMNS: &[(&str, &str, &str)] = &[
         "radio_enabled",
         "INTEGER NOT NULL DEFAULT 0",
     ),
+    // MusicBrainz ids are the join key for anything that wants to look a
+    // release or a recording up elsewhere. The server hands them over on every
+    // album and every song and koan was discarding all of them.
+    ("albums", "mbid", "TEXT"),
+    ("tracks", "mbid", "TEXT"),
+    // The server's own sort key, which is what it orders by. Artists already
+    // had this column and nothing ever filled it.
+    ("albums", "sort_name", "TEXT"),
 ];
 
 fn apply_migrations(conn: &Connection) -> rusqlite::Result<()> {

--- a/crates/koan-core/src/index/metadata.rs
+++ b/crates/koan-core/src/index/metadata.rs
@@ -176,6 +176,7 @@ fn read_metadata_lofty(
         remote_id: None,
         album_remote_id: None,
         artist_remote_id: None,
+        mbid: None,
         remote_url: None,
         album_added_at: mtime.and_then(iso8601_utc),
     })
@@ -236,6 +237,7 @@ fn read_metadata_fallback(path: &Path) -> Result<TrackMeta, MetadataError> {
         remote_id: None,
         album_remote_id: None,
         artist_remote_id: None,
+        mbid: None,
         remote_url: None,
         album_added_at: mtime.and_then(iso8601_utc),
     })
@@ -584,6 +586,7 @@ pub fn metadata_from_probe_result(meta: &MetadataRevision, fallback_title: &str)
         remote_id: None,
         album_remote_id: None,
         artist_remote_id: None,
+        mbid: None,
         remote_url: None,
         album_added_at: None,
     }

--- a/crates/koan-core/src/organize.rs
+++ b/crates/koan-core/src/organize.rs
@@ -1263,6 +1263,7 @@ mod tests {
             remote_url: None,
             album_remote_id: None,
             artist_remote_id: None,
+            mbid: None,
             album_added_at: None,
         }
     }

--- a/crates/koan-core/src/remote/client.rs
+++ b/crates/koan-core/src/remote/client.rs
@@ -473,6 +473,10 @@ pub struct SubsonicArtist {
     pub id: String,
     pub name: String,
     pub album_count: Option<i32>,
+    // OpenSubsonic. Both arrive in `getArtists`, so keeping them costs no
+    // extra request.
+    pub music_brainz_id: Option<String>,
+    pub sort_name: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -486,6 +490,19 @@ pub struct SubsonicAlbum {
     pub year: Option<i32>,
     pub genre: Option<String>,
     pub created: Option<String>,
+    // OpenSubsonic. All of these arrive in `getAlbumList2`, which the sync
+    // already pages through.
+    pub music_brainz_id: Option<String>,
+    pub sort_name: Option<String>,
+    #[serde(default)]
+    pub record_labels: Vec<SubsonicName>,
+}
+
+/// A bare `{"name": "..."}` object. The server uses this shape for record
+/// labels, genres and moods alike.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SubsonicName {
+    pub name: String,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -499,6 +516,10 @@ pub struct SubsonicAlbumFull {
     pub genre: Option<String>,
     pub song_count: Option<i32>,
     pub created: Option<String>,
+    pub music_brainz_id: Option<String>,
+    pub sort_name: Option<String>,
+    #[serde(default)]
+    pub record_labels: Vec<SubsonicName>,
     #[serde(default)]
     pub song: Vec<SubsonicSong>,
 }
@@ -525,6 +546,7 @@ pub struct SubsonicSong {
     pub sampling_rate: Option<i32>,
     pub bit_depth: Option<i32>,
     pub channel_count: Option<i32>,
+    pub music_brainz_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/koan-core/src/remote/sync.rs
+++ b/crates/koan-core/src/remote/sync.rs
@@ -3,7 +3,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::db::connection::Database;
 use crate::db::queries::{self, TrackMeta};
-use crate::remote::client::{SubsonicAlbumFull, SubsonicClient};
+use crate::remote::client::{SubsonicAlbumFull, SubsonicArtist, SubsonicClient};
 
 use rayon::prelude::*;
 use rusqlite::params;
@@ -206,6 +206,12 @@ pub fn sync_library(
         }
     }
 
+    // The artist list was fetched at the top and, until this, thrown away —
+    // artists only ever existed as a side effect of a track upsert, which is
+    // why not one of them had a MusicBrainz id or a sort name. Applied last,
+    // because the rows do not exist until their tracks have been written.
+    write_artists(db, &artists, &mut result);
+
     if result.is_complete() {
         update_last_sync(db, server_url, username, sync_start)?;
     } else {
@@ -224,6 +230,38 @@ pub fn sync_library(
     );
 
     Ok(result)
+}
+
+/// Record what the server knows about each artist.
+///
+/// Best-effort: a library that synced its tracks fine should not fail because
+/// one artist row could not be updated.
+fn write_artists(db: &Database, artists: &[SubsonicArtist], result: &mut SyncResult) {
+    if db.conn.execute_batch("BEGIN").is_err() {
+        return;
+    }
+    let mut enriched = 0;
+    for artist in artists {
+        match queries::enrich_remote_artist(
+            &db.conn,
+            &artist.id,
+            artist.music_brainz_id.as_deref(),
+            artist.sort_name.as_deref(),
+        ) {
+            Ok(()) => enriched += 1,
+            Err(e) => log::warn!(
+                "failed to record artist metadata for {}: {}",
+                artist.name,
+                e
+            ),
+        }
+    }
+    if db.conn.execute_batch("COMMIT").is_err() {
+        let _ = db.conn.execute_batch("ROLLBACK");
+        return;
+    }
+    result.artists_synced = enriched;
+    log::info!("recorded metadata for {enriched} artists");
 }
 
 /// Write one batch of fetched albums in a single transaction.
@@ -276,6 +314,7 @@ fn write_albums(
                 remote_url: Some(client.stream_url_template(&song.id)),
                 album_remote_id: Some(album.id.clone()),
                 artist_remote_id: album.artist_id.clone(),
+                mbid: song.music_brainz_id.clone(),
                 album_added_at: album.created.clone(),
             };
 
@@ -283,6 +322,20 @@ fn write_albums(
                 Ok(_) => result.tracks_synced += 1,
                 Err(e) => log::warn!("failed to insert remote track {}: {}", song.title, e),
             }
+        }
+
+        // The album row is created through its tracks, so it only ever sees
+        // what a file's tags say. Track totals, the label and the MusicBrainz
+        // id belong to the release, and came back in the same response.
+        if let Err(e) = queries::enrich_remote_album(
+            &db.conn,
+            &album.id,
+            album.music_brainz_id.as_deref(),
+            album.sort_name.as_deref(),
+            album.song_count,
+            album.record_labels.first().map(|l| l.name.as_str()),
+        ) {
+            log::warn!("failed to record album metadata for {}: {}", album.name, e);
         }
     }
 
@@ -428,6 +481,7 @@ mod tests {
             remote_url: Some(format!("https://example.com/stream?id={}", remote_id)),
             album_remote_id: Some(format!("album-of-{remote_id}")),
             artist_remote_id: Some(format!("artist-of-{remote_id}")),
+            mbid: Some(format!("mbid-of-{remote_id}")),
             album_added_at: None,
         }
     }
@@ -439,6 +493,115 @@ mod tests {
         assert_eq!(positive(Some(0)), None);
         assert_eq!(positive(Some(16)), Some(16));
         assert_eq!(positive(None), None);
+    }
+
+    /// The album row is created through its tracks, so it only ever sees what
+    /// a file's tags say. Track totals, the label and the MusicBrainz id are
+    /// properties of the release and arrive in the same response.
+    #[test]
+    fn album_metadata_from_the_server_is_recorded() {
+        let (db, _dir) = test_db();
+
+        let meta = remote_track_meta("remote-300", "Anguish", "Sleep", "Volume One");
+        queries::upsert_track(&db.conn, &meta).unwrap();
+
+        queries::enrich_remote_album(
+            &db.conn,
+            "album-of-remote-300",
+            Some("mb-album-1"),
+            Some("volume one"),
+            Some(6),
+            Some("Off The Disk"),
+        )
+        .unwrap();
+
+        let row: (Option<String>, Option<String>, Option<i32>, Option<String>) = db
+            .conn
+            .query_row(
+                "SELECT mbid, sort_name, total_tracks, label FROM albums WHERE title = 'Volume One'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
+            )
+            .unwrap();
+        assert_eq!(row.0.as_deref(), Some("mb-album-1"));
+        assert_eq!(row.1.as_deref(), Some("volume one"));
+        assert_eq!(row.2, Some(6));
+        assert_eq!(row.3.as_deref(), Some("Off The Disk"));
+    }
+
+    /// Enrichment fills blanks. A locally-scanned album whose tags named a
+    /// label must keep it, rather than have the server's answer written over.
+    #[test]
+    fn server_metadata_does_not_overwrite_what_tags_said() {
+        let (db, _dir) = test_db();
+
+        let mut meta = remote_track_meta("remote-301", "Dopesmoker", "Sleep", "Dopesmoker");
+        meta.label = Some("From The Tags".into());
+        queries::upsert_track(&db.conn, &meta).unwrap();
+
+        queries::enrich_remote_album(
+            &db.conn,
+            "album-of-remote-301",
+            None,
+            None,
+            None,
+            Some("From The Server"),
+        )
+        .unwrap();
+
+        let label: Option<String> = db
+            .conn
+            .query_row(
+                "SELECT label FROM albums WHERE title = 'Dopesmoker'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(label.as_deref(), Some("From The Tags"));
+    }
+
+    /// Artists existed only as a side effect of a track upsert, so nothing
+    /// ever wrote their MusicBrainz id or sort name.
+    #[test]
+    fn artist_metadata_from_the_server_is_recorded() {
+        let (db, _dir) = test_db();
+
+        let meta = remote_track_meta("remote-302", "Holy Mountain", "Sleep", "Holy Mountain");
+        queries::upsert_track(&db.conn, &meta).unwrap();
+
+        queries::enrich_remote_artist(
+            &db.conn,
+            "artist-of-remote-302",
+            Some("mb-artist-1"),
+            Some("sleep"),
+        )
+        .unwrap();
+
+        let row: (Option<String>, Option<String>) = db
+            .conn
+            .query_row(
+                "SELECT mbid, sort_name FROM artists WHERE name = 'Sleep'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(row.0.as_deref(), Some("mb-artist-1"));
+        assert_eq!(row.1.as_deref(), Some("sleep"));
+    }
+
+    /// The recording id travels with the track.
+    #[test]
+    fn a_synced_track_keeps_its_musicbrainz_id() {
+        let (db, _dir) = test_db();
+
+        let meta = remote_track_meta("remote-303", "Aquarian", "Sleep", "Dopesmoker");
+        let id = queries::upsert_track(&db.conn, &meta).unwrap();
+
+        let mbid: Option<String> = db
+            .conn
+            .query_row("SELECT mbid FROM tracks WHERE id = ?1", [id], |r| r.get(0))
+            .unwrap();
+        assert_eq!(mbid.as_deref(), Some("mbid-of-remote-303"));
     }
 
     /// A remote track carries the quality figures an OpenSubsonic server

--- a/crates/koan-server/src/graphql/mod.rs
+++ b/crates/koan-server/src/graphql/mod.rs
@@ -424,6 +424,7 @@ mod tests {
                         remote_url: None,
                         album_remote_id: None,
                         artist_remote_id: None,
+                        mbid: None,
                         album_added_at: None,
                         label: None,
                     };
@@ -461,6 +462,7 @@ mod tests {
             remote_url: None,
             album_remote_id: None,
             artist_remote_id: None,
+            mbid: None,
             album_added_at: None,
             label: None,
         };

--- a/crates/koan-server/src/mcp.rs
+++ b/crates/koan-server/src/mcp.rs
@@ -247,6 +247,7 @@ mod tests {
             remote_url: None,
             album_remote_id: None,
             artist_remote_id: None,
+            mbid: None,
             album_added_at: None,
             label: None,
         };

--- a/crates/koan-server/src/subsonic.rs
+++ b/crates/koan-server/src/subsonic.rs
@@ -2182,6 +2182,7 @@ mod tests {
             remote_url: None,
             album_remote_id: None,
             artist_remote_id: None,
+            mbid: None,
             album_added_at: None,
         }
     }


### PR DESCRIPTION
Follow-up to #239. That one was about three quality fields; this is the audit behind it — a diff of what the server sends against what koan keeps.

## The headline

`sync_library` calls `get_artists()`, counts the result, logs `syncing 1725 artists from remote`, and then **never uses the list**. Artists only ever came into being as a side effect of a track upsert, which sees a name and a remote id and nothing else. The consequence, measured on a 48k-track library:

```
artists.mbid       4 / 7232      ← and those four came from somewhere else
artists.sort_name  0 / 7232      ← the column has never been written by anything
```

`sort_name` is not decorative — `find_artists` orders by `COALESCE(a.sort_name, a.name)`, so the fallback has been doing all the work since the column was added.

## What else was going in the bin

Every one of these arrives in `getAlbumList2` / `getArtists`, which the sync **already pages through**. No new requests.

| field | went to | was |
|---|---|---|
| `musicBrainzId` (artist) | `artists.mbid` | discarded |
| `sortName` (artist) | `artists.sort_name` | discarded |
| `songCount` | `albums.total_tracks` | parsed into `SubsonicAlbum`, covered by a test, stored nowhere |
| `recordLabels[]` | `albums.label` | discarded |
| `musicBrainzId` (album) | `albums.mbid` *(new column)* | discarded |
| `sortName` (album) | `albums.sort_name` *(new column)* | discarded |
| `musicBrainzId` (song) | `tracks.mbid` *(new column)* | discarded |

MusicBrainz ids are the join key for anything that wants to look a release or recording up elsewhere — the artist-metadata work on the roadmap needs them, and they were being handed over for free on every request.

## Load-bearing decisions

- **Enrichment fills blanks, never overwrites.** An album row is created through its tracks, so a locally-scanned album carries what its tags said; the server's answer must not clobber that. All of it is `COALESCE(existing, incoming)`, with a test.
- **It goes in the sync, not through `TrackMeta`.** `get_or_create_album` already takes ten arguments. Threading four more through it and through `TrackMeta` to describe properties of a *release* would be worse than the problem. Track totals and record labels are not things a single file knows.
- **Artists are written last.** The rows do not exist until their tracks have been, so enriching earlier would be a no-op for everything new.
- **Artist enrichment is best-effort.** A library whose tracks synced fine should not fail because one artist row would not update.

## How to confirm it works

`just check` — four new tests: album metadata is recorded, artist metadata is recorded, a track keeps its recording id, and server metadata does not overwrite what tags said.

Verified against a live Navidrome 0.63.2 with a 48k-track library:

| | before | after |
|---|---|---|
| `artists.mbid` | 4 | **1714** |
| `artists.sort_name` | 0 | **1711** |
| `albums.mbid` | — | **5510** |
| `albums.sort_name` | — | **5510** |
| `albums.total_tracks` | 0 | **5510** |
| `albums.label` | 2557 | **4519** |
| `tracks.mbid` | — | **47944** |

(Artist totals are out of 7,232 rows because only 1,725 artists exist on the server; the rest are local-only.)

Three new columns via the existing `ADDED_COLUMNS` migration path, so an existing database picks them up on open and a full sync fills them.

## Deliberately not in this PR

- `originalReleaseDate` — the server distinguishes it from `releaseDate`, and koan uses `year`. Preferring the original would be more correct for reissues, but it changes what date-sorting means on an existing library, so it wants its own decision.
- `isCompilation`, `releaseTypes`, `discTitles`, `explicitStatus`, `moods`, `bpm`, `comment`, `isrc`, `contributors` — no column and no consumer yet.
- The `songLyrics` extension: the server can serve synced lyrics directly instead of the LRCLIB round trip. Separate change, needs a fetch path.