### PR TITLE
feat(ffi): events as an async sequence, not a callback interface

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -50,7 +50,7 @@ Five crates, one workspace. `koan-core` is the engine; `koan-tui`, `koan-server`
 
 GraphQL earns its keep for clients that genuinely *cannot* link the core -- a browser, or a phone controlling playback on a different machine.
 
-When you add a capability, ask whether both doors need it. `koan-ffi` returns cover art as raw bytes where GraphQL has to base64 it, and polls where GraphQL subscribes; otherwise the two mirror each other closely enough that a gap in one is usually a gap in both.
+When you add a capability, ask whether both doors need it. `koan-ffi` returns cover art as raw bytes where GraphQL has to base64 it, and hands out changes by awaiting `next_event` where GraphQL subscribes; otherwise the two mirror each other closely enough that a gap in one is usually a gap in both.
 
 ## Threading model
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@
 
 ## Unreleased
 
+### Changed
+
+- **Engine events are an async sequence rather than a callback interface.** `PlayerEvents` was a trait the client implemented and registered; it is now `next_event()`, awaited in a loop, and `PlayerEvent` carries what changed. The loop *is* the subscription, so its lifetime is the client's task and there is nothing to register or unregister.
+
+  The macOS app loses the object that existed only to bridge the two worlds — a callback has to be `Sendable` while the model is main-actor isolated, so every one of its three methods did nothing but hop back with `Task { @MainActor }`. It also loses an FFI round trip per event: the change already carries the new state, and the app was re-fetching it.
+
+  A client that falls behind now drops the events it missed instead of delaying the engine. Every variant carries an absolute value — a snapshot, a version, a position — so the one that does arrive is complete on its own.
+
 ### Added
 
 - **The macOS app takes the TUI's single-key shortcuts.** `space`, `<`/`>`, `,`/`.`, `f`, `R`, `p`, `/`, `l`/`a`, `r`, `g`/`G`, `L`, `z` and `?` do there what they do in the TUI, and Help ▸ Keyboard Shortcuts (`?`) lists them — generated from the table that implements them, so the two cannot drift.

--- a/apps/macos/Sources/Koan/Support/PlayerModel.swift
+++ b/apps/macos/Sources/Koan/Support/PlayerModel.swift
@@ -44,6 +44,9 @@ final class PlayerModel {
     /// polling the engine a second time on its own timer.
     var onTick: (() -> Void)?
 
+    /// The loop following the engine. Cancelling it ends the subscription.
+    @ObservationIgnored private var events: Task<Void, Never>?
+
     init(engine: KoanEngine) {
         self.engine = engine
         // Reading the engine is a suspension now, so the first frame renders
@@ -59,16 +62,41 @@ final class PlayerModel {
     /// rather than asking. The watching still happens — it just happens in
     /// Rust, over atomics, off the audio path.
     func start() async {
-        await engine.subscribe(listener: EventBridge(model: self))
         await tick()  // Seed from current state; events only carry changes.
         refreshDevices()
         startAutosave()
+        observe()
+    }
+
+    /// Follow the engine for as long as this model is alive.
+    ///
+    /// The loop *is* the subscription — there is nothing to register and
+    /// nothing to unregister, and cancelling the task ends it. Weakly held so
+    /// a model that goes away takes its loop with it.
+    private func observe() {
+        events?.cancel()
+        events = Task { [weak self] in
+            guard let engine = self?.engine else { return }
+            for await event in engine.events() {
+                guard let self else { return }
+                switch event {
+                case .playbackChanged(let nowPlaying):
+                    await self.tick(nowPlaying)
+                case .queueChanged:
+                    await self.applyQueueChange()
+                case .positionChanged(let positionMs):
+                    self.applyPosition(positionMs)
+                }
+            }
+        }
     }
 
     /// Apply a snapshot. Called on subscribe and whenever the engine says
     /// something changed.
-    fileprivate func tick() async {
-        let now = await engine.nowPlaying()
+    /// Apply a snapshot. `nil` fetches one — which only the initial seed needs,
+    /// since every event that reports a change carries the new state with it.
+    fileprivate func tick(_ snapshot: NowPlaying? = nil) async {
+        let now = if let snapshot { snapshot } else { await engine.nowPlaying() }
         nowPlaying = now
         updateDerived(now)
         // The queue only gets rebuilt when the engine says it changed.
@@ -492,27 +520,21 @@ final class PlayerModel {
     }
 }
 
-/// Bridges the engine's callbacks onto the main actor.
+/// Pulls events from the engine as an `AsyncSequence`.
 ///
-/// uniffi calls these from its own thread, so nothing here may touch the model
-/// directly — each hop is explicit. Separate from `PlayerModel` because the
-/// callback interface must be `Sendable` and the model is main-actor isolated.
-final class EventBridge: PlayerEvents, @unchecked Sendable {
-    private weak var model: PlayerModel?
-
-    init(model: PlayerModel) {
-        self.model = model
-    }
-
-    func playbackChanged(nowPlaying: NowPlaying) {
-        Task { @MainActor [weak model] in await model?.tick() }
-    }
-
-    func queueChanged(version: UInt64) {
-        Task { @MainActor [weak model] in await model?.applyQueueChange() }
-    }
-
-    func positionChanged(positionMs: UInt64) {
-        Task { @MainActor [weak model] in model?.applyPosition(positionMs) }
+/// `nextEvent()` answers one at a time and returns nil once the engine is
+/// gone; this makes that a `for await` loop, so a client's subscription lives
+/// exactly as long as the task reading it.
+extension KoanEngine {
+    func events() -> AsyncStream<PlayerEvent> {
+        AsyncStream { continuation in
+            let pump = Task {
+                while let event = await self.nextEvent() {
+                    continuation.yield(event)
+                }
+                continuation.finish()
+            }
+            continuation.onTermination = { _ in pump.cancel() }
+        }
     }
 }

--- a/crates/koan-ffi/src/lib.rs
+++ b/crates/koan-ffi/src/lib.rs
@@ -54,23 +54,29 @@ pub struct FuzzyMatch {
     pub kind: SearchKind,
 }
 
-/// Events pushed from the engine, so clients don't have to poll.
+/// Something the engine changed, delivered by awaiting `next_event`.
 ///
-/// Watching happens on a Rust thread reading atomics, not from the audio or
-/// decode threads: `set_position_ms` is a hot-path store and calling into a
-/// foreign language from there would put an unbounded amount of work in a
-/// timing-sensitive path. Discrete changes fire as they happen; position ticks
-/// only while something is playing, and only when the value actually moved.
-#[uniffi::export(with_foreign)]
-pub trait PlayerEvents: Send + Sync {
+/// A pull surface rather than a callback interface: a client writes a loop
+/// instead of an object, and the loop's lifetime is the subscription's, so
+/// there is nothing to unregister and nothing to leak across a reload.
+///
+/// Every variant carries an absolute value, never a delta, which is what makes
+/// it safe to drop the older ones when a client falls behind — the next one
+/// tells the whole truth on its own.
+// One variant carries a snapshot and two carry a u64. Boxing is what clippy
+// wants and is not on offer across the FFI, and the saving would be nothing:
+// these are built a handful of times a second, not held in a collection.
+#[allow(clippy::large_enum_variant)]
+#[derive(uniffi::Enum, Debug, Clone)]
+pub enum PlayerEvent {
     /// State, track, or format changed — anything a transport bar displays
     /// other than the position.
-    fn playback_changed(&self, now_playing: NowPlaying);
+    PlaybackChanged { now_playing: NowPlaying },
     /// The queue was mutated. Carries the version so a client can skip a
     /// refetch it has already done.
-    fn queue_changed(&self, version: u64);
+    QueueChanged { version: u64 },
     /// Playback position, while playing.
-    fn position_changed(&self, position_ms: u64);
+    PositionChanged { position_ms: u64 },
 }
 
 /// Reports how far a long task has got.
@@ -153,7 +159,7 @@ pub struct KoanEngine {
     state: Arc<SharedPlayerState>,
     tx: Sender<PlayerCommand>,
     db_path: PathBuf,
-    listener: Arc<parking_lot::RwLock<Option<Arc<dyn PlayerEvents>>>>,
+    events: tokio::sync::broadcast::Sender<PlayerEvent>,
     /// Set while the automatic sync is running, so a UI can say so rather than
     /// appearing to do nothing for the minute it takes.
     auto_syncing: Arc<std::sync::atomic::AtomicBool>,
@@ -219,22 +225,24 @@ impl KoanEngine {
     pub async fn now_playing(self: Arc<Self>) -> NowPlaying {
         offload::offload(move || self.now_playing_blocking()).await
     }
-    /// Start pushing events to `listener`. Replaces polling `now_playing()`.
+    /// Wait for the next thing to change.
     ///
-    /// One listener at a time — a second call replaces the first, which is what
-    /// a single UI wants and avoids leaking a listener across a reload.
-    pub async fn subscribe(self: Arc<Self>, listener: Arc<dyn PlayerEvents>) {
-        offload::offload(move || {
-            *self.listener.write() = Some(listener);
-        })
-        .await
-    }
-
-    pub async fn unsubscribe(self: Arc<Self>) {
-        offload::offload(move || {
-            *self.listener.write() = None;
-        })
-        .await
+    /// `None` once the engine is gone, which ends the caller's loop. A client
+    /// that falls behind loses the events it missed rather than delaying the
+    /// engine — every variant carries an absolute value, so the one that does
+    /// arrive is still correct.
+    pub async fn next_event(self: Arc<Self>) -> Option<PlayerEvent> {
+        let mut rx = self.events.subscribe();
+        loop {
+            match rx.recv().await {
+                Ok(event) => return Some(event),
+                // Fell behind. The next event supersedes whatever was dropped.
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                    log::debug!("client missed {n} events");
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => return None,
+            }
+        }
     }
 
     /// Cheap enough to poll every frame — use it to decide whether to call
@@ -1718,7 +1726,7 @@ impl OrganizeSelection {
 // --- Internals -------------------------------------------------------------
 
 impl KoanEngine {
-    /// Watch shared state and push changes to the listener.
+    /// Watch shared state and publish what changes.
     ///
     /// Polls, but in Rust and over atomics, which is nothing — and the client
     /// sees events. The alternative, notifying from the player's own mutation
@@ -1738,8 +1746,11 @@ impl KoanEngine {
                     let Some(engine) = engine.upgrade() else {
                         return; // Engine dropped; so is the app.
                     };
-                    let Some(listener) = engine.listener.read().clone() else {
-                        continue;
+                    // Nobody listening is not a reason to stop watching: a
+                    // client can start a loop at any point and expects the
+                    // next change, not the next change after it re-subscribes.
+                    let publish = |event| {
+                        let _ = engine.events.send(event);
                     };
 
                     let state = engine.state.playback_state();
@@ -1747,13 +1758,15 @@ impl KoanEngine {
                     let signature = (state, cursor);
                     if last_signature.as_ref() != Some(&signature) {
                         last_signature = Some(signature);
-                        listener.playback_changed(engine.now_playing_blocking());
+                        publish(PlayerEvent::PlaybackChanged {
+                            now_playing: engine.now_playing_blocking(),
+                        });
                     }
 
                     let version = engine.state.playlist_version();
                     if version != last_version {
                         last_version = version;
-                        listener.queue_changed(version);
+                        publish(PlayerEvent::QueueChanged { version });
                         ticks_since_download_nudge = 0;
                     } else if !engine.state.pending_downloads().is_empty() {
                         // Download progress moves without bumping the version,
@@ -1763,7 +1776,7 @@ impl KoanEngine {
                         ticks_since_download_nudge += 1;
                         if ticks_since_download_nudge >= 10 {
                             ticks_since_download_nudge = 0;
-                            listener.queue_changed(version);
+                            publish(PlayerEvent::QueueChanged { version });
                         }
                     }
 
@@ -1773,7 +1786,9 @@ impl KoanEngine {
                         let position = engine.state.position_ms();
                         if position != last_position {
                             last_position = position;
-                            listener.position_changed(position);
+                            publish(PlayerEvent::PositionChanged {
+                                position_ms: position,
+                            });
                         }
                     }
                 }
@@ -1918,16 +1933,17 @@ impl KoanEngine {
             });
         }
 
-        let listener: Arc<parking_lot::RwLock<Option<Arc<dyn PlayerEvents>>>> =
-            Arc::new(parking_lot::RwLock::new(None));
+        // Capacity, not a queue to drain: a client that falls behind drops the
+        // events it missed, and the next one it does get is a complete answer.
+        let (events, _) = tokio::sync::broadcast::channel(64);
         let engine = Arc::new(Self {
             state,
             tx,
             db_path,
+            events,
             auto_syncing,
             auto_scanning,
             cancel_library_task: Arc::new(std::sync::atomic::AtomicBool::new(false)),
-            listener,
         });
         engine.spawn_watcher();
         Ok(engine)


### PR DESCRIPTION
`PlayerEvents` was a trait the client implemented and registered. It is now `next_event()`, awaited in a loop, with `PlayerEvent` carrying what changed.

```swift
for await event in engine.events() {
    switch event { ... }
}
```

**The loop is the subscription.** Its lifetime is the client's task, so there is nothing to register, nothing to unregister, and nothing to leak across a reload — the old `subscribe`/`unsubscribe` pair and the "one listener at a time" rule both go away because they have nothing left to guard.

## What the app loses

`EventBridge` existed only to bridge two worlds: a callback interface must be `Sendable`, `PlayerModel` is main-actor isolated, so all three of its methods did nothing but hop back with `Task { @MainActor }`. It is gone, along with the `@unchecked Sendable` and the weak-model dance.

It also loses **an FFI round trip per event**. `playbackChanged` already carried the new snapshot; the app discarded it and called `nowPlaying()` again. `tick` takes the snapshot it was handed now, and only fetches one for the initial seed.

## Falling behind

A slow client drops the events it missed rather than delaying the engine — a broadcast channel with a capacity, not a queue anyone has to drain. That is only safe because **every variant carries an absolute value**: a snapshot, a version, a position, never a delta. Whichever event does arrive is a complete answer on its own, so the dropped ones cost nothing but a frame. `Lagged` is logged and skipped; `Closed` ends the loop.

The watcher also stops caring whether anyone is listening. It used to skip its work when no listener was registered, which meant a client starting a loop had to wait for the *next* change after it subscribed.

## Verifying

`cargo test --workspace` — 872 pass, clippy clean under `-D warnings`, `swift build` clean. `EventBridge` and `PlayerEvents` no longer appear anywhere in the app.

Not exercised in the GUI yet — the transport bar and queue updates are what to watch, since that is the whole surface this drives.

## One deliberate lint suppression

`clippy::large_enum_variant` fires because one variant holds a snapshot and two hold a `u64`. Boxing is what it wants and is not on offer across the FFI, and the saving would be nothing — these are built a handful of times a second, not held in a collection. Suppressed with that reasoning at the definition.

Closes #245.
