### PR TITLE
release: v0.27.1, and file v0.27.0's entries under v0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,6 @@
 # Changelog
 
-## Unreleased
-
-### Added
-
-- **`KOAN_CONFIG_DIR` points koan at a different configuration directory**, so one machine can run more than one library. `config_dir()` honours it, and `set_config_dir()` does the same in-process.
-
-### Fixed
-
-- **The test suite read the developer's own configuration, and asked for their keychain password.** `Config::load()` resolves its directory from `$HOME`, so tests inherited whatever library folders and remote server belonged to whoever ran them. A koan-tui *rendering* test spawned the download queue, which resolved the configured server and reached for the credentials to reach it with — and macOS put up a dialog asking for the login keychain password. The suite then blocked on it: koan-server's tests took 25.52s waiting, and 0.10s when the keychain was disabled.
-
-  Nothing was hardcoded; that is what made it easy to miss. The tests were simply configured as the person running them, and CI never noticed because a runner has no `~/.config/koan/` to inherit. On a developer's machine the same code path would have gone on to fetch tracks from their server.
-
-  Tests point the configuration at a disposable directory now, so they read a config nobody has edited. The ones that need a remote build their own rather than borrowing one.
-
-## v0.27.0 (2026-08-24)
+## v0.27.1 (2026-08-24)
 
 ### Changed
 
@@ -24,7 +10,11 @@
 
   A client that falls behind now drops the events it missed instead of delaying the engine. Every variant carries an absolute value — a snapshot, a version, a position — so the one that does arrive is complete on its own.
 
+## v0.27.0 (2026-08-24)
+
 ### Added
+
+- **`KOAN_CONFIG_DIR` points koan at a different configuration directory**, so one machine can run more than one library. `config_dir()` honours it, and `set_config_dir()` does the same in-process.
 
 - **The macOS app takes the TUI's single-key shortcuts.** `space`, `<`/`>`, `,`/`.`, `f`, `R`, `p`, `/`, `l`/`a`, `r`, `g`/`G`, `L`, `z` and `?` do there what they do in the TUI, and Help ▸ Keyboard Shortcuts (`?`) lists them — generated from the table that implements them, so the two cannot drift.
 
@@ -67,6 +57,12 @@
   `koan remote status` asks the way koan asks. It read the config field directly and never consulted the credential store, so it reported `password: not set` for every keychain-backed sign-in — the arrangement `koan remote login` creates — and then skipped its own connectivity check because of that same flag. The one tool that should have diagnosed this was reporting the opposite of the truth.
 
 ### Fixed
+
+- **The test suite read the developer's own configuration, and asked for their keychain password.** `Config::load()` resolves its directory from `$HOME`, so tests inherited whatever library folders and remote server belonged to whoever ran them. A koan-tui *rendering* test spawned the download queue, which resolved the configured server and reached for the credentials to reach it with — and macOS put up a dialog asking for the login keychain password. The suite then blocked on it: koan-server's tests took 25.52s waiting, and 0.10s when the keychain was disabled.
+
+  Nothing was hardcoded; that is what made it easy to miss. The tests were simply configured as the person running them, and CI never noticed because a runner has no `~/.config/koan/` to inherit. On a developer's machine the same code path would have gone on to fetch tracks from their server.
+
+  Tests point the configuration at a disposable directory now, so they read a config nobody has edited. The ones that need a remote build their own rather than borrowing one.
 
 - **Menu shortcuts no longer reach past a field you are typing in.** ⌘← and ⌥← skipped tracks instead of moving the caret or the word, and ⌘Z undid a queue edit instead of the typing — in the search field, a filter, Settings, anywhere. Every shortcut whose key also means something while typing is now *disabled* while a field has focus, which releases its key equivalent to the responder chain; declining the action instead would leave the menu swallowing the key, so the shortcut would stop working without the field ever hearing it. The bare-key shortcuts already asked what had focus; the modified ones never did.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.27.0 (2026-08-24)
+## Unreleased
 
 ### Added
 
@@ -14,7 +14,7 @@
 
   Tests point the configuration at a disposable directory now, so they read a config nobody has edited. The ones that need a remote build their own rather than borrowing one.
 
-## Unreleased
+## v0.27.0 (2026-08-24)
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2744,7 +2744,7 @@ dependencies = [
 
 [[package]]
 name = "koan-cli"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "chrono",
  "clap",
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "koan-core"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "argon2",
  "bliss-audio",
@@ -2810,7 +2810,7 @@ dependencies = [
 
 [[package]]
 name = "koan-ffi"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "chrono",
  "crossbeam-channel",
@@ -2830,7 +2830,7 @@ dependencies = [
 
 [[package]]
 name = "koan-server"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",
@@ -2863,7 +2863,7 @@ dependencies = [
 
 [[package]]
 name = "koan-tui"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "core-foundation 0.10.1",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/koan-core", "crates/koan-ffi", "crates/koan-server", "crates/koan-tui", "crates/koan-cli"]
 
 [workspace.package]
-version = "0.27.0"
+version = "0.27.1"
 edition = "2024"
 rust-version = "1.89"
 homepage = "https://github.com/radiosilence/koan"
@@ -13,9 +13,9 @@ license = "MIT"
 [workspace.dependencies]
 # Internal crates. Keep the version in step with [workspace.package] above —
 # a stale pin here publishes members that resolve against the wrong sibling.
-koan-core = { path = "crates/koan-core", version = "0.27.0" }
-koan-server = { path = "crates/koan-server", version = "0.27.0" }
-koan-tui = { path = "crates/koan-tui", version = "0.27.0" }
+koan-core = { path = "crates/koan-core", version = "0.27.1" }
+koan-server = { path = "crates/koan-server", version = "0.27.1" }
+koan-tui = { path = "crates/koan-tui", version = "0.27.1" }
 # Feature set is the union every member needs; `default-tls` is an alias for
 # `rustls`, so there is exactly one TLS stack.
 reqwest = { version = "0.13", default-features = false, features = [


### PR DESCRIPTION
**Cuts v0.27.1**, and repairs v0.27.0's changelog.

## Patch, not minor

The only change since the tag is #252, which swaps koan-ffi's callback interface for an async sequence. `koan-ffi` is `publish = false` and its only consumer is `apps/macos` in this repo, so no external call site breaks. Nothing a user can see changed either — same behaviour, one fewer FFI round trip per event.

## v0.27.0's entries were filed under the wrong heading

#248 renamed the Unreleased heading to `v0.27.0` while #250 inserted a fresh `Unreleased` above it. Both touched the same lines, the merge kept both headings, and the entries landed under whichever one happened to precede them.

This branch originally just swapped the two headings. That is no longer the right fix: **the tag was cut at `980bd35`, which is #250's merge**, so `KOAN_CONFIG_DIR` and the test-isolation fix genuinely shipped *in* v0.27.0 and were already filed correctly. What was misplaced were the other twelve — the async FFI boundary and the macOS 26 floor among them, both breaking. So they move down into v0.27.0 rather than the headings trading places.

After: **v0.27.0 lists all fourteen things it actually contains**, and `v0.27.1` holds the one that came after it.

## One thing this cannot fix

v0.27.0's release notes are already published on GitHub, generated from the broken changelog, and describe the release as containing only the test fix — with its two breaking changes listed as unreleased. Worth re-generating them from this once merged.

## Verifying

872 tests pass, clippy clean, version bumped across all five crates and the lockfile.
