### PR TITLE
release: v0.27.0 — say why the remote is unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.27.0 (2026-08-24)
 
 ### Added
 
@@ -24,17 +24,29 @@
 
   Generating destinations is separated from asking the disk about them, because only one of those is fast. `organize::generate` formats a pattern against an already-resolved selection and touches no files at all, so it reruns on every keystroke; `organize::check_against_disk` is the `stat`-per-file pass that finds occupied destinations and the artwork travelling alongside, and it lands a moment later. Ancillary files were previously discovered with a directory read *per file*, so an album of a dozen tracks did the same `readdir` a dozen times.
 
-### Fixed
-
-- **Menu shortcuts no longer reach past a field you are typing in.** ⌘← and ⌥← skipped tracks instead of moving the caret or the word, and ⌘Z undid a queue edit instead of the typing — in the search field, a filter, Settings, anywhere. Every shortcut whose key also means something while typing is now *disabled* while a field has focus, which releases its key equivalent to the responder chain; declining the action instead would leave the menu swallowing the key, so the shortcut would stop working without the field ever hearing it. The bare-key shortcuts already asked what had focus; the modified ones never did.
-
 ### Changed
 
 - **The macOS app requires macOS 26.** It was built against 14. Nothing in the app is holding the old floor up and the newer SwiftUI is worth having — `searchFocused`, which is what lets `/` put the caret in the search field, is 15-and-later on its own. The Homebrew cask requires Tahoe to match.
 
 - **`organizePreview` and `organizeExecute` both return `OrganizePlan`** (was `OrganizePreview` / `OrganizeResult`), an ordered list of per-file entries carrying `outcome` (`MOVE` / `UNCHANGED` / `CONFLICT` / `ERROR`), the destination, and the reason where there is one. **Breaking for GraphQL clients**: `moves`, `errors` and `skipped` are gone. A conflict previously arrived as a string in `errors` with the destination buried in the message, which is unusable for the thing a client most needs to render — a file about to be blocked, next to what is blocking it. The TUI's preview gains the same rows.
 
+- **The FFI never blocks its caller.** Every one of the 80 exported calls that can block is `async` now and runs on a worker thread; the six that stay synchronous read a single atomic or an O(1) length and cannot block by construction. Previously all of them were synchronous FFI functions and the hazard lived in doc comments, which had already failed — `lyrics()` was documented as safe to call from a view body and opened a database connection, and six paths in the macOS app reached the engine directly on the main actor, one of them from inside a SwiftUI `ForEach`.
+
+  Blocking moved into Rust rather than being wrapped at each call site. The app used to hop with `Task.detached`, which runs on Swift's cooperative pool — sized to the core count — so a cover-art storm or a scan starved every other task in the process. The engine's pool grows on demand and is deliberately not core-sized: a thread waiting on a socket costs a kernel stack, not CPU, and capping blocking work at the core count queues it behind nothing. koan-core stays synchronous, which is what its three synchronous consumers and its dedicated audio threads want; only the boundary changed.
+
+  Queue mutations and transport commands share one lane, in submission order. They previously each got their own `Task.detached`, so two in quick succession could reach the player in either order — dropping in an album and pressing undo could undo it before it landed.
+
+  Every `Task.detached` around an engine call is gone from the app, along with the helper that wrapped them.
+
+- **Nothing played when the library drive was offline, and nothing said why.** The log read `remote not configured` while the remote was configured perfectly well — what koan could not do was read the password, because macOS grants keychain access per binary and the app had never been granted it. `subsonic_client` returns nothing for four different reasons and every caller reported the same one, so "koan has no password" and "koan cannot read the password it has" printed identically, despite sending you to completely different places.
+
+  Tracks that cannot be fetched are marked failed with the reason now, instead of sitting as pending forever. The player waits for a track to become ready, so a download that was skipped left the queue silent until it ran off the end.
+
+  `koan remote status` asks the way koan asks. It read the config field directly and never consulted the credential store, so it reported `password: not set` for every keychain-backed sign-in — the arrangement `koan remote login` creates — and then skipped its own connectivity check because of that same flag. The one tool that should have diagnosed this was reporting the opposite of the truth.
+
 ### Fixed
+
+- **Menu shortcuts no longer reach past a field you are typing in.** ⌘← and ⌥← skipped tracks instead of moving the caret or the word, and ⌘Z undid a queue edit instead of the typing — in the search field, a filter, Settings, anywhere. Every shortcut whose key also means something while typing is now *disabled* while a field has focus, which releases its key equivalent to the responder chain; declining the action instead would leave the menu swallowing the key, so the shortcut would stop working without the field ever hearing it. The bare-key shortcuts already asked what had focus; the modified ones never did.
 
 - **The sync fetched 1,725 artists and threw the list away.** `get_artists` was called, counted, logged as "syncing 1725 artists" and then dropped — artists only ever came into being as a side effect of a track upsert, which saw nothing but a name and an id. That is why not one artist in a synced library had a MusicBrainz id or a sort name, and why the reported artist count was theatre. The list is applied now, and the count is what was actually written.
 
@@ -45,16 +57,6 @@
 - **A fresh HTTP client, and a fresh TLS handshake, for every remote request.** `subsonic_client()` built a new `SubsonicClient` on each call, and each of those builds two blocking `reqwest` clients — two runtimes on two threads with two cold connection pools. Browsing a synced library paid that per album cover. The download queue had already worked this out and kept a client of its own for the app's lifetime; the client is now shared process-wide and keyed on the credentials, so every caller gets connection reuse and logging in as someone else still replaces it.
 
 - **Reading the config forked a `git` process.** `Config::load()` re-read both TOML files, re-ran the figment merge, and re-scanned for credentials in version control — and that last check shells out to `git ls-files` whenever a password is present in the file, then panics if it is tracked. koan reaches config from paths that run per frame: the macOS settings pane reads `library_folders()` from a SwiftUI list body, so it did all of that per rendered frame. The check is what its own message says it is, a gate on starting, and runs once per process now. The merged config is cached and re-read when either file's mtime moves, so a config edited by hand is still picked up.
-
-### Changed
-
-- **The FFI never blocks its caller.** Every one of the 70 engine calls that can block is `async` now and runs on a worker thread; the five that stay synchronous read a single atomic and cannot block by construction. Previously all of them were synchronous FFI functions and the hazard lived in doc comments, which had already failed — `lyrics()` was documented as safe to call from a view body and opened a database connection, and six paths in the macOS app reached the engine directly on the main actor, one of them from inside a SwiftUI `ForEach`.
-
-  Blocking moved into Rust rather than being wrapped at each call site. The app used to hop with `Task.detached`, which runs on Swift's cooperative pool — sized to the core count — so a cover-art storm or a scan starved every other task in the process. The engine's pool grows on demand and is deliberately not core-sized: a thread waiting on a socket costs a kernel stack, not CPU, and capping blocking work at the core count queues it behind nothing. koan-core stays synchronous, which is what its three synchronous consumers and its dedicated audio threads want; only the boundary changed.
-
-  Queue mutations and transport commands share one lane, in submission order. They previously each got their own `Task.detached`, so two in quick succession could reach the player in either order — dropping in an album and pressing undo could undo it before it landed.
-
-  Every `Task.detached` around an engine call is gone from the app, along with the helper that wrapped them.
 
 ## v0.26.0 (2026-08-23)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2744,7 +2744,7 @@ dependencies = [
 
 [[package]]
 name = "koan-cli"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "koan-core"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "argon2",
  "bliss-audio",
@@ -2810,7 +2810,7 @@ dependencies = [
 
 [[package]]
 name = "koan-ffi"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "chrono",
  "crossbeam-channel",
@@ -2830,7 +2830,7 @@ dependencies = [
 
 [[package]]
 name = "koan-server"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",
@@ -2863,7 +2863,7 @@ dependencies = [
 
 [[package]]
 name = "koan-tui"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "core-foundation 0.10.1",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/koan-core", "crates/koan-ffi", "crates/koan-server", "crates/koan-tui", "crates/koan-cli"]
 
 [workspace.package]
-version = "0.26.0"
+version = "0.27.0"
 edition = "2024"
 rust-version = "1.89"
 homepage = "https://github.com/radiosilence/koan"
@@ -13,9 +13,9 @@ license = "MIT"
 [workspace.dependencies]
 # Internal crates. Keep the version in step with [workspace.package] above —
 # a stale pin here publishes members that resolve against the wrong sibling.
-koan-core = { path = "crates/koan-core", version = "0.26.0" }
-koan-server = { path = "crates/koan-server", version = "0.26.0" }
-koan-tui = { path = "crates/koan-tui", version = "0.26.0" }
+koan-core = { path = "crates/koan-core", version = "0.27.0" }
+koan-server = { path = "crates/koan-server", version = "0.27.0" }
+koan-tui = { path = "crates/koan-tui", version = "0.27.0" }
 # Feature set is the union every member needs; `default-tls` is an alias for
 # `rustls`, so there is exactly one TLS stack.
 reqwest = { version = "0.13", default-features = false, features = [

--- a/crates/koan-cli/src/commands/remote.rs
+++ b/crates/koan-cli/src/commands/remote.rs
@@ -105,6 +105,8 @@ pub fn cmd_remote_sync(full: bool) {
 }
 
 pub fn cmd_remote_status() {
+    use koan_core::helpers::PasswordSource;
+
     let cfg = config::Config::load().unwrap_or_default();
     if !cfg.remote.enabled || cfg.remote.url.is_empty() {
         println!("no remote server configured");
@@ -114,26 +116,43 @@ pub fn cmd_remote_status() {
     println!("{} {}", "server:".cyan(), cfg.remote.url);
     println!("{} {}", "username:".cyan(), cfg.remote.username);
 
-    let has_password = !cfg.remote.password.is_empty();
-    println!(
-        "{} {}",
-        "password:".cyan(),
-        if has_password {
-            "configured".green().to_string()
-        } else {
-            "not set".red().to_string()
-        }
-    );
+    // Asked the way everything else asks. Reporting on a field koan itself does
+    // not consult is how a keychain-backed sign-in — the arrangement `remote
+    // login` creates — came to be reported as having no password at all.
+    let (_, source) = koan_core::helpers::remote_password(&cfg);
+    let described = match &source {
+        PasswordSource::Keychain => "from the keychain".green().to_string(),
+        PasswordSource::Config => "from config.local.toml".green().to_string(),
+        PasswordSource::Missing => "not set".red().to_string(),
+        PasswordSource::Unreadable(why) => format!(
+            "{} {}",
+            "in the keychain, but koan cannot read it".red(),
+            format!("\u{2014} {why}").dimmed()
+        ),
+    };
+    println!("{} {}", "password:".cyan(), described);
 
-    if has_password && let Some(client) = koan_core::helpers::subsonic_client(&cfg) {
-        match client.ping() {
-            Ok(()) => println!("{} {}", "status:".cyan(), "connected".green()),
-            Err(e) => println!(
-                "{} {} {}",
-                "status:".cyan(),
-                "error".red(),
-                format!("\u{2014} {}", e).dimmed()
-            ),
+    // Attempted whenever credentials resolve, rather than gated on a guess
+    // about whether they would. The reach is the only part of this that
+    // actually proves anything.
+    let Some(client) = koan_core::helpers::subsonic_client(&cfg) else {
+        if matches!(source, PasswordSource::Unreadable(_)) {
+            println!(
+                "{} {}",
+                "hint:".yellow(),
+                "`koan remote login` rewrites the entry for this build".dimmed()
+            );
         }
+        return;
+    };
+
+    match client.ping() {
+        Ok(()) => println!("{} {}", "status:".cyan(), "connected".green()),
+        Err(e) => println!(
+            "{} {} {}",
+            "status:".cyan(),
+            "error".red(),
+            format!("\u{2014} {}", e).dimmed()
+        ),
     }
 }

--- a/crates/koan-core/src/helpers.rs
+++ b/crates/koan-core/src/helpers.rs
@@ -18,21 +18,54 @@ use crate::remote::client::{SubsonicAuth, SubsonicClient};
 // Subsonic client builder
 // ---------------------------------------------------------------------------
 
+/// Where the remote password came from, or why there is not one.
+///
+/// "koan has no password" and "koan cannot read the password it has" are
+/// different problems with different fixes, and anything reporting on the
+/// remote needs to tell them apart. A credential store that holds an entry and
+/// declines to hand it over — a locked keychain, a dismissed dialog, an item
+/// whose ACL does not list the binary asking — looks exactly like no password
+/// at all to a caller that only sees `Option<String>`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PasswordSource {
+    /// The platform credential store answered.
+    Keychain,
+    /// `config.local.toml`, or `KOAN_REMOTE__PASSWORD` layered over it.
+    Config,
+    /// Neither has one to give.
+    Missing,
+    /// The store holds an entry and would not part with it. Carries the
+    /// platform's own message, which is the only thing separating a locked
+    /// keychain from a refused one.
+    Unreadable(String),
+}
+
 /// Get the remote password. Keychain first, config second.
 ///
 /// The config copy is only a migration path now: `set_remote_credentials` writes
 /// to the keychain and clears it, so a plaintext password survives exactly until
 /// the next sign-in.
 pub fn get_remote_password(cfg: &Config) -> Option<String> {
-    if let Ok(pw) = crate::credentials::get_password(&cfg.remote.url)
-        && !pw.is_empty()
-    {
-        return Some(pw);
-    }
+    remote_password(cfg).0
+}
+
+/// `get_remote_password`, and how it got there.
+pub fn remote_password(cfg: &Config) -> (Option<String>, PasswordSource) {
+    let refusal = match crate::credentials::get_password(&cfg.remote.url) {
+        Ok(pw) if !pw.is_empty() => return (Some(pw), PasswordSource::Keychain),
+        // An empty stored password is no more useful than no entry at all.
+        Ok(_) | Err(crate::credentials::CredentialError::NotFound) => None,
+        Err(e) => Some(e.to_string()),
+    };
+
     if !cfg.remote.password.is_empty() {
-        return Some(cfg.remote.password.clone());
+        return (Some(cfg.remote.password.clone()), PasswordSource::Config);
     }
-    None
+
+    (
+        None,
+        refusal.map_or(PasswordSource::Missing, PasswordSource::Unreadable),
+    )
 }
 
 /// Index files that appear in the library folders while koan is running.
@@ -1164,6 +1197,32 @@ fn push_log(log_buf: &Arc<Mutex<Vec<String>>>, msg: String) {
     }
 }
 
+/// Why there is no remote client, in words worth showing someone.
+///
+/// Every caller of `subsonic_client` gets `None` for four different reasons and
+/// used to report the same one. "koan has no password" sends you to sign in;
+/// "koan cannot read the password it has" sends you to the keychain, and the
+/// two are indistinguishable to a caller holding an `Option`.
+pub fn remote_unavailable(cfg: &Config) -> String {
+    if !cfg.remote.enabled {
+        return "no remote server is configured".into();
+    }
+    if cfg.remote.url.is_empty() {
+        return "the remote server has no address".into();
+    }
+    match remote_password(cfg).1 {
+        PasswordSource::Missing => "no password is stored for the remote server".into(),
+        PasswordSource::Unreadable(why) => {
+            format!("the remote password is in the keychain but could not be read: {why}")
+        }
+        // A password resolved, so the client should have built. Nothing else
+        // returns `None`, but saying so beats claiming a cause that is wrong.
+        PasswordSource::Keychain | PasswordSource::Config => {
+            "the remote server could not be reached".into()
+        }
+    }
+}
+
 /// Spawn background downloads for remote tracks with LoadState::Pending.
 pub fn spawn_downloads(
     pending: Vec<(i64, QueueItemId)>,
@@ -1176,10 +1235,15 @@ pub fn spawn_downloads(
         .spawn(move || {
             let cfg = Config::load().unwrap_or_default();
             let Some(client) = subsonic_client(&cfg) else {
-                log::warn!(
-                    "remote not configured -- skipping {} downloads",
-                    pending.len()
-                );
+                // Marked failed rather than left Pending. A track that cannot
+                // be fetched will never become Ready, and the player waits for
+                // Ready — so returning here quietly meant a queue that sat
+                // saying nothing until it ran off the end.
+                let why = remote_unavailable(&cfg);
+                log::warn!("skipping {} downloads: {}", pending.len(), why);
+                for (_, queue_id) in pending {
+                    state.update_load_state(queue_id, LoadState::Failed(why.clone()));
+                }
                 return;
             };
             for (db_id, queue_id) in pending {


### PR DESCRIPTION
**Cuts v0.27.0**, and carries the fix that prompted it.

Diagnosed from a real failure: with the library drive offline, nothing played and the log said `remote not configured -- skipping 29 downloads` while the remote was configured perfectly well. What koan could not do was *read the password* — the Keychain grants access per binary, and the app had never been granted it.

Three separate things had to be wrong for that to be as opaque as it was.

## `subsonic_client` returns `None` for four reasons and everyone reported one

`remote_unavailable(cfg)` names which. Behind it, `remote_password` carries provenance: a credential store that holds an entry and declines to hand it over — locked keychain, dismissed dialog, an item whose ACL does not list the binary asking — is indistinguishable from having no password at all to a caller holding an `Option<String>`. "koan has no password" sends you to sign in. "koan cannot read the password it has" sends you somewhere else entirely.

## Pending tracks waited forever

`spawn_downloads` found no client and returned, leaving every item `LoadState::Pending`. The player waits for `Ready`, so the queue sat in silence until it ran off the end — logging one `warn` nobody was looking at. They are marked `Failed` with the reason now. A track that cannot be fetched will never become Ready, so leaving it Pending was a promise koan could not keep.

## `koan remote status` reported the opposite of the truth

```rust
let has_password = !cfg.remote.password.is_empty();
```

It read the config field and never asked the credential store — so it printed `password: not set` for every keychain-backed sign-in, which is exactly what `koan remote login` creates. It then gated its own connectivity probe on that same flag, so the one check that would have distinguished "no credential" from "credential koan cannot read" never ran. The tool that should have found this bug was actively hiding it.

Now it goes through the same path as everything else:

```
server:   https://music.asdadssdf.fdsdfs
username: admin
password: from the keychain
status:   connected
```

and when credentials cannot be resolved it says which of the four reasons, with the platform's own message for the unreadable case.

## Verifying

`cargo test --workspace` — 872 pass, clippy clean under `-D warnings`.

Confirmed against the failure that prompted it: before, `password: not set` and no probe; after, on the same machine and config, the output above. Playback over the remote works once the binary is granted keychain access.

Refs #247 — the diagnosis and the remaining questions are there.

## The release

Minor, not patch — two breaking changes ride along. Every koan-ffi call that can block is `async` now, which is every call site in every native client, and the macOS app's floor moved to macOS 26. `organizePreview`/`organizeExecute` also changed shape for GraphQL clients.

The unreleased changelog section had accumulated a `### Fixed` and a `### Changed` from each PR that touched it, so entries sat under whichever heading happened to precede them — this fix had landed under Changed. Consolidated to one of each, in order, nothing dropped, 12 entries across the seven merged PRs plus this one. The FFI entry was written before #238 merged and said 70 of 75 calls; that merge added nine methods and a second exported object, so it now reads 80 of 86.

No tag — that's yours to cut.

## Not in this PR

- **Nothing retries.** `spawn_downloads` fires once per enqueue. Granting access afterwards does not restart a download that already failed — you have to re-queue. Marking the items `Failed` at least makes that visible rather than looking like a stall.
- **The test suite prompts for your real keychain password**, and blocks on it. `cargo test --workspace` puts up a dialog for `koan_server-<hash>`, because a koan-server test reaches `Config::load()` and through it the credential store. It is not only rude: that suite runs in 25.52s waiting on the dialog and 0.10s with `KOAN_NO_KEYCHAIN=1`. Tests reading the developer's real config is the underlying problem and wants its own fix.
