### PR TITLE
feat(ffi): never block the caller

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -44,6 +44,8 @@ Five crates, one workspace. `koan-core` is the engine; `koan-tui`, `koan-server`
 | Auth | None needed | JWT, cookies, CORS |
 | For | macOS app, future iOS app | Web SPA, jukebox remotes |
 
+**Nothing over the FFI blocks its caller.** koan-core is synchronous — rusqlite has no async form, and the audio path is dedicated threads on purpose — so the boundary is where the hop happens: an exported call that can block is `async` and runs on a worker thread, and the handful that stay synchronous read one atomic. Queue mutations and transport commands go down a single lane so they reach the player in the order the user gave them. See `koan-ffi/src/offload.rs`.
+
 **A UI that can link the core should.** The macOS app sits directly on top of the audio engine, so routing its own commands through localhost HTTP would add a daemon, a port, an auth surface and a second process contending for the same SQLite file, and buy nothing. It links `koan-ffi`, and CoreAudio output never leaves Rust, so playback stays bit-perfect.
 
 GraphQL earns its keep for clients that genuinely *cannot* link the core -- a browser, or a phone controlling playback on a different machine.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,16 @@
 
 - **Reading the config forked a `git` process.** `Config::load()` re-read both TOML files, re-ran the figment merge, and re-scanned for credentials in version control — and that last check shells out to `git ls-files` whenever a password is present in the file, then panics if it is tracked. koan reaches config from paths that run per frame: the macOS settings pane reads `library_folders()` from a SwiftUI list body, so it did all of that per rendered frame. The check is what its own message says it is, a gate on starting, and runs once per process now. The merged config is cached and re-read when either file's mtime moves, so a config edited by hand is still picked up.
 
+### Changed
+
+- **The FFI never blocks its caller.** Every one of the 70 engine calls that can block is `async` now and runs on a worker thread; the five that stay synchronous read a single atomic and cannot block by construction. Previously all of them were synchronous FFI functions and the hazard lived in doc comments, which had already failed — `lyrics()` was documented as safe to call from a view body and opened a database connection, and six paths in the macOS app reached the engine directly on the main actor, one of them from inside a SwiftUI `ForEach`.
+
+  Blocking moved into Rust rather than being wrapped at each call site. The app used to hop with `Task.detached`, which runs on Swift's cooperative pool — sized to the core count — so a cover-art storm or a scan starved every other task in the process. The engine's pool grows on demand and is deliberately not core-sized: a thread waiting on a socket costs a kernel stack, not CPU, and capping blocking work at the core count queues it behind nothing. koan-core stays synchronous, which is what its three synchronous consumers and its dedicated audio threads want; only the boundary changed.
+
+  Queue mutations and transport commands share one lane, in submission order. They previously each got their own `Task.detached`, so two in quick succession could reach the player in either order — dropping in an album and pressing undo could undo it before it landed.
+
+  Every `Task.detached` around an engine call is gone from the app, along with the helper that wrapped them.
+
 ## v0.26.0 (2026-08-23)
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,7 +151,8 @@ Pre-push hook (`.claude/settings.json`) runs `cargo fmt --all` + `cargo clippy -
 
 | Module | What |
 |--------|------|
-| `lib.rs` | `KoanEngine` — the whole facade. Transport, queue ops, library queries, favourites, snapshots, devices, scan. Blocking; callers keep slow calls off the main thread |
+| `lib.rs` | `KoanEngine` — the whole facade. Transport, queue ops, library queries, favourites, snapshots, devices, scan. Every call that can block is `async`; only single-atomic reads stay sync |
+| `offload.rs` | Where blocking work goes — a growing thread pool for reads, and one ordered lane for anything that ends in a `PlayerCommand` |
 | `types.rs` | uniffi records mirroring koan-core types (`Track`, `Album`, `NowPlaying`, `QueueItem`, …) and the conversions |
 
 Swift bindings are generated, not checked in — `just macos-ffi` builds the lib and regenerates them.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2814,6 +2814,7 @@ version = "0.26.0"
 dependencies = [
  "chrono",
  "crossbeam-channel",
+ "futures-lite",
  "getrandom 0.4.3",
  "koan-core",
  "log",
@@ -2821,6 +2822,7 @@ dependencies = [
  "parking_lot",
  "rusqlite",
  "thiserror 2.0.20",
+ "tokio",
  "toml 1.1.4+spec-1.1.0",
  "uniffi",
  "uuid",

--- a/apps/macos/Sources/Koan/KoanApp.swift
+++ b/apps/macos/Sources/Koan/KoanApp.swift
@@ -18,8 +18,8 @@ final class AppState {
     let hotkeys: Hotkeys
     private var nowPlaying: NowPlayingCentre?
 
-    init() throws {
-        let engine = try KoanEngine()
+    init() async throws {
+        let engine = try await KoanEngine()
         self.engine = engine
         let player = PlayerModel(engine: engine)
         self.player = player
@@ -83,8 +83,8 @@ struct KoanApp: App {
             .task {
                 guard state == nil, startupError == nil else { return }
                 do {
-                    let created = try AppState()
-                    created.player.start()
+                    let created = try await AppState()
+                    await created.player.start()
                     created.player.restoreSession()
                     created.library.loadInitial()
                     state = created
@@ -95,7 +95,9 @@ struct KoanApp: App {
         }
         .onChange(of: scenePhase) { _, phase in
             // Backgrounding is the last dependable moment before termination.
-            if phase != .active { state?.player.saveSession() }
+            if phase != .active {
+                Task { await state?.player.saveSession() }
+            }
         }
         .windowToolbarStyle(.unified(showsTitle: false))
         .commands {
@@ -192,7 +194,7 @@ struct KoanApp: App {
             }
 
             CommandMenu("Queue") {
-                Button("Save Session") { state?.player.saveSession() }
+                Button("Save Session") { Task { await state?.player.saveSession() } }
                 Button("Clear Queue") { state?.player.clearQueue() }
             }
 

--- a/apps/macos/Sources/Koan/Support/ActivityModel.swift
+++ b/apps/macos/Sources/Koan/Support/ActivityModel.swift
@@ -77,13 +77,15 @@ final class ActivityModel {
         _ label: String,
         exclusive: Bool = false,
         cancellable: Bool = false,
-        _ work: @escaping @Sendable () throws -> T
+        _ work: @escaping @Sendable () async throws -> T
     ) async -> Result<T, Error> {
         let id = begin(label, exclusive: exclusive, cancellable: cancellable)
         defer { end(id) }
-        return await _Concurrency.Task.detached(priority: .userInitiated) {
-            Result { try work() }
-        }.value
+        do {
+            return .success(try await work())
+        } catch {
+            return .failure(error)
+        }
     }
 
     /// Run `work` with a reporter the engine can call back into, so the task
@@ -93,14 +95,16 @@ final class ActivityModel {
         _ label: String,
         exclusive: Bool = true,
         cancellable: Bool = true,
-        _ work: @escaping @Sendable (EngineProgress) throws -> T
+        _ work: @escaping @Sendable (EngineProgress) async throws -> T
     ) async -> Result<T, Error> {
         let id = begin(label, exclusive: exclusive, cancellable: cancellable)
         let progress = reporter(for: id)
         defer { end(id) }
-        return await _Concurrency.Task.detached(priority: .userInitiated) {
-            Result { try work(progress) }
-        }.value
+        do {
+            return .success(try await work(progress))
+        } catch {
+            return .failure(error)
+        }
     }
 
     /// For work that does not fit the closure shape — a long-lived poller, or

--- a/apps/macos/Sources/Koan/Support/CoverArtCache.swift
+++ b/apps/macos/Sources/Koan/Support/CoverArtCache.swift
@@ -76,9 +76,11 @@ final class CoverArtCache {
         let engine = self.engine
         let file = directory?.appendingPathComponent(Self.filename(for: key))
         let task = Task<NSImage?, Never> { [weak self] in
+            // Detached for the disk cache, not for the engine: reading and
+            // writing the file would otherwise happen on the main actor.
             let data = await Task.detached(priority: .utility) { () -> Data? in
                 if let file, let cached = try? Data(contentsOf: file) { return cached }
-                guard let fetched = Self.fetch(source, engine) else { return nil }
+                guard let fetched = await Self.fetch(source, engine) else { return nil }
                 if let file {
                     // Best effort: a cache that fails to write is still a cache.
                     try? fetched.write(to: file, options: .atomic)
@@ -110,19 +112,19 @@ final class CoverArtCache {
     private nonisolated static func fetch(
         _ source: AlbumArtwork.Source,
         _ engine: KoanEngine
-    ) -> Data? {
+    ) async -> Data? {
         switch source {
         case .album(let albumId):
             // Any track off the record will do — they share the artwork.
-            guard let tracks = try? engine.tracks(
+            guard let tracks = try? await engine.tracks(
                 albumId: albumId, artistId: nil, sort: .album, limit: 1, offset: 0
             ) else { return nil }
             guard let first = tracks.first(where: { $0.path != nil }) ?? tracks.first else {
                 return nil
             }
-            return (try? engine.coverArt(trackId: first.id, size: 400))?.data
+            return (try? await engine.coverArt(trackId: first.id, size: 400))?.data
         case .track(let trackId):
-            return (try? engine.coverArt(trackId: trackId, size: 600))?.data
+            return (try? await engine.coverArt(trackId: trackId, size: 600))?.data
         }
     }
 

--- a/apps/macos/Sources/Koan/Support/Hotkeys.swift
+++ b/apps/macos/Sources/Koan/Support/Hotkeys.swift
@@ -120,7 +120,7 @@ extension Hotkeys {
                 player.seek(bySeconds: 10)
             },
             Hotkey(keys: ["f"], label: "Favourite this track", group: .playback) {
-                _ = player.toggleFavouriteCurrent()
+                player.toggleFavouriteCurrent()
             },
             Hotkey(keys: ["R"], label: "Radio mode", group: .playback) {
                 player.toggleRadio()

--- a/apps/macos/Sources/Koan/Support/LibraryModel.swift
+++ b/apps/macos/Sources/Koan/Support/LibraryModel.swift
@@ -127,9 +127,7 @@ final class LibraryModel {
         let engine = self.engine
         let sort = albumSort
         Task {
-            albums = await Task.detached(priority: .userInitiated) {
-                (try? engine.albums(artistId: nil, sort: sort)) ?? []
-            }.value
+            albums = (try? await engine.albums(artistId: nil, sort: sort)) ?? []
             reindex()
         }
     }
@@ -201,14 +199,10 @@ final class LibraryModel {
         let sort = albumSort
         Task {
             if albums.isEmpty {
-                albums = await Task.detached(priority: .utility) {
-                    (try? engine.albums(artistId: nil, sort: sort)) ?? []
-                }.value
+                albums = (try? await engine.albums(artistId: nil, sort: sort)) ?? []
             }
             if artists.isEmpty {
-                artists = await Task.detached(priority: .utility) {
-                    (try? engine.artists(search: nil)) ?? []
-                }.value
+                artists = (try? await engine.artists(search: nil)) ?? []
             }
             reindex()
         }
@@ -233,31 +227,21 @@ final class LibraryModel {
                 break  // owned by the player and search models respectively
             case .albums:
                 if albums.isEmpty {
-                    albums = await Task.detached(priority: .userInitiated) {
-                        (try? engine.albums(artistId: nil, sort: sort)) ?? []
-                    }.value
+                    albums = (try? await engine.albums(artistId: nil, sort: sort)) ?? []
                     reindex()
                 }
             case .artists:
                 if artists.isEmpty {
-                    artists = await Task.detached(priority: .userInitiated) {
-                        (try? engine.artists(search: nil)) ?? []
-                    }.value
+                    artists = (try? await engine.artists(search: nil)) ?? []
                     reindex()
                 }
             case .favourites:
-                favourites = await Task.detached(priority: .userInitiated) {
-                    (try? engine.favourites()) ?? []
-                }.value
+                favourites = (try? await engine.favourites()) ?? []
             case .playHistory:
                 // Always refetched: it changes underneath you as you listen.
-                playHistory = await Task.detached(priority: .userInitiated) {
-                    (try? engine.playHistory(limit: historyPageSize, offset: 0)) ?? []
-                }.value
+                playHistory = (try? await engine.playHistory(limit: historyPageSize, offset: 0)) ?? []
             case .snapshots:
-                snapshots = await Task.detached(priority: .userInitiated) {
-                    (try? engine.snapshots()) ?? []
-                }.value
+                snapshots = (try? await engine.snapshots()) ?? []
             }
             isLoading = false
         }
@@ -270,15 +254,14 @@ final class LibraryModel {
         let doomed = Array(ids)
         // Dropped locally first so the list does not visibly lag the keystroke.
         playHistory.removeAll { ids.contains($0.id) }
-        Task.detached(priority: .userInitiated) { _ = try? engine.deletePlays(ids: doomed) }
+        Task { _ = try? await engine.deletePlays(ids: doomed) }
     }
 
     /// Forget every play.
     func clearPlayHistory() {
         let engine = self.engine
         Task {
-            _ = await Task.detached(priority: .userInitiated) { try? engine.clearPlayHistory() }
-                .value
+            _ = try? await engine.clearPlayHistory()
             playHistory = []
         }
     }
@@ -286,7 +269,7 @@ final class LibraryModel {
     func loadStats() {
         let engine = self.engine
         Task {
-            stats = await Task.detached(priority: .utility) { try? engine.libraryStats() }.value
+            stats = try? await engine.libraryStats()
         }
     }
 
@@ -295,11 +278,9 @@ final class LibraryModel {
         let engine = self.engine
         detailTracks = []
         Task {
-            detailTracks = await Task.detached(priority: .userInitiated) {
-                (try? engine.tracks(
-                    albumId: albumId, artistId: nil, sort: .album, limit: 500, offset: 0
-                )) ?? []
-            }.value
+            detailTracks = (try? await engine.tracks(
+                albumId: albumId, artistId: nil, sort: .album, limit: 500, offset: 0
+            )) ?? []
         }
     }
 
@@ -441,9 +422,7 @@ final class LibraryModel {
     func toggleFavourite(track id: Int64) {
         let engine = self.engine
         Task {
-            let now = await Task.detached(priority: .userInitiated) {
-                (try? engine.toggleFavourite(trackId: id))
-            }.value
+            let now = (try? await engine.toggleFavourite(trackId: id))
             guard let now else { return }
             if now { favouriteTrackIds.insert(id) } else { favouriteTrackIds.remove(id) }
             reloadFavouritesList()
@@ -453,9 +432,7 @@ final class LibraryModel {
     func toggleFavourite(album id: Int64) {
         let engine = self.engine
         Task {
-            let now = await Task.detached(priority: .userInitiated) {
-                (try? engine.toggleFavouriteAlbum(albumId: id))
-            }.value
+            let now = (try? await engine.toggleFavouriteAlbum(albumId: id))
             guard let now else { return }
             if now { favouriteAlbumIds.insert(id) } else { favouriteAlbumIds.remove(id) }
         }
@@ -464,9 +441,7 @@ final class LibraryModel {
     func toggleFavourite(artist id: Int64) {
         let engine = self.engine
         Task {
-            let now = await Task.detached(priority: .userInitiated) {
-                (try? engine.toggleFavouriteArtist(artistId: id))
-            }.value
+            let now = (try? await engine.toggleFavouriteArtist(artistId: id))
             guard let now else { return }
             if now { favouriteArtistIds.insert(id) } else { favouriteArtistIds.remove(id) }
         }
@@ -477,13 +452,11 @@ final class LibraryModel {
     func refreshFavourites() {
         let engine = self.engine
         Task {
-            let sets = await Task.detached(priority: .utility) {
-                (
-                    Set((try? engine.favouriteTrackIds()) ?? []),
-                    Set((try? engine.favouriteAlbumIds()) ?? []),
-                    Set((try? engine.favouriteArtistIds()) ?? [])
-                )
-            }.value
+            let sets = (
+                Set((try? await engine.favouriteTrackIds()) ?? []),
+                Set((try? await engine.favouriteAlbumIds()) ?? []),
+                Set((try? await engine.favouriteArtistIds()) ?? [])
+            )
             favouriteTrackIds = sets.0
             favouriteAlbumIds = sets.1
             favouriteArtistIds = sets.2
@@ -495,16 +468,14 @@ final class LibraryModel {
         guard section == .favourites else { return }
         let engine = self.engine
         Task {
-            favourites = await Task.detached(priority: .utility) {
-                (try? engine.favourites()) ?? []
-            }.value
+            favourites = (try? await engine.favourites()) ?? []
         }
     }
 
     func saveSnapshot(name: String) {
         let engine = self.engine
         Task {
-            await Task.detached(priority: .utility) { try? engine.saveSnapshot(name: name) }.value
+            try? await engine.saveSnapshot(name: name)
             load()
         }
     }
@@ -512,7 +483,7 @@ final class LibraryModel {
     func deleteSnapshot(name: String) {
         let engine = self.engine
         Task {
-            _ = await Task.detached(priority: .utility) { try? engine.deleteSnapshot(name: name) }.value
+            _ = try? await engine.deleteSnapshot(name: name)
             load()
         }
     }
@@ -528,9 +499,7 @@ final class LibraryModel {
             exclusive: true
         )
         Task {
-            _ = await Task.detached(priority: .utility) {
-                try? engine.syncRemote(full: full)
-            }.value
+            _ = try? await engine.syncRemote(full: full)
             if let job { activity?.end(job) }
             isScanning = false
             albums = []
@@ -556,9 +525,7 @@ final class LibraryModel {
         )
         let progress = job.flatMap { activity?.reporter(for: $0) }
         Task {
-            let result = await Task.detached(priority: .utility) {
-                try? engine.scanReporting(force: force, reporter: progress)
-            }.value
+            let result = try? await engine.scanReporting(force: force, reporter: progress)
             if let job { activity?.end(job) }
             scanSummary = result
             isScanning = false

--- a/apps/macos/Sources/Koan/Support/PlayableTransfer.swift
+++ b/apps/macos/Sources/Koan/Support/PlayableTransfer.swift
@@ -57,14 +57,14 @@ struct PlayableTransfer: Codable, Transferable, Hashable {
 
     /// Resolve to track IDs. Off the main actor — this is a database read, and
     /// an artist is a large one.
-    func trackIds(using engine: KoanEngine) -> [Int64] {
+    func trackIds(using engine: KoanEngine) async -> [Int64] {
         switch kind {
         case .track:
             return [id]
         case .album:
-            return (try? engine.trackIds(albumId: id, artistId: nil)) ?? []
+            return (try? await engine.trackIds(albumId: id, artistId: nil)) ?? []
         case .artist:
-            return (try? engine.trackIds(albumId: nil, artistId: id)) ?? []
+            return (try? await engine.trackIds(albumId: nil, artistId: id)) ?? []
         }
     }
 }

--- a/apps/macos/Sources/Koan/Support/PlayerModel.swift
+++ b/apps/macos/Sources/Koan/Support/PlayerModel.swift
@@ -46,30 +46,35 @@ final class PlayerModel {
 
     init(engine: KoanEngine) {
         self.engine = engine
-        self.nowPlaying = engine.nowPlaying()
+        // Reading the engine is a suspension now, so the first frame renders
+        // against a stopped transport and `start()` fills it in.
+        self.nowPlaying = NowPlaying(
+            state: .stopped, positionMs: 0, durationMs: 0, queueItemId: nil,
+            entry: nil, format: nil, playlistVersion: 0, radioEnabled: false
+        )
     }
 
     /// Subscribe to engine events. Nothing here polls any more: the engine
     /// pushes state changes, queue changes and position, so the UI reacts
     /// rather than asking. The watching still happens — it just happens in
     /// Rust, over atomics, off the audio path.
-    func start() {
-        engine.subscribe(listener: EventBridge(model: self))
-        tick()  // Seed from current state; events only carry changes.
+    func start() async {
+        await engine.subscribe(listener: EventBridge(model: self))
+        await tick()  // Seed from current state; events only carry changes.
         refreshDevices()
         startAutosave()
     }
 
     /// Apply a snapshot. Called on subscribe and whenever the engine says
     /// something changed.
-    fileprivate func tick() {
-        let now = engine.nowPlaying()
+    fileprivate func tick() async {
+        let now = await engine.nowPlaying()
         nowPlaying = now
         updateDerived(now)
         // The queue only gets rebuilt when the engine says it changed.
         if nowPlaying.playlistVersion != knownQueueVersion {
             knownQueueVersion = nowPlaying.playlistVersion
-            rebuildQueue()
+            await rebuildQueue()
         }
         settlePendingSeek()
         onTick?()
@@ -92,8 +97,8 @@ final class PlayerModel {
         }
     }
 
-    private func rebuildQueue() {
-        queue = engine.queue()
+    private func rebuildQueue() async {
+        queue = await engine.queue()
         queuedByTrack = Dictionary(
             queue.compactMap { item in item.trackId.map { ($0, item) } },
             // A track queued twice: prefer the entry that is actually doing
@@ -103,9 +108,9 @@ final class PlayerModel {
     }
 
     /// The queue changed — rebuild it and refresh what depends on it.
-    fileprivate func applyQueueChange() {
-        rebuildQueue()
-        tick()
+    fileprivate func applyQueueChange() async {
+        await rebuildQueue()
+        await tick()
     }
 
     /// Position moved. The only genuinely periodic event, and the only thing
@@ -177,14 +182,14 @@ final class PlayerModel {
 
     // MARK: - Transport
 
-    func togglePlayPause() { attempt { try engine.togglePlayPause() } }
-    func pause() { attempt { try engine.pause() } }
-    func resume() { attempt { try engine.resume() } }
-    func next() { attempt { try engine.next() } }
-    func previous() { attempt { try engine.previous() } }
-    func stop() { attempt { try engine.stop() } }
+    func togglePlayPause() { attempt { try await self.engine.togglePlayPause() } }
+    func pause() { attempt { try await self.engine.pause() } }
+    func resume() { attempt { try await self.engine.resume() } }
+    func next() { attempt { try await self.engine.next() } }
+    func previous() { attempt { try await self.engine.previous() } }
+    func stop() { attempt { try await self.engine.stop() } }
 
-    func play(itemId: String) { attempt { try engine.play(queueItemId: itemId) } }
+    func play(itemId: String) { attempt { try await self.engine.play(queueItemId: itemId) } }
 
     /// Commit a scrub. Position comes from the drag, not the engine.
     func seek(fraction: Double) {
@@ -209,10 +214,9 @@ final class PlayerModel {
 
     /// Favourite whatever is playing. No-op when the queue item has no library
     /// row behind it.
-    @discardableResult
-    func toggleFavouriteCurrent() -> Bool {
-        guard let trackId = currentTrackId else { return false }
-        return toggleFavourite(trackId: trackId)
+    func toggleFavouriteCurrent() {
+        guard let trackId = currentTrackId else { return }
+        toggleFavourite(trackId: trackId)
     }
 
     /// Hold the requested position until the engine agrees with it.
@@ -227,7 +231,7 @@ final class PlayerModel {
         if clock.durationMs > 0 {
             scrubbing = Double(ms) / Double(clock.durationMs)
         }
-        attempt { try engine.seek(positionMs: ms) }
+        attempt { try await self.engine.seek(positionMs: ms) }
     }
 
     // MARK: - Queue
@@ -242,7 +246,7 @@ final class PlayerModel {
     func playNow(trackIds: [Int64], startingAt index: Int = 0) {
         guard !trackIds.isEmpty else { return }
         let start = trackIds.indices.contains(index) ? index : 0
-        offMain { _ = try $0.replaceQueue(trackIds: trackIds, startAt: UInt32(start)) }
+        mutate { _ = try await $0.replaceQueue(trackIds: trackIds, startAt: UInt32(start)) }
     }
 
     /// Queue immediately after whatever is playing, rather than at the end.
@@ -250,7 +254,7 @@ final class PlayerModel {
     func playNext(trackIds: [Int64]) {
         guard !trackIds.isEmpty else { return }
         guard let cursor = currentItemId else { return enqueue(trackIds: trackIds) }
-        offMain { _ = try $0.insertAfter(trackIds: trackIds, afterQueueItemId: cursor) }
+        mutate { _ = try await $0.insertAfter(trackIds: trackIds, afterQueueItemId: cursor) }
     }
 
     /// Surface a one-off message in the same place engine errors appear.
@@ -258,42 +262,40 @@ final class PlayerModel {
 
     func enqueue(trackIds: [Int64]) {
         guard !trackIds.isEmpty else { return }
-        offMain { _ = try $0.addToQueue(trackIds: trackIds) }
+        mutate { _ = try await $0.addToQueue(trackIds: trackIds) }
     }
 
     func remove(itemIds: [String]) {
         guard !itemIds.isEmpty else { return }
-        offMain { try $0.removeFromQueue(queueItemIds: itemIds) }
+        mutate { try await $0.removeFromQueue(queueItemIds: itemIds) }
     }
 
     /// `after: false` inserts *before* the target, which is the only way to
     /// express "put this at the very top" or "put this above that album".
     func move(itemIds: [String], target: String, after: Bool) {
-        offMain {
-            try $0.moveInQueue(queueItemIds: itemIds, targetQueueItemId: target, after: after)
+        mutate {
+            try await $0.moveInQueue(queueItemIds: itemIds, targetQueueItemId: target, after: after)
         }
     }
 
-    func clearQueue() { attempt { try engine.clearQueue() } }
-    func undo() { attempt { try engine.undo() } }
-    func redo() { attempt { try engine.redo() } }
+    func clearQueue() { attempt { try await self.engine.clearQueue() } }
+    func undo() { attempt { try await self.engine.undo() } }
+    func redo() { attempt { try await self.engine.redo() } }
 
     // MARK: - Devices & modes
 
     func refreshDevices() {
         let engine = self.engine
         Task {
-            let found = await Task.detached(priority: .utility) {
-                (try? engine.devices()) ?? []
-            }.value
+            let found = (try? await engine.devices()) ?? []
             self.devices = found
-            self.currentDevice = engine.currentDevice()
+            self.currentDevice = await engine.currentDevice()
         }
     }
 
     func setDevice(_ name: String?) {
         attempt {
-            if let name { try engine.setDevice(name: name) } else { try engine.clearDevice() }
+            if let name { try await self.engine.setDevice(name: name) } else { try await self.engine.clearDevice() }
         }
         currentDevice = name
     }
@@ -312,9 +314,8 @@ final class PlayerModel {
     func toggleRadio() { setRadio(!radioEnabled) }
 
     /// Toggles, and returns nothing — the library view refetches to pick it up.
-    @discardableResult
-    func toggleFavourite(trackId: Int64) -> Bool {
-        (try? engine.toggleFavourite(trackId: trackId)) ?? false
+    func toggleFavourite(trackId: Int64) {
+        attempt { _ = try await self.engine.toggleFavourite(trackId: trackId) }
     }
 
     // MARK: - Edit actions
@@ -361,7 +362,7 @@ final class PlayerModel {
         let ids = Pasteboard.readTrackIds()
         guard !ids.isEmpty else { return }
         if let anchor = queue.last(where: { queueSelection.contains($0.queueItemId) }) {
-            offMain { _ = try $0.insertAfter(trackIds: ids, afterQueueItemId: anchor.queueItemId) }
+            mutate { _ = try await $0.insertAfter(trackIds: ids, afterQueueItemId: anchor.queueItemId) }
         } else {
             enqueue(trackIds: ids)
         }
@@ -373,9 +374,10 @@ final class PlayerModel {
         guard !dropped.isEmpty else { return }
         let engine = self.engine
         Task {
-            let ids = await Task.detached(priority: .userInitiated) {
-                dropped.flatMap { $0.trackIds(using: engine) }
-            }.value
+            var ids: [Int64] = []
+            for item in dropped {
+                ids += await item.trackIds(using: engine)
+            }
             guard !ids.isEmpty else { return }
             if playImmediately { playNow(trackIds: ids) } else { enqueue(trackIds: ids) }
         }
@@ -385,8 +387,8 @@ final class PlayerModel {
 
     /// Persist the queue and position. Called on quit, and periodically so an
     /// unclean exit doesn't lose the session.
-    func saveSession() {
-        try? engine.saveSession()
+    func saveSession() async {
+        try? await engine.saveSession()
         savedQueueVersion = queueVersion
     }
 
@@ -402,9 +404,9 @@ final class PlayerModel {
                 try? await Task.sleep(for: .seconds(1))
                 guard let self else { return }
                 if self.queueVersion != self.savedQueueVersion {
-                    self.saveSession()
+                    await self.saveSession()
                 } else if self.nowPlaying.entry != nil {
-                    try? self.engine.savePosition()
+                    try? await self.engine.savePosition()
                 }
             }
         }
@@ -414,9 +416,7 @@ final class PlayerModel {
     func restoreSession() {
         let engine = self.engine
         Task {
-            _ = await Task.detached(priority: .userInitiated) {
-                try? engine.restoreSession()
-            }.value
+            _ = try? await engine.restoreSession()
         }
     }
 
@@ -425,29 +425,30 @@ final class PlayerModel {
     /// Engine calls fail for real reasons (device vanished, track gone) but
     /// none of them are worth a modal. Surface it and carry on.
     ///
-    /// For cheap calls only — transport commands are a send down a channel.
-    private func attempt(_ body: () throws -> Void) {
-        do {
-            try body()
-        } catch {
-            lastError = String(describing: error)
+    private func attempt(_ body: @escaping () async throws -> Void) {
+        Task {
+            do {
+                try await body()
+            } catch {
+                lastError = String(describing: error)
+            }
         }
     }
 
-    /// Run a blocking engine call off the main actor.
+    /// A queue mutation, with the spinner and the error reporting every one of
+    /// them wants.
     ///
-    /// Anything that touches the queue resolves every track against the
-    /// database and builds a playlist item for each. On an artist that is
-    /// thousands of rows, and on the main actor it freezes the window. Nothing
-    /// here needs the result, so nothing waits for it — the engine pushes an
-    /// event when the queue actually changes.
-    private func offMain(_ body: @escaping @Sendable (KoanEngine) throws -> Void) {
+    /// Nothing waits for the result — the engine pushes an event when the queue
+    /// actually changes — but these are ordered against each other on the
+    /// engine's side, so dropping in an album and then pressing undo cannot
+    /// land the wrong way round.
+    private func mutate(_ body: @escaping (KoanEngine) async throws -> Void) {
         let engine = self.engine
         pendingMutations += 1
         let job = activity?.begin("Updating queue")
         Task {
             do {
-                try await Task.detached(priority: .userInitiated) { try body(engine) }.value
+                try await body(engine)
             } catch {
                 lastError = String(describing: error)
             }
@@ -470,11 +471,11 @@ final class EventBridge: PlayerEvents, @unchecked Sendable {
     }
 
     func playbackChanged(nowPlaying: NowPlaying) {
-        Task { @MainActor [weak model] in model?.tick() }
+        Task { @MainActor [weak model] in await model?.tick() }
     }
 
     func queueChanged(version: UInt64) {
-        Task { @MainActor [weak model] in model?.applyQueueChange() }
+        Task { @MainActor [weak model] in await model?.applyQueueChange() }
     }
 
     func positionChanged(positionMs: UInt64) {

--- a/apps/macos/Sources/Koan/Support/SearchModel.swift
+++ b/apps/macos/Sources/Koan/Support/SearchModel.swift
@@ -107,13 +107,11 @@ final class SearchModel {
             try? await Task.sleep(for: .milliseconds(160))
             guard !Task.isCancelled else { return }
 
-            let found = await Task.detached(priority: .userInitiated) {
-                (
-                    (try? engine.search(query: text, limit: 60)) ?? [],
-                    (try? engine.fuzzySearch(query: text, kind: .album, limit: 30)) ?? [],
-                    (try? engine.fuzzySearch(query: text, kind: .artist, limit: 30)) ?? []
-                )
-            }.value
+            let found = (
+                (try? await engine.search(query: text, limit: 60)) ?? [],
+                (try? await engine.fuzzySearch(query: text, kind: .album, limit: 30)) ?? [],
+                (try? await engine.fuzzySearch(query: text, kind: .artist, limit: 30)) ?? []
+            )
 
             guard !Task.isCancelled else { return }
             tracks = found.0

--- a/apps/macos/Sources/Koan/Support/SettingsModel.swift
+++ b/apps/macos/Sources/Koan/Support/SettingsModel.swift
@@ -30,14 +30,14 @@ final class SettingsModel {
     /// the engine — the credential store is write-only from this side.
     var password = ""
 
-    init(engine: KoanEngine, activity: ActivityModel) {
+    init(engine: KoanEngine, activity: ActivityModel) async {
         self.engine = engine
         self.activity = activity
-        self.settings = engine.settings()
+        self.settings = await engine.settings()
     }
 
     func reload() {
-        settings = engine.settings()
+        Task { settings = await engine.settings() }
     }
 
     // MARK: - Editing
@@ -52,11 +52,13 @@ final class SettingsModel {
     }
 
     private func commit() {
-        do {
-            try engine.updateSettings(s: settings)
-            lastError = nil
-        } catch {
-            lastError = Self.describe(error)
+        Task {
+            do {
+                try await engine.updateSettings(s: settings)
+                lastError = nil
+            } catch {
+                lastError = Self.describe(error)
+            }
         }
     }
 
@@ -95,7 +97,7 @@ final class SettingsModel {
         let engine = self.engine
         Task {
             let result = await activity.run("Forgetting \(URL(fileURLWithPath: path).lastPathComponent)", exclusive: true) {
-                try engine.forgetFolder(path: path)
+                try await engine.forgetFolder(path: path)
             }
             switch result {
             case .success(let n): lastResult = "Forgot \(n.formatted(.number)) tracks"
@@ -113,7 +115,7 @@ final class SettingsModel {
             let result = await activity.runReporting(
                 force ? "Rescanning every file" : "Scanning library"
             ) { progress in
-                try engine.scanReporting(force: force, reporter: progress)
+                try await engine.scanReporting(force: force, reporter: progress)
             }
             switch result {
             case .success(let s):
@@ -130,7 +132,7 @@ final class SettingsModel {
         let password = self.password
         Task {
             let result = await activity.run("Signing in") {
-                try engine.signInRemote(url: url, username: username, password: password)
+                try await engine.signInRemote(url: url, username: username, password: password)
             }
             switch result {
             case .success:
@@ -145,23 +147,22 @@ final class SettingsModel {
     }
 
     func signOut(forgetTracks: Bool) {
-        do {
-            try engine.signOutRemote()
-            lastResult = "Signed out"
-            lastError = nil
-        } catch {
-            lastError = Self.describe(error)
-            reload()
-            return
-        }
-        guard forgetTracks else {
-            reload()
-            return
-        }
-        let engine = self.engine
         Task {
+            do {
+                try await engine.signOutRemote()
+                lastResult = "Signed out"
+                lastError = nil
+            } catch {
+                lastError = Self.describe(error)
+                reload()
+                return
+            }
+            guard forgetTracks else {
+                reload()
+                return
+            }
             let result = await activity.run("Forgetting the server's tracks", exclusive: true) {
-                try engine.forgetRemote()
+                try await self.engine.forgetRemote()
             }
             switch result {
             case .success(let n): lastResult = "Signed out and forgot \(n.formatted(.number)) tracks"
@@ -175,7 +176,7 @@ final class SettingsModel {
         let engine = self.engine
         Task {
             let result = await activity.run(full ? "Full sync with server" : "Syncing with server") {
-                try engine.syncRemote(full: full)
+                try await engine.syncRemote(full: full)
             }
             switch result {
             case .success(let s):
@@ -198,7 +199,7 @@ final class SettingsModel {
         let engine = self.engine
         Task {
             let result = await activity.run("Clearing downloads") {
-                try engine.clearDownloadCache()
+                try await engine.clearDownloadCache()
             }
             switch result {
             case .success(let c):
@@ -214,7 +215,7 @@ final class SettingsModel {
         let engine = self.engine
         Task {
             let result = await activity.run("Clearing the library index") {
-                try engine.rebuildIndex()
+                try await engine.rebuildIndex()
             }
             switch result {
             case .success(let s):

--- a/apps/macos/Sources/Koan/Views/ArtistBrowser.swift
+++ b/apps/macos/Sources/Koan/Views/ArtistBrowser.swift
@@ -145,21 +145,15 @@ struct ArtistDetailView: View {
     private func load() async {
         let engine = library.engine
         let id = artistId
-        albums = await Task.detached(priority: .userInitiated) {
-            (try? engine.albums(artistId: id, sort: .year)) ?? []
-        }.value
-        similar = await Task.detached(priority: .utility) {
-            (try? engine.similarArtists(artistId: id)) ?? []
-        }.value
+        albums = (try? await engine.albums(artistId: id, sort: .year)) ?? []
+        similar = (try? await engine.similarArtists(artistId: id)) ?? []
     }
 
     private func shufflePlay() {
         let engine = library.engine
         let id = artistId
         Task {
-            let ids = await Task.detached(priority: .userInitiated) {
-                ((try? engine.randomTracks(count: 50, artistId: id)) ?? []).map(\.id)
-            }.value
+            let ids = ((try? await engine.randomTracks(count: 50, artistId: id)) ?? []).map(\.id)
             player.playNow(trackIds: ids)
             library.showQueueWhenReady(watching: player)
         }

--- a/apps/macos/Sources/Koan/Views/LinkText.swift
+++ b/apps/macos/Sources/Koan/Views/LinkText.swift
@@ -103,11 +103,9 @@ struct PlayableArtwork: View {
         let engine = library.engine
         let albumId = self.albumId
         Task {
-            let ids = await Task.detached(priority: .userInitiated) {
-                ((try? engine.tracks(
-                    albumId: albumId, artistId: nil, sort: .album, limit: 500, offset: 0
-                )) ?? []).map(\.id)
-            }.value
+            let ids = ((try? await engine.tracks(
+                albumId: albumId, artistId: nil, sort: .album, limit: 500, offset: 0
+            )) ?? []).map(\.id)
             loading = false
             player.playNow(trackIds: ids)
             library.showQueueWhenReady(watching: player)

--- a/apps/macos/Sources/Koan/Views/LyricsPanel.swift
+++ b/apps/macos/Sources/Koan/Views/LyricsPanel.swift
@@ -113,14 +113,12 @@ struct LyricsPanel: View {
         guard trackId != loadedTrackId else { return }
 
         loadedTrackId = trackId
-        lyrics = try? library.engine.lyrics(trackId: trackId)
+        lyrics = try? await library.engine.lyrics(trackId: trackId)
         guard lyrics == nil else { return }
 
         loading = true
         let engine = library.engine
-        let fetched = await Task.detached(priority: .utility) {
-            try? engine.fetchLyrics(trackId: trackId)
-        }.value
+        let fetched = try? await engine.fetchLyrics(trackId: trackId)
         loading = false
         // The track may have changed while LRCLIB was answering.
         guard loadedTrackId == trackId else { return }

--- a/apps/macos/Sources/Koan/Views/PickerSheet.swift
+++ b/apps/macos/Sources/Koan/Views/PickerSheet.swift
@@ -184,22 +184,21 @@ struct PickerSheet: View {
         resolving = true
         let engine = library.engine
         Task {
-            let trackIds = await Task.detached(priority: .userInitiated) {
-                rows.flatMap { row -> [Int64] in
-                    switch row.kind {
-                    case .track:
-                        return [row.id]
-                    case .album:
-                        return ((try? engine.tracks(
-                            albumId: row.id, artistId: nil, sort: .album, limit: 500, offset: 0
-                        )) ?? []).map(\.id)
-                    case .artist:
-                        return ((try? engine.tracks(
-                            albumId: nil, artistId: row.id, sort: .album, limit: 2000, offset: 0
-                        )) ?? []).map(\.id)
-                    }
+            var trackIds: [Int64] = []
+            for row in rows {
+                switch row.kind {
+                case .track:
+                    trackIds.append(row.id)
+                case .album:
+                    trackIds += ((try? await engine.tracks(
+                        albumId: row.id, artistId: nil, sort: .album, limit: 500, offset: 0
+                    )) ?? []).map(\.id)
+                case .artist:
+                    trackIds += ((try? await engine.tracks(
+                        albumId: nil, artistId: row.id, sort: .album, limit: 2000, offset: 0
+                    )) ?? []).map(\.id)
                 }
-            }.value
+            }
 
             resolving = false
             guard !trackIds.isEmpty else { return }
@@ -243,10 +242,10 @@ struct PickerSheet: View {
             try? await Task.sleep(for: .milliseconds(140))
             guard !Task.isCancelled else { return }
 
-            let found = await Task.detached(priority: .userInitiated) { () -> [PickerRow] in
+            let found: [PickerRow] =
                 switch kind {
                 case .track:
-                    return ((try? engine.search(query: text, limit: 60)) ?? []).map {
+                    ((try? await engine.search(query: text, limit: 60)) ?? []).map {
                         PickerRow(
                             id: $0.id,
                             kind: .track,
@@ -256,11 +255,10 @@ struct PickerSheet: View {
                         )
                     }
                 case .album, .artist:
-                    return ((try? engine.fuzzySearch(query: text, kind: kind, limit: 40)) ?? []).map {
+                    ((try? await engine.fuzzySearch(query: text, kind: kind, limit: 40)) ?? []).map {
                         PickerRow(id: $0.id, kind: kind, title: $0.name, subtitle: nil, durationMs: nil)
                     }
                 }
-            }.value
 
             guard !Task.isCancelled else { return }
             results = found

--- a/apps/macos/Sources/Koan/Views/PlayableMenu.swift
+++ b/apps/macos/Sources/Koan/Views/PlayableMenu.swift
@@ -30,14 +30,14 @@ enum Playable {
         }
     }
 
-    func trackIds(using engine: KoanEngine) -> [Int64] {
+    func trackIds(using engine: KoanEngine) async -> [Int64] {
         switch self {
         case .track(let t):
             return [t.id]
         case .album(let a):
-            return (try? engine.trackIds(albumId: a.id, artistId: nil)) ?? []
+            return (try? await engine.trackIds(albumId: a.id, artistId: nil)) ?? []
         case .artist(let id, _):
-            return (try? engine.trackIds(albumId: nil, artistId: id)) ?? []
+            return (try? await engine.trackIds(albumId: nil, artistId: id)) ?? []
         }
     }
 }
@@ -114,9 +114,7 @@ struct PlayableMenu: View {
         let engine = library.engine
         let playable = self.playable
         Task {
-            let ids = await Task.detached(priority: .userInitiated) {
-                playable.trackIds(using: engine)
-            }.value
+            let ids = await playable.trackIds(using: engine)
             guard !ids.isEmpty else { return }
             body(ids)
         }
@@ -141,14 +139,16 @@ enum Share {
     static func link(for playable: Playable, engine: KoanEngine, player: PlayerModel) {
         let name = playable.name
         Task {
-            let result = await Task.detached(priority: .userInitiated) { () -> Result<KoanFFI.Share, Error> in
-                let ids = playable.trackIds(using: engine)
-                guard !ids.isEmpty else {
-                    return .failure(ShareFailure.nothingToShare)
-                }
-                return Result { try engine.createShare(trackIds: ids, description: name) }
-            }.value
-            deliver(result, to: player)
+            let ids = await playable.trackIds(using: engine)
+            guard !ids.isEmpty else {
+                return deliver(.failure(ShareFailure.nothingToShare), to: player)
+            }
+            do {
+                let share = try await engine.createShare(trackIds: ids, description: name)
+                deliver(.success(share), to: player)
+            } catch {
+                deliver(.failure(error), to: player)
+            }
         }
     }
 
@@ -164,10 +164,12 @@ enum Share {
             return
         }
         Task {
-            let result = await Task.detached(priority: .userInitiated) { () -> Result<KoanFFI.Share, Error> in
-                Result { try engine.createShare(trackIds: trackIds, description: name) }
-            }.value
-            deliver(result, to: player)
+            do {
+                let share = try await engine.createShare(trackIds: trackIds, description: name)
+                deliver(.success(share), to: player)
+            } catch {
+                deliver(.failure(error), to: player)
+            }
         }
     }
 
@@ -267,9 +269,7 @@ struct PlayableHeaderButton: View {
             let engine = library.engine
             let playable = self.playable
             Task {
-                let ids = await Task.detached(priority: .userInitiated) {
-                    playable.trackIds(using: engine)
-                }.value
+                let ids = await playable.trackIds(using: engine)
                 loading = false
                 player.playNow(trackIds: ids)
                 library.showQueueWhenReady(watching: player)
@@ -329,9 +329,7 @@ struct QueueButtons: View {
         working = true
         let engine = library.engine
         Task {
-            let ids = await Task.detached(priority: .userInitiated) {
-                playable.trackIds(using: engine)
-            }.value
+            let ids = await playable.trackIds(using: engine)
             working = false
             guard !ids.isEmpty else { return }
             body(ids)

--- a/apps/macos/Sources/Koan/Views/QueueView.swift
+++ b/apps/macos/Sources/Koan/Views/QueueView.swift
@@ -195,9 +195,7 @@ struct QueueView: View {
     private func showInLibrary(trackId: Int64, highlight: Bool) {
         let engine = library.engine
         Task {
-            let albumId = await Task.detached(priority: .userInitiated) {
-                (try? engine.track(trackId: trackId))??.albumId
-            }.value
+            let albumId = (try? await engine.track(trackId: trackId))??.albumId
             guard let albumId else {
                 player.report("That track is no longer in the library.")
                 return

--- a/apps/macos/Sources/Koan/Views/RowPlayButton.swift
+++ b/apps/macos/Sources/Koan/Views/RowPlayButton.swift
@@ -45,9 +45,7 @@ struct RowPlayButton: View {
         let engine = library.engine
         let playable = self.playable
         Task {
-            let ids = await Task.detached(priority: .userInitiated) {
-                playable.trackIds(using: engine)
-            }.value
+            let ids = await playable.trackIds(using: engine)
             loading = false
             player.playNow(trackIds: ids)
             library.showQueueWhenReady(watching: player)

--- a/apps/macos/Sources/Koan/Views/SettingsView.swift
+++ b/apps/macos/Sources/Koan/Views/SettingsView.swift
@@ -34,9 +34,9 @@ struct SettingsView: View {
             }
         }
         .frame(width: 560, height: 460)
-        .onAppear {
+        .task {
             if model == nil {
-                let created = SettingsModel(engine: library.engine, activity: activity)
+                let created = await SettingsModel(engine: library.engine, activity: activity)
                 created.library = library
                 model = created
             }

--- a/apps/macos/Sources/Koan/Views/SnapshotsView.swift
+++ b/apps/macos/Sources/Koan/Views/SnapshotsView.swift
@@ -32,7 +32,7 @@ struct SnapshotsView: View {
                             }
                             Spacer()
                             Button("Restore") {
-                                try? player.engine.restoreSnapshot(name: snapshot.name)
+                                Task { try? await player.engine.restoreSnapshot(name: snapshot.name) }
                             }
                             Button {
                                 library.deleteSnapshot(name: snapshot.name)

--- a/crates/koan-ffi/Cargo.toml
+++ b/crates/koan-ffi/Cargo.toml
@@ -31,6 +31,11 @@ nucleo = "0.5"
 parking_lot = "0.12"
 rusqlite = { workspace = true }
 thiserror = "2"
+tokio = { version = "1", features = ["rt", "sync"] }
 uniffi = { version = "0.32", features = ["cli"] }
 uuid = { version = "1", features = ["v7"] }
 chrono = "0.4"
+
+[dev-dependencies]
+futures-lite = "2"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/crates/koan-ffi/src/lib.rs
+++ b/crates/koan-ffi/src/lib.rs
@@ -7,11 +7,14 @@
 //! to reach it; GraphQL stays the surface for clients that genuinely can't
 //! link the core (web, iOS, jukebox remotes).
 //!
-//! Threading: the engine is `Send + Sync` and every method blocks. Callers on
-//! the UI thread should keep the long ones (`scan`, `fuzzy_search` over a large
-//! library) on a background queue. DB connections are opened per call, matching
-//! what the GraphQL resolvers do — WAL makes that cheap and it sidesteps
-//! holding a lock across a scan.
+//! Threading: anything that can block is `async` and runs on a worker thread,
+//! so no caller is ever holding a thread while koan-core reads a file or waits
+//! on a socket. The handful of methods that stay synchronous read an atomic or
+//! a lock and nothing else — see `offload` for where the work actually goes and
+//! why ordering has a lane of its own.
+//!
+//! DB connections are opened per call, matching what the GraphQL resolvers do —
+//! WAL makes that cheap and it sidesteps holding a lock across a scan.
 
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
@@ -29,6 +32,7 @@ use koan_core::player::state::{
 };
 use uuid::Uuid;
 
+mod offload;
 mod types;
 pub use types::*;
 
@@ -165,124 +169,66 @@ pub struct KoanEngine {
 impl KoanEngine {
     /// Spawns the player thread and opens the library. One per process.
     #[uniffi::constructor]
-    pub fn new() -> Result<Arc<Self>, KoanError> {
-        init_logging();
-        let db_path = config::db_path();
-        // Fail fast on a broken library rather than after the audio threads exist.
-        Database::open(&db_path).map_err(|e| KoanError::Database {
-            message: e.to_string(),
-        })?;
-
-        let (state, _timeline, _viz, tx) = Player::spawn();
-        koan_core::radio::spawn_autoqueue(state.clone(), tx.clone(), db_path.clone());
-
-        let auto_syncing = Arc::new(std::sync::atomic::AtomicBool::new(false));
-        {
-            let flag = auto_syncing.clone();
-            koan_core::helpers::spawn_auto_sync(db_path.clone(), move |running| {
-                flag.store(running, std::sync::atomic::Ordering::Relaxed);
-            });
-        }
-
-        // Local files are watched rather than synced on a timer: a folder that
-        // has not changed costs nothing to notice, and one that has should show
-        // up without being asked.
-        let auto_scanning = Arc::new(std::sync::atomic::AtomicBool::new(false));
-        {
-            let flag = auto_scanning.clone();
-            koan_core::helpers::spawn_library_watch(db_path.clone(), move |running| {
-                flag.store(running, std::sync::atomic::Ordering::Relaxed);
-            });
-        }
-
-        let listener: Arc<parking_lot::RwLock<Option<Arc<dyn PlayerEvents>>>> =
-            Arc::new(parking_lot::RwLock::new(None));
-        let engine = Arc::new(Self {
-            state,
-            tx,
-            db_path,
-            auto_syncing,
-            auto_scanning,
-            cancel_library_task: Arc::new(std::sync::atomic::AtomicBool::new(false)),
-            listener,
-        });
-        engine.spawn_watcher();
-        Ok(engine)
+    pub async fn new() -> Result<Arc<Self>, KoanError> {
+        offload::offload(Self::build).await
     }
-
     // --- Transport ---------------------------------------------------------
 
     /// Move the cursor to `queue_item_id` and start playing it.
-    pub fn play(&self, queue_item_id: String) -> Result<(), KoanError> {
-        self.send(PlayerCommand::Play(parse_qid(&queue_item_id)?))
+    pub async fn play(self: Arc<Self>, queue_item_id: String) -> Result<(), KoanError> {
+        offload::sequenced(move || self.send(PlayerCommand::Play(parse_qid(&queue_item_id)?))).await
     }
 
-    pub fn pause(&self) -> Result<(), KoanError> {
-        self.send(PlayerCommand::Pause)
+    pub async fn pause(self: Arc<Self>) -> Result<(), KoanError> {
+        offload::sequenced(move || self.send(PlayerCommand::Pause)).await
     }
 
-    pub fn resume(&self) -> Result<(), KoanError> {
-        self.send(PlayerCommand::Resume)
+    pub async fn resume(self: Arc<Self>) -> Result<(), KoanError> {
+        offload::sequenced(move || self.send(PlayerCommand::Resume)).await
     }
 
-    pub fn stop(&self) -> Result<(), KoanError> {
-        self.send(PlayerCommand::Stop)
+    pub async fn stop(self: Arc<Self>) -> Result<(), KoanError> {
+        offload::sequenced(move || self.send(PlayerCommand::Stop)).await
     }
 
     /// Space-bar behaviour: pause when playing, resume otherwise.
-    pub fn toggle_play_pause(&self) -> Result<(), KoanError> {
-        match self.state.playback_state() {
-            PlaybackState::Playing => self.pause(),
-            _ => self.resume(),
-        }
+    pub async fn toggle_play_pause(self: Arc<Self>) -> Result<(), KoanError> {
+        offload::sequenced(move || match self.state.playback_state() {
+            PlaybackState::Playing => self.send(PlayerCommand::Pause),
+            _ => self.send(PlayerCommand::Resume),
+        })
+        .await
     }
 
-    pub fn next(&self) -> Result<(), KoanError> {
-        self.send(PlayerCommand::NextTrack)
+    pub async fn next(self: Arc<Self>) -> Result<(), KoanError> {
+        offload::sequenced(move || self.send(PlayerCommand::NextTrack)).await
     }
 
-    pub fn previous(&self) -> Result<(), KoanError> {
-        self.send(PlayerCommand::PrevTrack)
+    pub async fn previous(self: Arc<Self>) -> Result<(), KoanError> {
+        offload::sequenced(move || self.send(PlayerCommand::PrevTrack)).await
     }
 
-    pub fn seek(&self, position_ms: u64) -> Result<(), KoanError> {
-        self.send(PlayerCommand::Seek(position_ms))
+    pub async fn seek(self: Arc<Self>, position_ms: u64) -> Result<(), KoanError> {
+        offload::sequenced(move || self.send(PlayerCommand::Seek(position_ms))).await
     }
 
     // --- Observable state --------------------------------------------------
 
     /// One consistent read of everything the transport bar needs. The UI polls
     /// this; `playlist_version` tells it whether the queue also needs refetching.
-    pub fn now_playing(&self) -> NowPlaying {
-        let info = self.state.track_info();
-        let cursor = self.state.cursor();
-        let play_state = self.state.playback_state();
-        let entry = cursor
-            .and_then(|cid| self.state.get_item(cid))
-            .map(|item| QueueItem::from_cursor_item(&item, play_state));
-
-        NowPlaying {
-            state: play_state.into(),
-            position_ms: self.state.position_ms(),
-            duration_ms: info.as_ref().map(|i| i.duration_ms).unwrap_or(0),
-            queue_item_id: cursor.map(|c| c.0.to_string()),
-            entry,
-            format: info.as_ref().map(StreamFormat::from),
-            playlist_version: self.state.playlist_version(),
-            radio_enabled: self.state.radio_mode(),
-        }
+    pub async fn now_playing(self: Arc<Self>) -> NowPlaying {
+        offload::offload(move || self.now_playing_blocking()).await
     }
-
     /// Start pushing events to `listener`. Replaces polling `now_playing()`.
     ///
     /// One listener at a time — a second call replaces the first, which is what
     /// a single UI wants and avoids leaking a listener across a reload.
-    pub fn subscribe(&self, listener: Arc<dyn PlayerEvents>) {
-        *self.listener.write() = Some(listener);
+    pub async fn subscribe(self: Arc<Self>, listener: Arc<dyn PlayerEvents>) {
+        offload::offload(move || *self.listener.write() = Some(listener)).await
     }
 
-    pub fn unsubscribe(&self) {
-        *self.listener.write() = None;
+    pub async fn unsubscribe(self: Arc<Self>) {
+        offload::offload(move || *self.listener.write() = None).await
     }
 
     /// Cheap enough to poll every frame — use it to decide whether to call
@@ -291,37 +237,48 @@ impl KoanEngine {
         self.state.playlist_version()
     }
 
-    pub fn queue(&self) -> Vec<QueueItem> {
-        self.state
-            .derive_visible_queue()
-            .entries
-            .iter()
-            .map(QueueItem::from)
-            .collect()
+    /// Off-thread despite touching no I/O: this clones every entry, strings
+    /// included, and runs on every queue change. A long queue is real work.
+    pub async fn queue(self: Arc<Self>) -> Vec<QueueItem> {
+        offload::offload(move || {
+            self.state
+                .derive_visible_queue()
+                .entries
+                .iter()
+                .map(QueueItem::from)
+                .collect()
+        })
+        .await
     }
 
     // --- Queue mutation ----------------------------------------------------
 
     /// Append tracks. Starts playback if the player was stopped, and kicks off
     /// downloads for anything remote. Returns the new queue item IDs.
-    pub fn add_to_queue(&self, track_ids: Vec<i64>) -> Result<Vec<String>, KoanError> {
-        let db = self.db()?;
-        let (items, pending) = self.build_items(&db, &track_ids);
-        if items.is_empty() {
-            return Ok(Vec::new());
-        }
+    pub async fn add_to_queue(
+        self: Arc<Self>,
+        track_ids: Vec<i64>,
+    ) -> Result<Vec<String>, KoanError> {
+        offload::sequenced(move || {
+            let db = self.db()?;
+            let (items, pending) = self.build_items(&db, &track_ids);
+            if items.is_empty() {
+                return Ok(Vec::new());
+            }
 
-        let ids: Vec<String> = items.iter().map(|i| i.id.0.to_string()).collect();
-        let first = items[0].id;
-        let was_stopped = self.state.playback_state() == PlaybackState::Stopped;
+            let ids: Vec<String> = items.iter().map(|i| i.id.0.to_string()).collect();
+            let first = items[0].id;
+            let was_stopped = self.state.playback_state() == PlaybackState::Stopped;
 
-        self.send(PlayerCommand::AddToPlaylist(items))?;
-        if was_stopped {
-            let _ = self.tx.send(PlayerCommand::Play(first));
-        }
-        self.start_downloads(pending);
+            self.send(PlayerCommand::AddToPlaylist(items))?;
+            if was_stopped {
+                let _ = self.tx.send(PlayerCommand::Play(first));
+            }
+            self.start_downloads(pending);
 
-        Ok(ids)
+            Ok(ids)
+        })
+        .await
     }
 
     /// Clear the queue and play `track_ids` from the top.
@@ -331,254 +288,306 @@ impl KoanEngine {
     /// two commands means the first track audibly starts before the jump lands:
     /// clicking track nine of an album flashed track one as playing first.
     /// An index past the end starts at the beginning.
-    pub fn replace_queue(
-        &self,
+    pub async fn replace_queue(
+        self: Arc<Self>,
         track_ids: Vec<i64>,
         start_at: Option<u32>,
     ) -> Result<Vec<String>, KoanError> {
-        let db = self.db()?;
-        let (items, pending) = self.build_items(&db, &track_ids);
-        if items.is_empty() {
-            self.send(PlayerCommand::ClearPlaylist)?;
-            return Ok(Vec::new());
-        }
+        offload::sequenced(move || {
+            let db = self.db()?;
+            let (items, pending) = self.build_items(&db, &track_ids);
+            if items.is_empty() {
+                self.send(PlayerCommand::ClearPlaylist)?;
+                return Ok(Vec::new());
+            }
 
-        let ids: Vec<String> = items.iter().map(|i| i.id.0.to_string()).collect();
-        self.send(PlayerCommand::ReplacePlaylist {
-            items,
-            start: start_at.unwrap_or(0) as usize,
-        })?;
-        self.start_downloads(pending);
+            let ids: Vec<String> = items.iter().map(|i| i.id.0.to_string()).collect();
+            self.send(PlayerCommand::ReplacePlaylist {
+                items,
+                start: start_at.unwrap_or(0) as usize,
+            })?;
+            self.start_downloads(pending);
 
-        Ok(ids)
+            Ok(ids)
+        })
+        .await
     }
 
     /// Insert after an existing item — what a drop between two rows means.
-    pub fn insert_after(
-        &self,
+    pub async fn insert_after(
+        self: Arc<Self>,
         track_ids: Vec<i64>,
         after_queue_item_id: String,
     ) -> Result<Vec<String>, KoanError> {
-        let after = parse_qid(&after_queue_item_id)?;
-        let db = self.db()?;
-        let (items, pending) = self.build_items(&db, &track_ids);
-        if items.is_empty() {
-            return Ok(Vec::new());
-        }
+        offload::sequenced(move || {
+            let after = parse_qid(&after_queue_item_id)?;
+            let db = self.db()?;
+            let (items, pending) = self.build_items(&db, &track_ids);
+            if items.is_empty() {
+                return Ok(Vec::new());
+            }
 
-        let ids: Vec<String> = items.iter().map(|i| i.id.0.to_string()).collect();
-        self.send(PlayerCommand::InsertInPlaylist { items, after })?;
-        self.start_downloads(pending);
+            let ids: Vec<String> = items.iter().map(|i| i.id.0.to_string()).collect();
+            self.send(PlayerCommand::InsertInPlaylist { items, after })?;
+            self.start_downloads(pending);
 
-        Ok(ids)
+            Ok(ids)
+        })
+        .await
     }
 
     /// Removed as one undo step, however many IDs are passed.
-    pub fn remove_from_queue(&self, queue_item_ids: Vec<String>) -> Result<(), KoanError> {
-        let ids = parse_qids(&queue_item_ids)?;
-        self.send(PlayerCommand::RemoveFromPlaylistBatch(ids))
+    pub async fn remove_from_queue(
+        self: Arc<Self>,
+        queue_item_ids: Vec<String>,
+    ) -> Result<(), KoanError> {
+        offload::sequenced(move || {
+            let ids = parse_qids(&queue_item_ids)?;
+            self.send(PlayerCommand::RemoveFromPlaylistBatch(ids))
+        })
+        .await
     }
 
     /// Reorder. `after` puts the items below the target rather than above.
-    pub fn move_in_queue(
-        &self,
+    pub async fn move_in_queue(
+        self: Arc<Self>,
         queue_item_ids: Vec<String>,
         target_queue_item_id: String,
         after: bool,
     ) -> Result<(), KoanError> {
-        let ids = parse_qids(&queue_item_ids)?;
-        let target = parse_qid(&target_queue_item_id)?;
-        self.send(PlayerCommand::MoveItemsInPlaylist { ids, target, after })
+        offload::sequenced(move || {
+            let ids = parse_qids(&queue_item_ids)?;
+            let target = parse_qid(&target_queue_item_id)?;
+            self.send(PlayerCommand::MoveItemsInPlaylist { ids, target, after })
+        })
+        .await
     }
 
-    pub fn clear_queue(&self) -> Result<(), KoanError> {
-        self.send(PlayerCommand::ClearPlaylist)
+    pub async fn clear_queue(self: Arc<Self>) -> Result<(), KoanError> {
+        offload::sequenced(move || self.send(PlayerCommand::ClearPlaylist)).await
     }
 
-    pub fn undo(&self) -> Result<(), KoanError> {
-        self.send(PlayerCommand::Undo)
+    pub async fn undo(self: Arc<Self>) -> Result<(), KoanError> {
+        offload::sequenced(move || self.send(PlayerCommand::Undo)).await
     }
 
-    pub fn redo(&self) -> Result<(), KoanError> {
-        self.send(PlayerCommand::Redo)
+    pub async fn redo(self: Arc<Self>) -> Result<(), KoanError> {
+        offload::sequenced(move || self.send(PlayerCommand::Redo)).await
     }
 
     // --- Library -----------------------------------------------------------
 
-    pub fn artists(&self, search: Option<String>) -> Result<Vec<Artist>, KoanError> {
-        let db = self.db()?;
-        let rows = match search.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
-            Some(q) => queries::find_artists(&db.conn, q),
-            None => queries::all_artists(&db.conn),
-        }
-        .map_err(db_err)?;
-        Ok(rows.into_iter().map(Artist::from).collect())
-    }
-
-    pub fn albums(&self, artist_id: Option<i64>, sort: AlbumSort) -> Result<Vec<Album>, KoanError> {
-        let db = self.db()?;
-        let rows = match artist_id {
-            Some(id) => queries::albums_for_artist(&db.conn, id),
-            None => queries::all_albums(&db.conn),
-        }
-        .map_err(db_err)?;
-
-        let mut albums: Vec<Album> = rows.into_iter().map(Album::from).collect();
-        match sort {
-            // Albums predating the added_at column sort last rather than first,
-            // which is what an empty string would do.
-            AlbumSort::RecentlyAdded => albums.sort_by(|a, b| {
-                b.added_at
-                    .as_deref()
-                    .unwrap_or("")
-                    .cmp(a.added_at.as_deref().unwrap_or(""))
-            }),
-            AlbumSort::Title => albums.sort_by_key(|a| a.title.to_lowercase()),
-            AlbumSort::Artist => {
-                albums.sort_by_key(|a| (a.artist_name.to_lowercase(), a.year.unwrap_or(0)))
+    pub async fn artists(
+        self: Arc<Self>,
+        search: Option<String>,
+    ) -> Result<Vec<Artist>, KoanError> {
+        offload::offload(move || {
+            let db = self.db()?;
+            let rows = match search.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
+                Some(q) => queries::find_artists(&db.conn, q),
+                None => queries::all_artists(&db.conn),
             }
-            AlbumSort::Year => albums.sort_by_key(|a| std::cmp::Reverse(a.year.unwrap_or(0))),
-            AlbumSort::Random => shuffle(&mut albums),
-        }
-        Ok(albums)
+            .map_err(db_err)?;
+            Ok(rows.into_iter().map(Artist::from).collect())
+        })
+        .await
     }
 
-    pub fn album(&self, album_id: i64) -> Result<Option<Album>, KoanError> {
-        let db = self.db()?;
-        Ok(queries::get_album(&db.conn, album_id)
-            .map_err(db_err)?
-            .map(Album::from))
+    pub async fn albums(
+        self: Arc<Self>,
+        artist_id: Option<i64>,
+        sort: AlbumSort,
+    ) -> Result<Vec<Album>, KoanError> {
+        offload::offload(move || {
+            let db = self.db()?;
+            let rows = match artist_id {
+                Some(id) => queries::albums_for_artist(&db.conn, id),
+                None => queries::all_albums(&db.conn),
+            }
+            .map_err(db_err)?;
+
+            let mut albums: Vec<Album> = rows.into_iter().map(Album::from).collect();
+            match sort {
+                // Albums predating the added_at column sort last rather than first,
+                // which is what an empty string would do.
+                AlbumSort::RecentlyAdded => albums.sort_by(|a, b| {
+                    b.added_at
+                        .as_deref()
+                        .unwrap_or("")
+                        .cmp(a.added_at.as_deref().unwrap_or(""))
+                }),
+                AlbumSort::Title => albums.sort_by_key(|a| a.title.to_lowercase()),
+                AlbumSort::Artist => {
+                    albums.sort_by_key(|a| (a.artist_name.to_lowercase(), a.year.unwrap_or(0)))
+                }
+                AlbumSort::Year => albums.sort_by_key(|a| std::cmp::Reverse(a.year.unwrap_or(0))),
+                AlbumSort::Random => shuffle(&mut albums),
+            }
+            Ok(albums)
+        })
+        .await
+    }
+
+    pub async fn album(self: Arc<Self>, album_id: i64) -> Result<Option<Album>, KoanError> {
+        offload::offload(move || {
+            let db = self.db()?;
+            Ok(queries::get_album(&db.conn, album_id)
+                .map_err(db_err)?
+                .map(Album::from))
+        })
+        .await
     }
 
     /// Tracks for an album or artist, or a page of the whole library when
     /// neither is given.
-    pub fn tracks(
-        &self,
+    pub async fn tracks(
+        self: Arc<Self>,
         album_id: Option<i64>,
         artist_id: Option<i64>,
         sort: TrackSort,
         limit: u32,
         offset: u32,
     ) -> Result<Vec<Track>, KoanError> {
-        let db = self.db()?;
-        let rows = match (album_id, artist_id) {
-            (Some(aid), _) => queries::tracks_for_album(&db.conn, aid),
-            (None, Some(aid)) => queries::tracks_for_artist(&db.conn, aid),
-            (None, None) => queries::all_tracks_paged(&db.conn, limit, offset),
-        }
-        .map_err(db_err)?;
-        Ok(self.decorate(&db, sort_rows(rows, sort)))
+        offload::offload(move || self.tracks_blocking(album_id, artist_id, sort, limit, offset))
+            .await
     }
 
-    pub fn track(&self, track_id: i64) -> Result<Option<Track>, KoanError> {
-        let db = self.db()?;
-        let Some(row) = queries::get_track_row(&db.conn, track_id).map_err(db_err)? else {
-            return Ok(None);
-        };
-        Ok(self.decorate(&db, vec![row]).into_iter().next())
+    pub async fn track(self: Arc<Self>, track_id: i64) -> Result<Option<Track>, KoanError> {
+        offload::offload(move || {
+            let db = self.db()?;
+            let Some(row) = queries::get_track_row(&db.conn, track_id).map_err(db_err)? else {
+                return Ok(None);
+            };
+            Ok(self.decorate(&db, vec![row]).into_iter().next())
+        })
+        .await
     }
 
     /// FTS5 search across title, artist, album, genre.
-    pub fn search(&self, query: String, limit: u32) -> Result<Vec<Track>, KoanError> {
-        let db = self.db()?;
-        let rows = queries::search_tracks_paged(&db.conn, &query, limit, 0).map_err(db_err)?;
-        Ok(self.decorate(&db, rows))
+    pub async fn search(
+        self: Arc<Self>,
+        query: String,
+        limit: u32,
+    ) -> Result<Vec<Track>, KoanError> {
+        offload::offload(move || {
+            let db = self.db()?;
+            let rows = queries::search_tracks_paged(&db.conn, &query, limit, 0).map_err(db_err)?;
+            Ok(self.decorate(&db, rows))
+        })
+        .await
     }
 
     /// Nucleo fuzzy match — what the command palette wants. Ranked, best first.
-    pub fn fuzzy_search(
-        &self,
+    pub async fn fuzzy_search(
+        self: Arc<Self>,
         query: String,
         kind: SearchKind,
         limit: u32,
     ) -> Result<Vec<FuzzyMatch>, KoanError> {
-        use nucleo::pattern::{CaseMatching, Normalization};
-        use nucleo::{Config as NucleoConfig, Nucleo};
+        offload::offload(move || {
+            use nucleo::pattern::{CaseMatching, Normalization};
+            use nucleo::{Config as NucleoConfig, Nucleo};
 
-        let db = self.db()?;
-        let items: Vec<(i64, String)> = match kind {
-            SearchKind::Track => queries::all_tracks(&db.conn)
-                .map_err(db_err)?
-                .into_iter()
-                .map(|t| {
-                    (
-                        t.id,
-                        format!("{} — {} — {}", t.artist_name, t.album_title, t.title),
-                    )
-                })
-                .collect(),
-            SearchKind::Album => queries::all_albums(&db.conn)
-                .map_err(db_err)?
-                .into_iter()
-                .map(|a| (a.id, format!("{} — {}", a.artist_name, a.title)))
-                .collect(),
-            SearchKind::Artist => queries::all_artists(&db.conn)
-                .map_err(db_err)?
-                .into_iter()
-                .map(|a| (a.id, a.name))
-                .collect(),
-        };
+            let db = self.db()?;
+            let items: Vec<(i64, String)> = match kind {
+                SearchKind::Track => queries::all_tracks(&db.conn)
+                    .map_err(db_err)?
+                    .into_iter()
+                    .map(|t| {
+                        (
+                            t.id,
+                            format!("{} — {} — {}", t.artist_name, t.album_title, t.title),
+                        )
+                    })
+                    .collect(),
+                SearchKind::Album => queries::all_albums(&db.conn)
+                    .map_err(db_err)?
+                    .into_iter()
+                    .map(|a| (a.id, format!("{} — {}", a.artist_name, a.title)))
+                    .collect(),
+                SearchKind::Artist => queries::all_artists(&db.conn)
+                    .map_err(db_err)?
+                    .into_iter()
+                    .map(|a| (a.id, a.name))
+                    .collect(),
+            };
 
-        let mut nucleo: Nucleo<u32> = Nucleo::new(NucleoConfig::DEFAULT, Arc::new(|| {}), None, 1);
-        let injector = nucleo.injector();
-        for (i, (_, text)) in items.iter().enumerate() {
-            let text = text.clone();
-            injector.push(i as u32, |_val, cols| {
-                cols[0] = text.into();
-            });
-        }
-
-        nucleo
-            .pattern
-            .reparse(0, &query, CaseMatching::Smart, Normalization::Smart, false);
-        for _ in 0..20 {
-            nucleo.tick(10);
-        }
-
-        let snap = nucleo.snapshot();
-        let count = (snap.matched_item_count() as usize).min(limit as usize);
-        let mut out = Vec::with_capacity(count);
-        for i in 0..count as u32 {
-            if let Some(item) = snap.get_matched_item(i)
-                && let Some((id, name)) = items.get(*item.data as usize)
-            {
-                out.push(FuzzyMatch {
-                    id: *id,
-                    name: name.clone(),
-                    kind,
+            let mut nucleo: Nucleo<u32> =
+                Nucleo::new(NucleoConfig::DEFAULT, Arc::new(|| {}), None, 1);
+            let injector = nucleo.injector();
+            for (i, (_, text)) in items.iter().enumerate() {
+                let text = text.clone();
+                injector.push(i as u32, |_val, cols| {
+                    cols[0] = text.into();
                 });
             }
-        }
-        Ok(out)
+
+            nucleo
+                .pattern
+                .reparse(0, &query, CaseMatching::Smart, Normalization::Smart, false);
+            for _ in 0..20 {
+                nucleo.tick(10);
+            }
+
+            let snap = nucleo.snapshot();
+            let count = (snap.matched_item_count() as usize).min(limit as usize);
+            let mut out = Vec::with_capacity(count);
+            for i in 0..count as u32 {
+                if let Some(item) = snap.get_matched_item(i)
+                    && let Some((id, name)) = items.get(*item.data as usize)
+                {
+                    out.push(FuzzyMatch {
+                        id: *id,
+                        name: name.clone(),
+                        kind,
+                    });
+                }
+            }
+            Ok(out)
+        })
+        .await
     }
 
-    pub fn random_tracks(
-        &self,
+    pub async fn random_tracks(
+        self: Arc<Self>,
         count: u32,
         artist_id: Option<i64>,
     ) -> Result<Vec<Track>, KoanError> {
-        let db = self.db()?;
-        let rows = queries::random_tracks(&db.conn, count, artist_id).map_err(db_err)?;
-        Ok(self.decorate(&db, rows))
+        offload::offload(move || {
+            let db = self.db()?;
+            let rows = queries::random_tracks(&db.conn, count, artist_id).map_err(db_err)?;
+            Ok(self.decorate(&db, rows))
+        })
+        .await
     }
 
-    pub fn similar_artists(&self, artist_id: i64) -> Result<Vec<SimilarArtist>, KoanError> {
-        let db = self.db()?;
-        let rows = queries::get_similar_artists_detailed(&db.conn, artist_id).map_err(db_err)?;
-        Ok(rows
-            .into_iter()
-            .map(|e| SimilarArtist {
-                artist_id: e.artist.id,
-                name: e.artist.name,
-                score: e.score,
-                source: e.source,
-            })
-            .collect())
+    pub async fn similar_artists(
+        self: Arc<Self>,
+        artist_id: i64,
+    ) -> Result<Vec<SimilarArtist>, KoanError> {
+        offload::offload(move || {
+            let db = self.db()?;
+            let rows =
+                queries::get_similar_artists_detailed(&db.conn, artist_id).map_err(db_err)?;
+            Ok(rows
+                .into_iter()
+                .map(|e| SimilarArtist {
+                    artist_id: e.artist.id,
+                    name: e.artist.name,
+                    score: e.score,
+                    source: e.source,
+                })
+                .collect())
+        })
+        .await
     }
 
-    pub fn library_stats(&self) -> Result<Stats, KoanError> {
-        let db = self.db()?;
-        Ok(queries::library_stats(&db.conn).map_err(db_err)?.into())
+    pub async fn library_stats(self: Arc<Self>) -> Result<Stats, KoanError> {
+        offload::offload(move || {
+            let db = self.db()?;
+            Ok(queries::library_stats(&db.conn).map_err(db_err)?.into())
+        })
+        .await
     }
 
     /// Raw image bytes — no base64 round trip, unlike the GraphQL surface,
@@ -589,90 +598,99 @@ impl KoanEngine {
     /// fallback every album is blank. `size` requests a thumbnail; the grid
     /// wants one, the now-playing pane doesn't. Network on the remote path —
     /// call it off the main thread.
-    pub fn cover_art(
-        &self,
+    pub async fn cover_art(
+        self: Arc<Self>,
         track_id: i64,
         size: Option<u32>,
     ) -> Result<Option<CoverArt>, KoanError> {
-        let db = self.db()?;
-        let Some(row) = queries::get_track_row(&db.conn, track_id).map_err(db_err)? else {
-            return Ok(None);
-        };
+        offload::offload(move || {
+            let db = self.db()?;
+            let Some(row) = queries::get_track_row(&db.conn, track_id).map_err(db_err)? else {
+                return Ok(None);
+            };
 
-        if let Some(path) = row.path.as_ref().or(row.cached_path.as_ref())
-            && let Some(data) = koan_core::index::metadata::extract_cover_art(Path::new(path))
-        {
-            let mime = sniff_mime(&data).to_string();
-            return Ok(Some(CoverArt { data, mime }));
-        }
-
-        let Some(remote_id) = row.remote_id else {
-            return Ok(None);
-        };
-        let cfg = Config::cached();
-        if !cfg.remote.enabled {
-            return Ok(None);
-        }
-        let Some(client) = koan_core::helpers::subsonic_client(&cfg) else {
-            return Ok(None);
-        };
-        match client.get_cover_art(&remote_id, size) {
-            Ok(data) if !data.is_empty() => {
+            if let Some(path) = row.path.as_ref().or(row.cached_path.as_ref())
+                && let Some(data) = koan_core::index::metadata::extract_cover_art(Path::new(path))
+            {
                 let mime = sniff_mime(&data).to_string();
-                Ok(Some(CoverArt { data, mime }))
+                return Ok(Some(CoverArt { data, mime }));
             }
-            // No art on the server is normal, not a failure worth surfacing.
-            _ => Ok(None),
-        }
+
+            let Some(remote_id) = row.remote_id else {
+                return Ok(None);
+            };
+            let cfg = Config::cached();
+            if !cfg.remote.enabled {
+                return Ok(None);
+            }
+            let Some(client) = koan_core::helpers::subsonic_client(&cfg) else {
+                return Ok(None);
+            };
+            match client.get_cover_art(&remote_id, size) {
+                Ok(data) if !data.is_empty() => {
+                    let mime = sniff_mime(&data).to_string();
+                    Ok(Some(CoverArt { data, mime }))
+                }
+                // No art on the server is normal, not a failure worth surfacing.
+                _ => Ok(None),
+            }
+        })
+        .await
     }
 
     /// Cached lyrics only — this never hits the network, so it is safe to call
     /// from a view body's task without stalling on LRCLIB.
-    pub fn lyrics(&self, track_id: i64) -> Result<Option<Lyrics>, KoanError> {
-        let db = self.db()?;
-        Ok(queries::get_cached_lyrics(&db.conn, track_id)
-            .map_err(db_err)?
-            .map(|(content, synced)| {
-                let lines = if synced {
-                    koan_core::lyrics::parse_lrc(&content)
-                        .into_iter()
-                        .map(|l| LyricLine {
-                            time_secs: l.time_secs,
-                            text: l.text,
-                        })
-                        .collect()
-                } else {
-                    Vec::new()
-                };
-                Lyrics {
-                    content,
-                    synced,
-                    source: "cache".into(),
-                    lines,
-                }
-            }))
+    pub async fn lyrics(self: Arc<Self>, track_id: i64) -> Result<Option<Lyrics>, KoanError> {
+        offload::offload(move || {
+            let db = self.db()?;
+            Ok(queries::get_cached_lyrics(&db.conn, track_id)
+                .map_err(db_err)?
+                .map(|(content, synced)| {
+                    let lines = if synced {
+                        koan_core::lyrics::parse_lrc(&content)
+                            .into_iter()
+                            .map(|l| LyricLine {
+                                time_secs: l.time_secs,
+                                text: l.text,
+                            })
+                            .collect()
+                    } else {
+                        Vec::new()
+                    };
+                    Lyrics {
+                        content,
+                        synced,
+                        source: "cache".into(),
+                        lines,
+                    }
+                }))
+        })
+        .await
     }
 
     /// Cache, then LRCLIB. Hits the network on a miss, so never call this from
     /// the main thread — `lyrics()` is the non-blocking read.
-    pub fn fetch_lyrics(&self, track_id: i64) -> Result<Option<Lyrics>, KoanError> {
-        let db = self.db()?;
-        let Some(row) = queries::get_track_row(&db.conn, track_id).map_err(db_err)? else {
-            return Ok(None);
-        };
-        let duration_secs = row.duration_ms.unwrap_or(0).max(0) as u64 / 1000;
-        match koan_core::lyrics::fetch_lyrics(
-            &db.conn,
-            track_id,
-            &row.artist_name,
-            &row.title,
-            &row.album_title,
-            duration_secs,
-        ) {
-            Ok(l) => Ok(Some(l.into())),
-            // A track with no lyrics anywhere is the normal case, not an error.
-            Err(_) => Ok(None),
-        }
+    pub async fn fetch_lyrics(self: Arc<Self>, track_id: i64) -> Result<Option<Lyrics>, KoanError> {
+        offload::offload(move || {
+            let db = self.db()?;
+            let Some(row) = queries::get_track_row(&db.conn, track_id).map_err(db_err)? else {
+                return Ok(None);
+            };
+            let duration_secs = row.duration_ms.unwrap_or(0).max(0) as u64 / 1000;
+            match koan_core::lyrics::fetch_lyrics(
+                &db.conn,
+                track_id,
+                &row.artist_name,
+                &row.title,
+                &row.album_title,
+                duration_secs,
+            ) {
+                Ok(l) => Ok(Some(l.into())),
+                // A track with no lyrics anywhere is the normal case, not an error.
+                Err(_) => Ok(None),
+            }
+        })
+        .await
     }
 
     // --- Play history ------------------------------------------------------
@@ -681,258 +699,311 @@ impl KoanEngine {
     ///
     /// A list of events, not of tracks: a track played three times is three
     /// entries. Entries whose track has left the library are already gone.
-    pub fn play_history(
-        &self,
+    pub async fn play_history(
+        self: Arc<Self>,
         limit: u32,
         offset: u32,
     ) -> Result<Vec<PlayHistoryEntry>, KoanError> {
-        let db = self.db()?;
-        let rows = queries::play_history_with_tracks(&db.conn, limit, offset).map_err(db_err)?;
-        let (plays, tracks): (Vec<_>, Vec<_>) = rows
-            .into_iter()
-            .map(|r| ((r.id, r.played_at, r.listened_ms, r.source), r.track))
-            .unzip();
-        Ok(self
-            .decorate(&db, tracks)
-            .into_iter()
-            .zip(plays)
-            .map(
-                |(track, (id, played_at, listened_ms, source))| PlayHistoryEntry {
-                    id,
-                    track,
-                    played_at,
-                    listened_ms,
-                    source,
-                },
-            )
-            .collect())
+        offload::offload(move || {
+            let db = self.db()?;
+            let rows =
+                queries::play_history_with_tracks(&db.conn, limit, offset).map_err(db_err)?;
+            let (plays, tracks): (Vec<_>, Vec<_>) = rows
+                .into_iter()
+                .map(|r| ((r.id, r.played_at, r.listened_ms, r.source), r.track))
+                .unzip();
+            Ok(self
+                .decorate(&db, tracks)
+                .into_iter()
+                .zip(plays)
+                .map(
+                    |(track, (id, played_at, listened_ms, source))| PlayHistoryEntry {
+                        id,
+                        track,
+                        played_at,
+                        listened_ms,
+                        source,
+                    },
+                )
+                .collect())
+        })
+        .await
     }
 
     /// How many times a track has been played.
-    pub fn play_count(&self, track_id: i64) -> Result<i64, KoanError> {
-        let db = self.db()?;
-        queries::play_count(&db.conn, track_id).map_err(db_err)
+    pub async fn play_count(self: Arc<Self>, track_id: i64) -> Result<i64, KoanError> {
+        offload::offload(move || {
+            let db = self.db()?;
+            queries::play_count(&db.conn, track_id).map_err(db_err)
+        })
+        .await
     }
 
     /// Forget specific plays. Returns how many entries were removed.
-    pub fn delete_plays(&self, ids: Vec<i64>) -> Result<u32, KoanError> {
-        let db = self.db()?;
-        let removed = queries::delete_plays(&db.conn, &ids).map_err(db_err)?;
-        Ok(removed as u32)
+    pub async fn delete_plays(self: Arc<Self>, ids: Vec<i64>) -> Result<u32, KoanError> {
+        offload::offload(move || {
+            let db = self.db()?;
+            let removed = queries::delete_plays(&db.conn, &ids).map_err(db_err)?;
+            Ok(removed as u32)
+        })
+        .await
     }
 
     /// Forget every play. Returns how many entries were removed.
-    pub fn clear_play_history(&self) -> Result<u32, KoanError> {
-        let db = self.db()?;
-        let removed = queries::clear_play_history(&db.conn).map_err(db_err)?;
-        Ok(removed as u32)
+    pub async fn clear_play_history(self: Arc<Self>) -> Result<u32, KoanError> {
+        offload::offload(move || {
+            let db = self.db()?;
+            let removed = queries::clear_play_history(&db.conn).map_err(db_err)?;
+            Ok(removed as u32)
+        })
+        .await
     }
 
     // --- Favourites --------------------------------------------------------
 
-    pub fn favourites(&self) -> Result<Vec<Track>, KoanError> {
-        let db = self.db()?;
-        let ids = queries::favourite_track_ids_batch(&db.conn).map_err(db_err)?;
-        let mut rows = Vec::new();
-        for id in ids {
-            if let Ok(Some(row)) = queries::get_track_row(&db.conn, id) {
-                rows.push(row);
+    pub async fn favourites(self: Arc<Self>) -> Result<Vec<Track>, KoanError> {
+        offload::offload(move || {
+            let db = self.db()?;
+            let ids = queries::favourite_track_ids_batch(&db.conn).map_err(db_err)?;
+            let mut rows = Vec::new();
+            for id in ids {
+                if let Ok(Some(row)) = queries::get_track_row(&db.conn, id) {
+                    rows.push(row);
+                }
             }
-        }
-        rows.sort_by(|a, b| {
-            (&a.artist_name, &a.album_title, a.disc, a.track_number).cmp(&(
-                &b.artist_name,
-                &b.album_title,
-                b.disc,
-                b.track_number,
-            ))
-        });
-        Ok(self.decorate(&db, rows))
+            rows.sort_by(|a, b| {
+                (&a.artist_name, &a.album_title, a.disc, a.track_number).cmp(&(
+                    &b.artist_name,
+                    &b.album_title,
+                    b.disc,
+                    b.track_number,
+                ))
+            });
+            Ok(self.decorate(&db, rows))
+        })
+        .await
     }
 
     /// Returns the new state. Syncs to the remote server in the background when
     /// one is configured.
-    pub fn toggle_favourite(&self, track_id: i64) -> Result<bool, KoanError> {
-        let db = self.db()?;
-        let path = queries::track_favourite_key(&db.conn, track_id)
-            .map_err(db_err)?
-            .ok_or_else(|| KoanError::NotFound {
-                message: format!("track {track_id}"),
-            })?;
+    pub async fn toggle_favourite(self: Arc<Self>, track_id: i64) -> Result<bool, KoanError> {
+        offload::offload(move || {
+            let db = self.db()?;
+            let path = queries::track_favourite_key(&db.conn, track_id)
+                .map_err(db_err)?
+                .ok_or_else(|| KoanError::NotFound {
+                    message: format!("track {track_id}"),
+                })?;
 
-        let now_favourite =
-            queries::toggle_favourite(&db.conn, Path::new(&path)).map_err(fav_err)?;
-        koan_core::helpers::sync_favourite_to_remote(&db, Path::new(&path), now_favourite);
-        Ok(now_favourite)
+            let now_favourite =
+                queries::toggle_favourite(&db.conn, Path::new(&path)).map_err(fav_err)?;
+            koan_core::helpers::sync_favourite_to_remote(&db, Path::new(&path), now_favourite);
+            Ok(now_favourite)
+        })
+        .await
     }
 
     /// Every favourited track id, for the UI to read row state from one place
     /// rather than from a copy baked into each row when it was fetched.
-    pub fn favourite_track_ids(&self) -> Result<Vec<i64>, KoanError> {
-        let db = self.db()?;
-        Ok(queries::favourite_track_ids_batch(&db.conn)
-            .map_err(db_err)?
-            .into_iter()
-            .collect())
+    pub async fn favourite_track_ids(self: Arc<Self>) -> Result<Vec<i64>, KoanError> {
+        offload::offload(move || {
+            let db = self.db()?;
+            Ok(queries::favourite_track_ids_batch(&db.conn)
+                .map_err(db_err)?
+                .into_iter()
+                .collect())
+        })
+        .await
     }
 
-    pub fn favourite_album_ids(&self) -> Result<Vec<i64>, KoanError> {
-        let db = self.db()?;
-        Ok(queries::favourite_album_id_set(&db.conn)
-            .map_err(fav_err)?
-            .into_iter()
-            .collect())
+    pub async fn favourite_album_ids(self: Arc<Self>) -> Result<Vec<i64>, KoanError> {
+        offload::offload(move || {
+            let db = self.db()?;
+            Ok(queries::favourite_album_id_set(&db.conn)
+                .map_err(fav_err)?
+                .into_iter()
+                .collect())
+        })
+        .await
     }
 
-    pub fn favourite_artist_ids(&self) -> Result<Vec<i64>, KoanError> {
-        let db = self.db()?;
-        Ok(queries::favourite_artist_id_set(&db.conn)
-            .map_err(fav_err)?
-            .into_iter()
-            .collect())
+    pub async fn favourite_artist_ids(self: Arc<Self>) -> Result<Vec<i64>, KoanError> {
+        offload::offload(move || {
+            let db = self.db()?;
+            Ok(queries::favourite_artist_id_set(&db.conn)
+                .map_err(fav_err)?
+                .into_iter()
+                .collect())
+        })
+        .await
     }
 
     /// Toggle an album favourite. Returns the new state.
-    pub fn toggle_favourite_album(&self, album_id: i64) -> Result<bool, KoanError> {
-        let db = self.db()?;
-        let (artist, title) = queries::album_favourite_key(&db.conn, album_id)
-            .map_err(db_err)?
-            .ok_or_else(|| KoanError::NotFound {
-                message: format!("album {album_id}"),
-            })?;
-        let now = queries::toggle_favourite_album(&db.conn, &artist, &title).map_err(fav_err)?;
-        koan_core::helpers::sync_collection_favourite_to_remote(
-            &db,
-            koan_core::helpers::FavouriteKind::Album,
-            album_id,
-            now,
-        );
-        Ok(now)
+    pub async fn toggle_favourite_album(self: Arc<Self>, album_id: i64) -> Result<bool, KoanError> {
+        offload::offload(move || {
+            let db = self.db()?;
+            let (artist, title) = queries::album_favourite_key(&db.conn, album_id)
+                .map_err(db_err)?
+                .ok_or_else(|| KoanError::NotFound {
+                    message: format!("album {album_id}"),
+                })?;
+            let now =
+                queries::toggle_favourite_album(&db.conn, &artist, &title).map_err(fav_err)?;
+            koan_core::helpers::sync_collection_favourite_to_remote(
+                &db,
+                koan_core::helpers::FavouriteKind::Album,
+                album_id,
+                now,
+            );
+            Ok(now)
+        })
+        .await
     }
 
     /// Toggle an artist favourite. Returns the new state.
-    pub fn toggle_favourite_artist(&self, artist_id: i64) -> Result<bool, KoanError> {
-        let db = self.db()?;
-        let name = queries::artist_favourite_key(&db.conn, artist_id)
-            .map_err(db_err)?
-            .ok_or_else(|| KoanError::NotFound {
-                message: format!("artist {artist_id}"),
-            })?;
-        let now = queries::toggle_favourite_artist(&db.conn, &name).map_err(fav_err)?;
-        koan_core::helpers::sync_collection_favourite_to_remote(
-            &db,
-            koan_core::helpers::FavouriteKind::Artist,
-            artist_id,
-            now,
-        );
-        Ok(now)
+    pub async fn toggle_favourite_artist(
+        self: Arc<Self>,
+        artist_id: i64,
+    ) -> Result<bool, KoanError> {
+        offload::offload(move || {
+            let db = self.db()?;
+            let name = queries::artist_favourite_key(&db.conn, artist_id)
+                .map_err(db_err)?
+                .ok_or_else(|| KoanError::NotFound {
+                    message: format!("artist {artist_id}"),
+                })?;
+            let now = queries::toggle_favourite_artist(&db.conn, &name).map_err(fav_err)?;
+            koan_core::helpers::sync_collection_favourite_to_remote(
+                &db,
+                koan_core::helpers::FavouriteKind::Artist,
+                artist_id,
+                now,
+            );
+            Ok(now)
+        })
+        .await
     }
 
     // --- Snapshots ---------------------------------------------------------
 
-    pub fn snapshots(&self) -> Result<Vec<Snapshot>, KoanError> {
-        let db = self.db()?;
-        Ok(queries::list_snapshots(&db.conn)
-            .map_err(fav_err)?
-            .into_iter()
-            .map(Snapshot::from)
-            .collect())
+    pub async fn snapshots(self: Arc<Self>) -> Result<Vec<Snapshot>, KoanError> {
+        offload::offload(move || {
+            let db = self.db()?;
+            Ok(queries::list_snapshots(&db.conn)
+                .map_err(fav_err)?
+                .into_iter()
+                .map(Snapshot::from)
+                .collect())
+        })
+        .await
     }
 
-    pub fn save_snapshot(&self, name: String) -> Result<(), KoanError> {
-        let db = self.db()?;
-        let (items, cursor) = self.state.snapshot_playlist();
-        let persisted: Vec<PersistedQueueItem> = items
-            .iter()
-            .map(PersistedQueueItem::from_playlist_item)
-            .collect();
-        let cursor_path = cursor.and_then(|cid| {
-            items
+    pub async fn save_snapshot(self: Arc<Self>, name: String) -> Result<(), KoanError> {
+        offload::offload(move || {
+            let db = self.db()?;
+            let (items, cursor) = self.state.snapshot_playlist();
+            let persisted: Vec<PersistedQueueItem> = items
                 .iter()
-                .find(|i| i.id == cid)
-                .map(|i| i.path.to_string_lossy().into_owned())
-        });
+                .map(PersistedQueueItem::from_playlist_item)
+                .collect();
+            let cursor_path = cursor.and_then(|cid| {
+                items
+                    .iter()
+                    .find(|i| i.id == cid)
+                    .map(|i| i.path.to_string_lossy().into_owned())
+            });
 
-        queries::save_snapshot(
-            &db.conn,
-            &name,
-            &persisted,
-            cursor_path.as_deref(),
-            self.state.position_ms(),
-        )
-        .map_err(fav_err)
-        .map(|_| ())
+            queries::save_snapshot(
+                &db.conn,
+                &name,
+                &persisted,
+                cursor_path.as_deref(),
+                self.state.position_ms(),
+            )
+            .map_err(fav_err)
+            .map(|_| ())
+        })
+        .await
     }
 
     /// Replaces the queue and resumes at the saved position. Items still in the
     /// library are re-resolved so cache paths and downloads stay correct.
-    pub fn restore_snapshot(&self, name: String) -> Result<(), KoanError> {
-        let db = self.db()?;
-        let snap = queries::load_snapshot(&db.conn, &name)
-            .map_err(fav_err)?
-            .ok_or_else(|| KoanError::NotFound {
-                message: format!("snapshot '{name}'"),
-            })?;
+    pub async fn restore_snapshot(self: Arc<Self>, name: String) -> Result<(), KoanError> {
+        offload::sequenced(move || {
+            let db = self.db()?;
+            let snap = queries::load_snapshot(&db.conn, &name)
+                .map_err(fav_err)?
+                .ok_or_else(|| KoanError::NotFound {
+                    message: format!("snapshot '{name}'"),
+                })?;
 
-        let (items, pending) = restore_items(&db, &snap.items);
+            let (items, pending) = restore_items(&db, &snap.items);
 
-        self.send(PlayerCommand::ClearPlaylist)?;
-        if items.is_empty() {
-            return Ok(());
-        }
+            self.send(PlayerCommand::ClearPlaylist)?;
+            if items.is_empty() {
+                return Ok(());
+            }
 
-        let cursor = snap
-            .cursor_path
-            .as_ref()
-            .and_then(|cp| {
-                items
-                    .iter()
-                    .find(|i| i.path.to_string_lossy() == cp.as_str())
-            })
-            .map(|i| i.id)
-            .unwrap_or(items[0].id);
+            let cursor = snap
+                .cursor_path
+                .as_ref()
+                .and_then(|cp| {
+                    items
+                        .iter()
+                        .find(|i| i.path.to_string_lossy() == cp.as_str())
+                })
+                .map(|i| i.id)
+                .unwrap_or(items[0].id);
 
-        self.send(PlayerCommand::AddToPlaylist(items))?;
-        let _ = self.tx.send(PlayerCommand::Play(cursor));
-        if snap.position_ms > 0 {
-            let _ = self.tx.send(PlayerCommand::Seek(snap.position_ms));
-        }
-        self.start_downloads(pending);
+            self.send(PlayerCommand::AddToPlaylist(items))?;
+            let _ = self.tx.send(PlayerCommand::Play(cursor));
+            if snap.position_ms > 0 {
+                let _ = self.tx.send(PlayerCommand::Seek(snap.position_ms));
+            }
+            self.start_downloads(pending);
 
-        Ok(())
+            Ok(())
+        })
+        .await
     }
 
-    pub fn delete_snapshot(&self, name: String) -> Result<bool, KoanError> {
-        let db = self.db()?;
-        queries::delete_snapshot(&db.conn, &name).map_err(fav_err)
+    pub async fn delete_snapshot(self: Arc<Self>, name: String) -> Result<bool, KoanError> {
+        offload::offload(move || {
+            let db = self.db()?;
+            queries::delete_snapshot(&db.conn, &name).map_err(fav_err)
+        })
+        .await
     }
 
     // --- Session persistence -----------------------------------------------
 
     /// Write the queue and position so the next launch can pick them up.
     /// Call it on quit; it is cheap enough to call on a timer too.
-    pub fn save_session(&self) -> Result<(), KoanError> {
-        let db = self.db()?;
-        let (items, cursor) = self.state.snapshot_playlist();
-        let persisted: Vec<PersistedQueueItem> = items
-            .iter()
-            .map(PersistedQueueItem::from_playlist_item)
-            .collect();
-        let cursor_path = cursor.and_then(|cid| {
-            items
+    pub async fn save_session(self: Arc<Self>) -> Result<(), KoanError> {
+        offload::offload(move || {
+            let db = self.db()?;
+            let (items, cursor) = self.state.snapshot_playlist();
+            let persisted: Vec<PersistedQueueItem> = items
                 .iter()
-                .find(|i| i.id == cid)
-                .map(|i| i.path.to_string_lossy().into_owned())
-        });
-        queries::save_playback_state(
-            &db.conn,
-            &persisted,
-            cursor_path.as_deref(),
-            self.state.position_ms(),
-            self.state.playback_state() == PlaybackState::Playing,
-            self.state.radio_mode(),
-        )
-        .map_err(fav_err)
+                .map(PersistedQueueItem::from_playlist_item)
+                .collect();
+            let cursor_path = cursor.and_then(|cid| {
+                items
+                    .iter()
+                    .find(|i| i.id == cid)
+                    .map(|i| i.path.to_string_lossy().into_owned())
+            });
+            queries::save_playback_state(
+                &db.conn,
+                &persisted,
+                cursor_path.as_deref(),
+                self.state.position_ms(),
+                self.state.playback_state() == PlaybackState::Playing,
+                self.state.radio_mode(),
+            )
+            .map_err(fav_err)
+        })
+        .await
     }
 
     /// Persist where you are, without rewriting the queue.
@@ -940,23 +1011,26 @@ impl KoanEngine {
     /// Cheap enough to call every second, which is what makes a crash cost a
     /// second of playback rather than the whole session. `save_session` still
     /// runs when the queue changes and on quit.
-    pub fn save_position(&self) -> Result<(), KoanError> {
-        let db = self.db()?;
-        let (items, cursor) = self.state.snapshot_playlist();
-        let cursor_path = cursor.and_then(|cid| {
-            items
-                .iter()
-                .find(|i| i.id == cid)
-                .map(|i| i.path.to_string_lossy().into_owned())
-        });
-        queries::save_playback_position(
-            &db.conn,
-            cursor_path.as_deref(),
-            self.state.position_ms(),
-            self.state.playback_state() == PlaybackState::Playing,
-            self.state.radio_mode(),
-        )
-        .map_err(fav_err)
+    pub async fn save_position(self: Arc<Self>) -> Result<(), KoanError> {
+        offload::offload(move || {
+            let db = self.db()?;
+            let (items, cursor) = self.state.snapshot_playlist();
+            let cursor_path = cursor.and_then(|cid| {
+                items
+                    .iter()
+                    .find(|i| i.id == cid)
+                    .map(|i| i.path.to_string_lossy().into_owned())
+            });
+            queries::save_playback_position(
+                &db.conn,
+                cursor_path.as_deref(),
+                self.state.position_ms(),
+                self.state.playback_state() == PlaybackState::Playing,
+                self.state.radio_mode(),
+            )
+            .map_err(fav_err)
+        })
+        .await
     }
 
     /// Restore the queue saved by `save_session`, cursor and position included.
@@ -967,69 +1041,76 @@ impl KoanEngine {
     /// making noise at whoever opened it.
     ///
     /// Returns the number of items restored.
-    pub fn restore_session(&self) -> Result<u32, KoanError> {
-        let db = self.db()?;
-        let Some(saved) = queries::load_playback_state(&db.conn).map_err(fav_err)? else {
-            return Ok(0);
-        };
+    pub async fn restore_session(self: Arc<Self>) -> Result<u32, KoanError> {
+        offload::sequenced(move || {
+            let db = self.db()?;
+            let Some(saved) = queries::load_playback_state(&db.conn).map_err(fav_err)? else {
+                return Ok(0);
+            };
 
-        // Restored whether or not there is a queue left to play.
-        self.state.set_radio_mode(saved.radio_enabled);
+            // Restored whether or not there is a queue left to play.
+            self.state.set_radio_mode(saved.radio_enabled);
 
-        let (items, pending) = restore_items(&db, &saved.items);
-        if items.is_empty() {
-            return Ok(0);
-        }
+            let (items, pending) = restore_items(&db, &saved.items);
+            if items.is_empty() {
+                return Ok(0);
+            }
 
-        let count = items.len() as u32;
-        let cursor = saved
-            .cursor_path
-            .as_ref()
-            .and_then(|cp| {
-                items
-                    .iter()
-                    .find(|i| i.path.to_string_lossy() == cp.as_str())
-            })
-            .map(|i| i.id);
+            let count = items.len() as u32;
+            let cursor = saved
+                .cursor_path
+                .as_ref()
+                .and_then(|cp| {
+                    items
+                        .iter()
+                        .find(|i| i.path.to_string_lossy() == cp.as_str())
+                })
+                .map(|i| i.id);
 
-        self.send(PlayerCommand::AddToPlaylist(items))?;
-        self.start_downloads(pending);
+            self.send(PlayerCommand::AddToPlaylist(items))?;
+            self.start_downloads(pending);
 
-        if let Some(id) = cursor {
-            self.state.set_cursor(Some(id));
-            self.park_at(id, saved.position_ms, saved.was_playing);
-        }
+            if let Some(id) = cursor {
+                self.state.set_cursor(Some(id));
+                self.park_at(id, saved.position_ms, saved.was_playing);
+            }
 
-        Ok(count)
+            Ok(count)
+        })
+        .await
     }
 
     // --- Output device -----------------------------------------------------
 
-    pub fn devices(&self) -> Result<Vec<Device>, KoanError> {
-        let devices = koan_core::audio::list_output_devices().map_err(|e| KoanError::Audio {
-            message: e.to_string(),
-        })?;
-        Ok(devices
-            .into_iter()
-            .map(|d| Device {
-                name: d.name,
-                sample_rates: d.sample_rates,
-            })
-            .collect())
+    pub async fn devices(self: Arc<Self>) -> Result<Vec<Device>, KoanError> {
+        offload::offload(move || {
+            let devices =
+                koan_core::audio::list_output_devices().map_err(|e| KoanError::Audio {
+                    message: e.to_string(),
+                })?;
+            Ok(devices
+                .into_iter()
+                .map(|d| Device {
+                    name: d.name,
+                    sample_rates: d.sample_rates,
+                })
+                .collect())
+        })
+        .await
     }
 
-    pub fn set_device(&self, name: String) -> Result<(), KoanError> {
-        self.send(PlayerCommand::SetOutputDevice(name))
+    pub async fn set_device(self: Arc<Self>, name: String) -> Result<(), KoanError> {
+        offload::sequenced(move || self.send(PlayerCommand::SetOutputDevice(name))).await
     }
 
-    pub fn clear_device(&self) -> Result<(), KoanError> {
-        self.send(PlayerCommand::ClearOutputDevice)
+    pub async fn clear_device(self: Arc<Self>) -> Result<(), KoanError> {
+        offload::sequenced(move || self.send(PlayerCommand::ClearOutputDevice)).await
     }
 
     /// The device name persisted in config, or `None` for the system default.
     /// Read from config rather than the player so it survives a restart.
-    pub fn current_device(&self) -> Option<String> {
-        Config::cached().playback.output_device.clone()
+    pub async fn current_device(self: Arc<Self>) -> Option<String> {
+        offload::offload(move || Config::cached().playback.output_device.clone()).await
     }
 
     // --- Radio -------------------------------------------------------------
@@ -1046,53 +1127,56 @@ impl KoanEngine {
     // --- Settings ----------------------------------------------------------
 
     /// The whole configuration, as the settings window shows it.
-    pub fn settings(&self) -> Settings {
-        let cfg = Config::load().unwrap_or_default();
-        let cache_dir = cfg.cache_dir();
-        let cache_bytes = koan_core::helpers::cache_size_bytes(&cfg);
+    pub async fn settings(self: Arc<Self>) -> Settings {
+        offload::offload(move || {
+            let cfg = Config::load().unwrap_or_default();
+            let cache_dir = cfg.cache_dir();
+            let cache_bytes = koan_core::helpers::cache_size_bytes(&cfg);
 
-        let db = self.db().ok();
-        Settings {
-            library_folders: cfg
-                .library
-                .folders
-                .iter()
-                .map(|p| LibraryFolder {
-                    path: p.to_string_lossy().into_owned(),
-                    tracks: db
-                        .as_ref()
-                        .map(|db| koan_core::helpers::tracks_under(db, p))
-                        .unwrap_or(0),
-                })
-                .collect(),
+            let db = self.db().ok();
+            Settings {
+                library_folders: cfg
+                    .library
+                    .folders
+                    .iter()
+                    .map(|p| LibraryFolder {
+                        path: p.to_string_lossy().into_owned(),
+                        tracks: db
+                            .as_ref()
+                            .map(|db| koan_core::helpers::tracks_under(db, p))
+                            .unwrap_or(0),
+                    })
+                    .collect(),
 
-            remote_enabled: cfg.remote.enabled,
-            remote_url: cfg.remote.url.clone(),
-            remote_username: cfg.remote.username.clone(),
-            remote_signed_in: koan_core::helpers::get_remote_password(&cfg).is_some(),
-            remote_tracks: db
-                .as_ref()
-                .map(koan_core::helpers::tracks_from_server)
-                .unwrap_or(0),
-            transcode_quality: cfg.remote.transcode_quality.clone(),
-            download_workers: cfg.remote.download_workers as u32,
-            cache_limit: cfg.remote.cache_limit.clone().unwrap_or_default(),
-            cache_dir: cache_dir.to_string_lossy().into_owned(),
-            cache_bytes,
-            auto_sync: cfg.remote.auto_sync,
-            auto_sync_interval_mins: cfg.remote.auto_sync_interval_mins,
+                remote_enabled: cfg.remote.enabled,
+                remote_url: cfg.remote.url.clone(),
+                remote_username: cfg.remote.username.clone(),
+                remote_signed_in: koan_core::helpers::get_remote_password(&cfg).is_some(),
+                remote_tracks: db
+                    .as_ref()
+                    .map(koan_core::helpers::tracks_from_server)
+                    .unwrap_or(0),
+                transcode_quality: cfg.remote.transcode_quality.clone(),
+                download_workers: cfg.remote.download_workers as u32,
+                cache_limit: cfg.remote.cache_limit.clone().unwrap_or_default(),
+                cache_dir: cache_dir.to_string_lossy().into_owned(),
+                cache_bytes,
+                auto_sync: cfg.remote.auto_sync,
+                auto_sync_interval_mins: cfg.remote.auto_sync_interval_mins,
 
-            replaygain: match cfg.playback.replaygain {
-                config::ReplayGainMode::Off => "off".into(),
-                config::ReplayGainMode::Track => "track".into(),
-                config::ReplayGainMode::Album => "album".into(),
-            },
-            pre_amp_db: cfg.playback.pre_amp_db,
+                replaygain: match cfg.playback.replaygain {
+                    config::ReplayGainMode::Off => "off".into(),
+                    config::ReplayGainMode::Track => "track".into(),
+                    config::ReplayGainMode::Album => "album".into(),
+                },
+                pre_amp_db: cfg.playback.pre_amp_db,
 
-            radio_lookahead: cfg.radio.lookahead as u32,
-            radio_batch_size: cfg.radio.batch_size as u32,
-            radio_discovery_weight: cfg.radio.discovery_weight,
-        }
+                radio_lookahead: cfg.radio.lookahead as u32,
+                radio_batch_size: cfg.radio.batch_size as u32,
+                radio_discovery_weight: cfg.radio.discovery_weight,
+            }
+        })
+        .await
     }
 
     /// Write the settings back.
@@ -1100,63 +1184,66 @@ impl KoanEngine {
     /// Everything lands in `config.local.toml`, which is the machine-specific
     /// layer — the same file the CLI writes and one the TUI will pick up. The
     /// password is not here; it goes through `sign_in_remote`.
-    pub fn update_settings(&self, s: Settings) -> Result<(), KoanError> {
-        use toml::Value;
+    pub async fn update_settings(self: Arc<Self>, s: Settings) -> Result<(), KoanError> {
+        offload::offload(move || {
+            use toml::Value;
 
-        let cfg_err = |e: config::ConfigError| KoanError::BadArgument {
-            message: e.to_string(),
-        };
+            let cfg_err = |e: config::ConfigError| KoanError::BadArgument {
+                message: e.to_string(),
+            };
 
-        let mut library = toml::map::Map::new();
-        library.insert(
-            "folders".into(),
-            Value::Array(
-                s.library_folders
-                    .iter()
-                    .map(|f| Value::String(f.path.clone()))
-                    .collect(),
-            ),
-        );
-        Config::patch_local("library", &library).map_err(cfg_err)?;
+            let mut library = toml::map::Map::new();
+            library.insert(
+                "folders".into(),
+                Value::Array(
+                    s.library_folders
+                        .iter()
+                        .map(|f| Value::String(f.path.clone()))
+                        .collect(),
+                ),
+            );
+            Config::patch_local("library", &library).map_err(cfg_err)?;
 
-        let mut remote = toml::map::Map::new();
-        remote.insert("enabled".into(), Value::Boolean(s.remote_enabled));
-        remote.insert("url".into(), Value::String(s.remote_url.clone()));
-        remote.insert("username".into(), Value::String(s.remote_username.clone()));
-        remote.insert(
-            "transcode_quality".into(),
-            Value::String(s.transcode_quality.clone()),
-        );
-        remote.insert(
-            "download_workers".into(),
-            Value::Integer(s.download_workers.max(1) as i64),
-        );
-        remote.insert("cache_limit".into(), Value::String(s.cache_limit.clone()));
-        remote.insert("auto_sync".into(), Value::Boolean(s.auto_sync));
-        remote.insert(
-            "auto_sync_interval_mins".into(),
-            Value::Integer(s.auto_sync_interval_mins as i64),
-        );
-        Config::patch_local("remote", &remote).map_err(cfg_err)?;
+            let mut remote = toml::map::Map::new();
+            remote.insert("enabled".into(), Value::Boolean(s.remote_enabled));
+            remote.insert("url".into(), Value::String(s.remote_url.clone()));
+            remote.insert("username".into(), Value::String(s.remote_username.clone()));
+            remote.insert(
+                "transcode_quality".into(),
+                Value::String(s.transcode_quality.clone()),
+            );
+            remote.insert(
+                "download_workers".into(),
+                Value::Integer(s.download_workers.max(1) as i64),
+            );
+            remote.insert("cache_limit".into(), Value::String(s.cache_limit.clone()));
+            remote.insert("auto_sync".into(), Value::Boolean(s.auto_sync));
+            remote.insert(
+                "auto_sync_interval_mins".into(),
+                Value::Integer(s.auto_sync_interval_mins as i64),
+            );
+            Config::patch_local("remote", &remote).map_err(cfg_err)?;
 
-        let mut playback = toml::map::Map::new();
-        playback.insert("replaygain".into(), Value::String(s.replaygain.clone()));
-        playback.insert("pre_amp_db".into(), Value::Float(s.pre_amp_db));
-        Config::patch_local("playback", &playback).map_err(cfg_err)?;
+            let mut playback = toml::map::Map::new();
+            playback.insert("replaygain".into(), Value::String(s.replaygain.clone()));
+            playback.insert("pre_amp_db".into(), Value::Float(s.pre_amp_db));
+            Config::patch_local("playback", &playback).map_err(cfg_err)?;
 
-        let mut radio = toml::map::Map::new();
-        radio.insert("lookahead".into(), Value::Integer(s.radio_lookahead as i64));
-        radio.insert(
-            "batch_size".into(),
-            Value::Integer(s.radio_batch_size.max(1) as i64),
-        );
-        radio.insert(
-            "discovery_weight".into(),
-            Value::Float(s.radio_discovery_weight.clamp(0.0, 1.0)),
-        );
-        Config::patch_local("radio", &radio).map_err(cfg_err)?;
+            let mut radio = toml::map::Map::new();
+            radio.insert("lookahead".into(), Value::Integer(s.radio_lookahead as i64));
+            radio.insert(
+                "batch_size".into(),
+                Value::Integer(s.radio_batch_size.max(1) as i64),
+            );
+            radio.insert(
+                "discovery_weight".into(),
+                Value::Float(s.radio_discovery_weight.clamp(0.0, 1.0)),
+            );
+            Config::patch_local("radio", &radio).map_err(cfg_err)?;
 
-        Ok(())
+            Ok(())
+        })
+        .await
     }
 
     /// Whether the automatic library sync is running right now.
@@ -1183,48 +1270,60 @@ impl KoanEngine {
     ///
     /// Checked against the server before anything is written, and the password
     /// goes to the platform credential store rather than to a file.
-    pub fn sign_in_remote(
-        &self,
+    pub async fn sign_in_remote(
+        self: Arc<Self>,
         url: String,
         username: String,
         password: String,
     ) -> Result<(), KoanError> {
-        koan_core::helpers::set_remote_credentials(&url, &username, &password).map_err(|e| {
-            KoanError::BadArgument {
-                message: e.to_string(),
-            }
+        offload::offload(move || {
+            koan_core::helpers::set_remote_credentials(&url, &username, &password).map_err(|e| {
+                KoanError::BadArgument {
+                    message: e.to_string(),
+                }
+            })
         })
+        .await
     }
 
     /// Forget the server. Leaves the synced library alone — those tracks are
     /// still real, they just cannot be fetched until you sign in again.
-    pub fn sign_out_remote(&self) -> Result<(), KoanError> {
-        let cfg = Config::load().unwrap_or_default();
-        let _ = koan_core::credentials::delete_password(&cfg.remote.url);
+    pub async fn sign_out_remote(self: Arc<Self>) -> Result<(), KoanError> {
+        offload::offload(move || {
+            let cfg = Config::load().unwrap_or_default();
+            let _ = koan_core::credentials::delete_password(&cfg.remote.url);
 
-        let mut remote = toml::map::Map::new();
-        remote.insert("enabled".into(), toml::Value::Boolean(false));
-        remote.insert("password".into(), toml::Value::String(String::new()));
-        Config::patch_local("remote", &remote).map_err(|e| KoanError::BadArgument {
-            message: e.to_string(),
+            let mut remote = toml::map::Map::new();
+            remote.insert("enabled".into(), toml::Value::Boolean(false));
+            remote.insert("password".into(), toml::Value::String(String::new()));
+            Config::patch_local("remote", &remote).map_err(|e| KoanError::BadArgument {
+                message: e.to_string(),
+            })
         })
+        .await
     }
 
     /// Forget every track that came from a folder.
     ///
     /// A track the server also has keeps its row and loses only its local path.
     /// Albums and artists left holding nothing go too.
-    pub fn forget_folder(&self, path: String) -> Result<u64, KoanError> {
-        let db = self.db()?;
-        koan_core::helpers::forget_folder(&db, Path::new(&path)).map_err(db_err)
+    pub async fn forget_folder(self: Arc<Self>, path: String) -> Result<u64, KoanError> {
+        offload::offload(move || {
+            let db = self.db()?;
+            koan_core::helpers::forget_folder(&db, Path::new(&path)).map_err(db_err)
+        })
+        .await
     }
 
     /// Forget everything that only existed on the server.
     ///
     /// A track held locally as well keeps its row and loses its remote id.
-    pub fn forget_remote(&self) -> Result<u64, KoanError> {
-        let db = self.db()?;
-        koan_core::helpers::forget_remote(&db).map_err(db_err)
+    pub async fn forget_remote(self: Arc<Self>) -> Result<u64, KoanError> {
+        offload::offload(move || {
+            let db = self.db()?;
+            koan_core::helpers::forget_remote(&db).map_err(db_err)
+        })
+        .await
     }
 
     /// Drop the library index so the next scan rebuilds it.
@@ -1232,35 +1331,232 @@ impl KoanEngine {
     /// Favourites survive — they key on the file path. Lyrics, play history and
     /// acoustic embeddings do not; they key on row ids that are about to stop
     /// existing.
-    pub fn rebuild_index(&self) -> Result<RebuildSummary, KoanError> {
-        let db = self.db()?;
-        let summary = koan_core::helpers::rebuild_index(&db).map_err(db_err)?;
-        Ok(RebuildSummary {
-            tracks: summary.tracks,
-            albums: summary.albums,
-            artists: summary.artists,
+    pub async fn rebuild_index(self: Arc<Self>) -> Result<RebuildSummary, KoanError> {
+        offload::offload(move || {
+            let db = self.db()?;
+            let summary = koan_core::helpers::rebuild_index(&db).map_err(db_err)?;
+            Ok(RebuildSummary {
+                tracks: summary.tracks,
+                albums: summary.albums,
+                artists: summary.artists,
+            })
         })
+        .await
     }
 
     /// Delete every downloaded remote track. The library rows stay.
-    pub fn clear_download_cache(&self) -> Result<CacheCleared, KoanError> {
-        let db = self.db()?;
-        let cfg = Config::load().unwrap_or_default();
-        let cleared = koan_core::helpers::clear_download_cache(&db, &cfg);
-        Ok(CacheCleared {
-            files: cleared.files,
-            bytes: cleared.bytes,
+    pub async fn clear_download_cache(self: Arc<Self>) -> Result<CacheCleared, KoanError> {
+        offload::offload(move || {
+            let db = self.db()?;
+            let cfg = Config::load().unwrap_or_default();
+            let cleared = koan_core::helpers::clear_download_cache(&db, &cfg);
+            Ok(CacheCleared {
+                files: cleared.files,
+                bytes: cleared.bytes,
+            })
         })
+        .await
     }
 
     /// Rescans every configured library folder. Blocking and slow — call it off
     /// the main thread.
-    pub fn scan(&self, force: bool) -> Result<ScanSummary, KoanError> {
-        self.scan_reporting(force, None)
+    pub async fn scan(self: Arc<Self>, force: bool) -> Result<ScanSummary, KoanError> {
+        offload::offload(move || self.scan_blocking(force, None)).await
     }
 
     /// `scan`, saying how far it has got.
-    pub fn scan_reporting(
+    pub async fn scan_reporting(
+        self: Arc<Self>,
+        force: bool,
+        reporter: Option<Arc<dyn ProgressReporter>>,
+    ) -> Result<ScanSummary, KoanError> {
+        offload::offload(move || self.scan_blocking(force, reporter)).await
+    }
+
+    /// Pull the remote library into the local database. Long and network-bound
+    /// — call it off the main thread. `full` ignores the incremental cursor and
+    /// re-walks every album.
+    pub async fn sync_remote(self: Arc<Self>, full: bool) -> Result<SyncSummary, KoanError> {
+        offload::offload(move || {
+            let db = self.db()?;
+            let cfg = Config::load().unwrap_or_default();
+            let client = koan_core::helpers::subsonic_client(&cfg).ok_or_else(|| {
+                KoanError::BadArgument {
+                    message: "no remote server configured".into(),
+                }
+            })?;
+
+            let result = koan_core::remote::sync::sync_library(
+                &db,
+                &client,
+                full,
+                &cfg.remote.url,
+                &cfg.remote.username,
+            )
+            .map_err(|e| KoanError::Database {
+                message: e.to_string(),
+            })?;
+
+            // Favourites are part of a sync, not a separate errand. Without this
+            // a star made on the server — or on another machine — never reaches
+            // the app, and one made here only leaves if you happen to run the CLI.
+            let favourites = koan_core::helpers::reconcile_favourites(&db, &client);
+
+            Ok(SyncSummary {
+                artists: result.artists_synced as u32,
+                albums: result.albums_synced as u32,
+                tracks: result.tracks_synced as u32,
+                albums_failed: result.albums_failed as u32,
+                favourites_pushed: favourites.pushed as u32,
+                favourites_imported: favourites.imported as u32,
+            })
+        })
+        .await
+    }
+
+    /// Create a public share link on the remote server for these tracks.
+    ///
+    /// Only tracks the server knows about can go in it — the link points at the
+    /// server, so a local-only file has nothing for it to point at. A mixed
+    /// selection shares what it can; `skipped` says how much it left out.
+    /// Network-bound; keep it off the main thread.
+    pub async fn create_share(
+        self: Arc<Self>,
+        track_ids: Vec<i64>,
+        description: Option<String>,
+    ) -> Result<Share, KoanError> {
+        offload::offload(move || {
+            let db = self.db()?;
+            let cfg = Config::load().unwrap_or_default();
+            koan_core::helpers::create_share(&db, &cfg, &track_ids, description.as_deref())
+                .map(|outcome| Share {
+                    url: outcome.url,
+                    shared: outcome.shared as u32,
+                    skipped: outcome.skipped as u32,
+                })
+                .map_err(|e| KoanError::BadArgument {
+                    message: e.to_string(),
+                })
+        })
+        .await
+    }
+
+    /// Track IDs for an album or an artist, in running order. What the context
+    /// menu actions resolve to before touching the queue.
+    pub async fn track_ids(
+        self: Arc<Self>,
+        album_id: Option<i64>,
+        artist_id: Option<i64>,
+    ) -> Result<Vec<i64>, KoanError> {
+        offload::offload(move || {
+            Ok(self
+                .tracks_blocking(album_id, artist_id, TrackSort::Album, 2000, 0)?
+                .into_iter()
+                .map(|t| t.id)
+                .collect())
+        })
+        .await
+    }
+
+    /// Where the library folders point. Shown in settings.
+    pub async fn library_folders(self: Arc<Self>) -> Vec<String> {
+        offload::offload(move || {
+            Config::cached()
+                .library
+                .folders
+                .iter()
+                .map(|p| p.to_string_lossy().into_owned())
+                .collect()
+        })
+        .await
+    }
+}
+
+// --- Internals -------------------------------------------------------------
+
+impl KoanEngine {
+    /// Watch shared state and push changes to the listener.
+    ///
+    /// Polls, but in Rust and over atomics, which is nothing — and the client
+    /// sees events. The alternative, notifying from the player's own mutation
+    /// points, would put foreign calls on the decode thread.
+    fn spawn_watcher(self: &Arc<Self>) {
+        let engine = Arc::downgrade(self);
+        std::thread::Builder::new()
+            .name("koan-events".into())
+            .spawn(move || {
+                let mut last_version = u64::MAX;
+                let mut last_position = u64::MAX;
+                let mut last_signature: Option<(PlaybackState, Option<String>)> = None;
+                let mut ticks_since_download_nudge = 0u32;
+
+                loop {
+                    std::thread::sleep(std::time::Duration::from_millis(100));
+                    let Some(engine) = engine.upgrade() else {
+                        return; // Engine dropped; so is the app.
+                    };
+                    let Some(listener) = engine.listener.read().clone() else {
+                        continue;
+                    };
+
+                    let state = engine.state.playback_state();
+                    let cursor = engine.state.cursor().map(|c| c.0.to_string());
+                    let signature = (state, cursor);
+                    if last_signature.as_ref() != Some(&signature) {
+                        last_signature = Some(signature);
+                        listener.playback_changed(engine.now_playing_blocking());
+                    }
+
+                    let version = engine.state.playlist_version();
+                    if version != last_version {
+                        last_version = version;
+                        listener.queue_changed(version);
+                        ticks_since_download_nudge = 0;
+                    } else if !engine.state.pending_downloads().is_empty() {
+                        // Download progress moves without bumping the version,
+                        // so nothing above would announce it. Once a second is
+                        // plenty for a progress bar and keeps the client from
+                        // having to poll for the one thing events don't cover.
+                        ticks_since_download_nudge += 1;
+                        if ticks_since_download_nudge >= 10 {
+                            ticks_since_download_nudge = 0;
+                            listener.queue_changed(version);
+                        }
+                    }
+
+                    // Only while playing: a paused position doesn't move, and
+                    // re-sending it would keep a transport bar redrawing.
+                    if state == PlaybackState::Playing {
+                        let position = engine.state.position_ms();
+                        if position != last_position {
+                            last_position = position;
+                            listener.position_changed(position);
+                        }
+                    }
+                }
+            })
+            .ok();
+    }
+
+    fn tracks_blocking(
+        &self,
+        album_id: Option<i64>,
+        artist_id: Option<i64>,
+        sort: TrackSort,
+        limit: u32,
+        offset: u32,
+    ) -> Result<Vec<Track>, KoanError> {
+        let db = self.db()?;
+        let rows = match (album_id, artist_id) {
+            (Some(aid), _) => queries::tracks_for_album(&db.conn, aid),
+            (None, Some(aid)) => queries::tracks_for_artist(&db.conn, aid),
+            (None, None) => queries::all_tracks_paged(&db.conn, limit, offset),
+        }
+        .map_err(db_err)?;
+        Ok(self.decorate(&db, sort_rows(rows, sort)))
+    }
+
+    fn scan_blocking(
         &self,
         force: bool,
         reporter: Option<Arc<dyn ProgressReporter>>,
@@ -1320,156 +1616,69 @@ impl KoanEngine {
         Ok(summary)
     }
 
-    /// Pull the remote library into the local database. Long and network-bound
-    /// — call it off the main thread. `full` ignores the incremental cursor and
-    /// re-walks every album.
-    pub fn sync_remote(&self, full: bool) -> Result<SyncSummary, KoanError> {
-        let db = self.db()?;
-        let cfg = Config::load().unwrap_or_default();
-        let client =
-            koan_core::helpers::subsonic_client(&cfg).ok_or_else(|| KoanError::BadArgument {
-                message: "no remote server configured".into(),
-            })?;
-
-        let result = koan_core::remote::sync::sync_library(
-            &db,
-            &client,
-            full,
-            &cfg.remote.url,
-            &cfg.remote.username,
-        )
-        .map_err(|e| KoanError::Database {
+    fn build() -> Result<Arc<Self>, KoanError> {
+        init_logging();
+        let db_path = config::db_path();
+        // Fail fast on a broken library rather than after the audio threads exist.
+        Database::open(&db_path).map_err(|e| KoanError::Database {
             message: e.to_string(),
         })?;
 
-        // Favourites are part of a sync, not a separate errand. Without this
-        // a star made on the server — or on another machine — never reaches
-        // the app, and one made here only leaves if you happen to run the CLI.
-        let favourites = koan_core::helpers::reconcile_favourites(&db, &client);
+        let (state, _timeline, _viz, tx) = Player::spawn();
+        koan_core::radio::spawn_autoqueue(state.clone(), tx.clone(), db_path.clone());
 
-        Ok(SyncSummary {
-            artists: result.artists_synced as u32,
-            albums: result.albums_synced as u32,
-            tracks: result.tracks_synced as u32,
-            albums_failed: result.albums_failed as u32,
-            favourites_pushed: favourites.pushed as u32,
-            favourites_imported: favourites.imported as u32,
-        })
+        let auto_syncing = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        {
+            let flag = auto_syncing.clone();
+            koan_core::helpers::spawn_auto_sync(db_path.clone(), move |running| {
+                flag.store(running, std::sync::atomic::Ordering::Relaxed);
+            });
+        }
+
+        // Local files are watched rather than synced on a timer: a folder that
+        // has not changed costs nothing to notice, and one that has should show
+        // up without being asked.
+        let auto_scanning = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        {
+            let flag = auto_scanning.clone();
+            koan_core::helpers::spawn_library_watch(db_path.clone(), move |running| {
+                flag.store(running, std::sync::atomic::Ordering::Relaxed);
+            });
+        }
+
+        let listener: Arc<parking_lot::RwLock<Option<Arc<dyn PlayerEvents>>>> =
+            Arc::new(parking_lot::RwLock::new(None));
+        let engine = Arc::new(Self {
+            state,
+            tx,
+            db_path,
+            auto_syncing,
+            auto_scanning,
+            cancel_library_task: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            listener,
+        });
+        engine.spawn_watcher();
+        Ok(engine)
     }
 
-    /// Create a public share link on the remote server for these tracks.
-    ///
-    /// Only tracks the server knows about can go in it — the link points at the
-    /// server, so a local-only file has nothing for it to point at. A mixed
-    /// selection shares what it can; `skipped` says how much it left out.
-    /// Network-bound; keep it off the main thread.
-    pub fn create_share(
-        &self,
-        track_ids: Vec<i64>,
-        description: Option<String>,
-    ) -> Result<Share, KoanError> {
-        let db = self.db()?;
-        let cfg = Config::load().unwrap_or_default();
-        koan_core::helpers::create_share(&db, &cfg, &track_ids, description.as_deref())
-            .map(|outcome| Share {
-                url: outcome.url,
-                shared: outcome.shared as u32,
-                skipped: outcome.skipped as u32,
-            })
-            .map_err(|e| KoanError::BadArgument {
-                message: e.to_string(),
-            })
-    }
+    fn now_playing_blocking(&self) -> NowPlaying {
+        let info = self.state.track_info();
+        let cursor = self.state.cursor();
+        let play_state = self.state.playback_state();
+        let entry = cursor
+            .and_then(|cid| self.state.get_item(cid))
+            .map(|item| QueueItem::from_cursor_item(&item, play_state));
 
-    /// Track IDs for an album or an artist, in running order. What the context
-    /// menu actions resolve to before touching the queue.
-    pub fn track_ids(
-        &self,
-        album_id: Option<i64>,
-        artist_id: Option<i64>,
-    ) -> Result<Vec<i64>, KoanError> {
-        Ok(self
-            .tracks(album_id, artist_id, TrackSort::Album, 2000, 0)?
-            .into_iter()
-            .map(|t| t.id)
-            .collect())
-    }
-
-    /// Where the library folders point. Shown in settings.
-    pub fn library_folders(&self) -> Vec<String> {
-        Config::cached()
-            .library
-            .folders
-            .iter()
-            .map(|p| p.to_string_lossy().into_owned())
-            .collect()
-    }
-}
-
-// --- Internals -------------------------------------------------------------
-
-impl KoanEngine {
-    /// Watch shared state and push changes to the listener.
-    ///
-    /// Polls, but in Rust and over atomics, which is nothing — and the client
-    /// sees events. The alternative, notifying from the player's own mutation
-    /// points, would put foreign calls on the decode thread.
-    fn spawn_watcher(self: &Arc<Self>) {
-        let engine = Arc::downgrade(self);
-        std::thread::Builder::new()
-            .name("koan-events".into())
-            .spawn(move || {
-                let mut last_version = u64::MAX;
-                let mut last_position = u64::MAX;
-                let mut last_signature: Option<(PlaybackState, Option<String>)> = None;
-                let mut ticks_since_download_nudge = 0u32;
-
-                loop {
-                    std::thread::sleep(std::time::Duration::from_millis(100));
-                    let Some(engine) = engine.upgrade() else {
-                        return; // Engine dropped; so is the app.
-                    };
-                    let Some(listener) = engine.listener.read().clone() else {
-                        continue;
-                    };
-
-                    let state = engine.state.playback_state();
-                    let cursor = engine.state.cursor().map(|c| c.0.to_string());
-                    let signature = (state, cursor);
-                    if last_signature.as_ref() != Some(&signature) {
-                        last_signature = Some(signature);
-                        listener.playback_changed(engine.now_playing());
-                    }
-
-                    let version = engine.state.playlist_version();
-                    if version != last_version {
-                        last_version = version;
-                        listener.queue_changed(version);
-                        ticks_since_download_nudge = 0;
-                    } else if !engine.state.pending_downloads().is_empty() {
-                        // Download progress moves without bumping the version,
-                        // so nothing above would announce it. Once a second is
-                        // plenty for a progress bar and keeps the client from
-                        // having to poll for the one thing events don't cover.
-                        ticks_since_download_nudge += 1;
-                        if ticks_since_download_nudge >= 10 {
-                            ticks_since_download_nudge = 0;
-                            listener.queue_changed(version);
-                        }
-                    }
-
-                    // Only while playing: a paused position doesn't move, and
-                    // re-sending it would keep a transport bar redrawing.
-                    if state == PlaybackState::Playing {
-                        let position = engine.state.position_ms();
-                        if position != last_position {
-                            last_position = position;
-                            listener.position_changed(position);
-                        }
-                    }
-                }
-            })
-            .ok();
+        NowPlaying {
+            state: play_state.into(),
+            position_ms: self.state.position_ms(),
+            duration_ms: info.as_ref().map(|i| i.duration_ms).unwrap_or(0),
+            queue_item_id: cursor.map(|c| c.0.to_string()),
+            entry,
+            format: info.as_ref().map(StreamFormat::from),
+            playlist_version: self.state.playlist_version(),
+            radio_enabled: self.state.radio_mode(),
+        }
     }
 
     fn db(&self) -> Result<Database, KoanError> {

--- a/crates/koan-ffi/src/offload.rs
+++ b/crates/koan-ffi/src/offload.rs
@@ -1,0 +1,152 @@
+//! Somewhere for blocking work to happen that is not the caller's thread.
+//!
+//! koan-core is synchronous throughout — rusqlite has no async form, the audio
+//! path is dedicated OS threads, and three of its four consumers are sync
+//! loops. So the boundary is where the hop belongs, and this is the hop. It is
+//! the same offload `koan-server` does at its own edge, for the same reason.
+//!
+//! Nothing here uses tokio's async I/O; `spawn_blocking` is a thread pool that
+//! happens to hand back a future. The pool grows on demand and is not sized to
+//! the core count — a thread waiting on a socket costs a kernel stack and
+//! address space it never touches, not CPU, and capping blocking work at the
+//! core count queues it behind nothing.
+
+use std::sync::LazyLock;
+
+use crossbeam_channel::Sender;
+use tokio::runtime::Runtime;
+
+type Job = Box<dyn FnOnce() + Send + 'static>;
+
+/// Owns the blocking pool. Current-thread because the async half is never
+/// used: uniffi polls exported futures from Swift, so there is no driver to
+/// run and no worker threads beyond the ones jobs are handed to.
+static RUNTIME: LazyLock<Runtime> = LazyLock::new(|| {
+    tokio::runtime::Builder::new_current_thread()
+        // A tripwire, not a target. Threads are spawned on demand and parked
+        // when idle, so a GUI sits at a handful; reaching this many blocked at
+        // once is a runaway, and failing there beats failing at the OS thread
+        // limit, where `spawn` starts erroring somewhere unrelated.
+        .max_blocking_threads(512)
+        .build()
+        .expect("a runtime with no driver to start")
+});
+
+/// Run `f` off the calling thread.
+///
+/// Order between concurrent calls is undefined — use [`sequenced`] where it
+/// matters. A panic in `f` is re-raised here, so uniffi reports it the same way
+/// it did when these calls were synchronous.
+pub async fn offload<T, F>(f: F) -> T
+where
+    F: FnOnce() -> T + Send + 'static,
+    T: Send + 'static,
+{
+    match RUNTIME.spawn_blocking(f).await {
+        Ok(value) => value,
+        Err(e) => std::panic::resume_unwind(e.into_panic()),
+    }
+}
+
+/// Run `f` on the one lane every player command shares, in submission order.
+///
+/// Queue mutations resolve tracks against the database before sending a
+/// `PlayerCommand`, so two running concurrently would reach the channel in
+/// whichever order finished first: dropping in an album and then pressing undo
+/// could undo the drop before it landed. A pool cannot promise that ordering,
+/// so this is one thread and a queue.
+pub async fn sequenced<T, F>(f: F) -> T
+where
+    F: FnOnce() -> T + Send + 'static,
+    T: Send + 'static,
+{
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    LANE.send(Box::new(move || {
+        // The receiver is gone when the caller's Task was cancelled. The work
+        // is done either way; only the answer had nowhere to go.
+        let _ = tx.send(f());
+    }))
+    .expect("the command lane outlives the engine");
+
+    match rx.await {
+        Ok(value) => value,
+        Err(_) => panic!("the command lane stopped running"),
+    }
+}
+
+static LANE: LazyLock<Sender<Job>> = LazyLock::new(|| {
+    let (tx, rx) = crossbeam_channel::unbounded::<Job>();
+    std::thread::Builder::new()
+        .name("koan-commands".into())
+        .spawn(move || {
+            for job in rx {
+                job();
+            }
+        })
+        .expect("the command lane needs one thread");
+    tx
+});
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[tokio::test]
+    async fn offloaded_work_runs_off_the_caller() {
+        let caller = std::thread::current().id();
+        assert_ne!(caller, offload(|| std::thread::current().id()).await);
+    }
+
+    #[tokio::test]
+    async fn the_lane_runs_commands_in_submission_order() {
+        let seen = Arc::new(parking_lot::Mutex::new(Vec::new()));
+        let started = Arc::new(AtomicUsize::new(0));
+
+        // Submitted back to back without awaiting, which is how two queue
+        // mutations from one gesture reach the engine.
+        let jobs: Vec<_> = (0..16)
+            .map(|i| {
+                let (seen, started) = (seen.clone(), started.clone());
+                sequenced(move || {
+                    // The first job dawdles, so a pool would let later ones
+                    // overtake it and the assertion below would catch it.
+                    if started.fetch_add(1, Ordering::AcqRel) == 0 {
+                        std::thread::sleep(std::time::Duration::from_millis(30));
+                    }
+                    seen.lock().push(i);
+                })
+            })
+            .collect();
+        for job in jobs {
+            job.await;
+        }
+
+        assert_eq!(*seen.lock(), (0..16).collect::<Vec<i32>>());
+    }
+
+    /// The case that matters: uniffi polls exported futures from Swift, with no
+    /// tokio runtime anywhere on the stack. If awaiting these needed an ambient
+    /// runtime the whole surface would deadlock in the app and nowhere else.
+    #[test]
+    fn both_work_with_no_runtime_on_the_stack() {
+        assert_eq!(
+            42,
+            futures_lite::future::block_on(offload(|| 42)),
+            "spawn_blocking's pool runs without its runtime being driven"
+        );
+        assert_eq!(7, futures_lite::future::block_on(sequenced(|| 7)));
+    }
+
+    #[tokio::test]
+    async fn a_panic_crosses_back_to_the_caller() {
+        let escaped = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            futures_lite::future::block_on(offload(|| panic!("boom")))
+        }));
+        assert!(
+            escaped.is_err(),
+            "a panic must not be swallowed into a hang"
+        );
+    }
+}


### PR DESCRIPTION
The rule this enforces: **nothing over the FFI blocks its caller.** 80 of the 86 exported calls are `async` and run on a worker thread. The six that stay synchronous — `playlistVersion`, `setRadio`, `isAutoSyncing`, `isAutoScanning`, `cancelLibraryTask` on `KoanEngine`, and `count()` on `OrganizeSelection` — read or write a single atomic or an O(1) length, so they cannot block by construction.

That line is mechanical on purpose. "Async when it blocks" needs a correct judgement about what blocks, and that judgement had already failed: `lyrics()` carried a comment saying it was safe to call from a view body's task, and opens a database connection. Six paths in the app reached the engine directly on the main actor, one of them `libraryFolders()` from inside a SwiftUI `ForEach`.

## The blocking moved into Rust

The app used to wrap calls in `Task.detached`, which runs them on Swift's **cooperative pool — sized to the core count**. So the old design didn't avoid the problem, it relocated it into Swift's scheduler: a cover-art storm or a scan occupied threads every other task in the process needed.

`offload.rs` owns the threads instead. The pool grows on demand, parks idle workers and caps at 512 — deliberately not core-sized, because a thread waiting on a socket costs a kernel stack and untouched address space, not CPU, and capping blocking work at the core count creates queueing behind nothing. The cap is a tripwire against a runaway spawning until the OS starts refusing threads, not a tuning knob.

## koan-core stays synchronous

rusqlite has no async form — every "async SQLite" crate is `spawn_blocking` with a nicer face — the audio path is dedicated threads with timing constraints, and three of koan-core's four consumers are synchronous loops. koan-server already resolves the same mismatch at its own edge and leaves the core alone; this does the same thing at the other one.

## No runtime is driven

uniffi polls exported futures from the foreign side, so there is no executor on the stack when the app calls in. The tokio runtime here exists only to own `spawn_blocking`'s pool; its async half is never used, and `async_runtime = "tokio"` is deliberately not set (it would wrap every future in `async_compat::Compat`). `both_work_with_no_runtime_on_the_stack` covers exactly that path, because it is the one the app creates and the one that would deadlock if the assumption were wrong.

## Ordering is explicit

Queue mutations and transport commands share one lane, in submission order. They each got their own `Task.detached` before, so two in quick succession could reach the player either way round — dropping in an album and then pressing undo could undo it before it landed. `the_lane_runs_commands_in_submission_order` makes the first job dawdle so a pool would visibly reorder.

## Behaviour changes worth checking

- **The quit save is now fire-and-forget.** `saveSession()` was synchronous on the `scenePhase` hook and completed before termination; it is now a `Task`. Exposure is bounded by the existing one-second autosave, so at worst a second of position drift. I deliberately did **not** add an `NSApplicationDelegate` holding termination via `reply(toApplicationShouldTerminate:)` — #242 said I would — because a hung save blocking quit is a worse failure than a second of drift. Say the word and I'll add it.
- **Two things now render one frame later**, because `init` can no longer read the engine: the transport bar seeds from a stopped state until `start()` lands, and the settings window shows its existing `ProgressView()` until its async init returns.

## Merged with #238

#238 landed while this was open, adding nine organize methods and a second exported object, `OrganizeSelection`. They get the same treatment.

`OrganizeSelection::generate` is worth a look: it touches no files, and its comment said that made it *"safe to call as fast as someone can type"* — the same shape of claim `lyrics()` made, wrong for the same reason. It resolves a destination per track across the whole selection. It is on the pool now.

That changes something on the Swift side beyond adding `await`: **both preview passes can now arrive stale.** The fast pass used to be synchronous and could not be overtaken, so only the disk pass checked the generation counter. Both check it now.

## Verifying

`cargo test --workspace` — 872 pass, clippy clean under `-D warnings`. `swift build` clean.

Every `Task.detached` around an engine call is gone from the app, along with `offMain`, the helper that wrapped them; `ActivityModel.run`/`runReporting` lost their detached hop too. One `Task.detached` remains, in `CoverArtCache`, and it is the app's own disk-cache I/O rather than an engine call — commented as such.

Not smoke-tested in the GUI yet: the desktop is shared and I didn't want to steal focus. Worth a launch before merging.

Closes #242. Follow-up in #245 (events as an async sequence rather than a callback interface).
