### PR TITLE
fix(ci): drop deprecated depends_on string comparison from the cask

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -426,10 +426,10 @@ jobs:
 
             url "https://github.com/radiosilence/koan/releases/download/v#{version}/Koan.dmg"
             name "koan"
-            desc "Bit-perfect music player for macOS"
+            desc "Bit-perfect music player"
             homepage "https://github.com/radiosilence/koan"
 
-            depends_on macos: ">= :tahoe"
+            depends_on macos: :tahoe
 
             app "kōan.app"
 
@@ -438,9 +438,7 @@ jobs:
               system_command "/usr/bin/xattr", args: ["-cr", "#{appdir}/kōan.app"]
             end
 
-            zap trash: [
-              "~/.config/koan",
-            ]
+            zap trash: "~/.config/koan"
           end
           CASK
           sed -i 's/^          //' Casks/koan-app.rb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@
 
 - **Reading the config forked a `git` process.** `Config::load()` re-read both TOML files, re-ran the figment merge, and re-scanned for credentials in version control — and that last check shells out to `git ls-files` whenever a password is present in the file, then panics if it is tracked. koan reaches config from paths that run per frame: the macOS settings pane reads `library_folders()` from a SwiftUI list body, so it did all of that per rendered frame. The check is what its own message says it is, a gate on starting, and runs once per process now. The merged config is cached and re-read when either file's mtime moves, so a config edited by hand is still picked up.
 
+- **The Homebrew cask warned on every `brew` command.** `depends_on macos: ">= :tahoe"` is a deprecated string comparison; the bare symbol has always meant "that version or newer", so the requirement is unchanged. The workflow that regenerates the cask on release is fixed too, not just the published tap.
+
 ## v0.26.0 (2026-08-23)
 
 ### Added


### PR DESCRIPTION
Every `brew` command printed a deprecation warning for `koan-app`:

```
Warning: Calling string comparison format for `depends_on macos:` is deprecated!
Use `depends_on macos: :tahoe` instead.
```

`">= :tahoe"` is the deprecated string-comparison form. The bare symbol has always meant *that version or newer*, so the requirement is unchanged — `brew info --cask koan-app` still reports `Required: macOS >= 26`.

The cask is generated by the release job in `ci-cd.yml`, so fixing only the published tap would last until the next release. Both are fixed; the tap is already pushed ([radiosilence/homebrew-koan@6d85606](https://github.com/radiosilence/homebrew-koan/commit/6d85606)) so the warning is gone now rather than at v0.28.0.

Also clears the two `brew style` offenses the generated cask carried — a cask desc may not name the platform, and a single-element `zap trash` array. `brew style --cask koan-app` is clean.

## Verifying

`brew update && brew info --cask koan-app` — no warning, requirement unchanged. The workflow block at `.github/workflows/ci-cd.yml:422` should match the file now in the tap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L2QYGXTN6dYC7MX5KNY8a5