### PR TITLE
fix(macos): the sidebar footer drew under the transport bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,10 @@
 
 - **Reading the config forked a `git` process.** `Config::load()` re-read both TOML files, re-ran the figment merge, and re-scanned for credentials in version control — and that last check shells out to `git ls-files` whenever a password is present in the file, then panics if it is tracked. koan reaches config from paths that run per frame: the macOS settings pane reads `library_folders()` from a SwiftUI list body, so it did all of that per rendered frame. The check is what its own message says it is, a gate on starting, and runs once per process now. The merged config is cached and re-read when either file's mtime moves, so a config edited by hand is still picked up.
 
+- **The foot of the macOS sidebar was cut off by the transport bar.** The bar is a `safeAreaInset` on the split view, which reserves space in the window but not inside a column's own scroll view. The detail column already compensated; the sidebar never did, so its footer was laid out against a frame whose bottom sits behind the bar — the divider and the first activity row showed, and the progress bar, the cancel button and the library counts underneath them did not. During a sync you got a label with nothing to say how far along it was.
+
+  The sidebar takes the same measured inset the detail column takes, so the footer grows upward from the top of the bar.
+
 ## v0.26.0 (2026-08-23)
 
 ### Added

--- a/apps/macos/Sources/Koan/Views/RootView.swift
+++ b/apps/macos/Sources/Koan/Views/RootView.swift
@@ -35,7 +35,7 @@ struct RootView: View {
         @Bindable var ui = ui
 
         NavigationSplitView {
-            SidebarView()
+            SidebarView(bottomInset: transportHeight)
                 .navigationSplitViewColumnWidth(min: 190, ideal: 215, max: 290)
         } detail: {
             NavigationStack(path: $library.path) {

--- a/apps/macos/Sources/Koan/Views/SidebarView.swift
+++ b/apps/macos/Sources/Koan/Views/SidebarView.swift
@@ -3,6 +3,13 @@ import KoanFFI
 import SwiftUI
 
 struct SidebarView: View {
+    /// The transport bar's height. The bar is a `safeAreaInset` on the split
+    /// view, which reserves space in the window but not inside this List — so
+    /// the footer drew underneath it and everything below the first activity
+    /// row was cut off. Measured in `RootView` and passed down rather than
+    /// guessed at, for the same reason the detail column measures it.
+    let bottomInset: CGFloat
+
     @Environment(LibraryModel.self) private var library
     @Environment(PlayerModel.self) private var player
     @Environment(SearchModel.self) private var search
@@ -91,6 +98,7 @@ struct SidebarView: View {
         .onChange(of: searchFocused) { _, new in NSLog("SIDEBAR searchFocused = \(new)") }
         .safeAreaInset(edge: .bottom) {
             footer
+                .padding(.bottom, bottomInset)
         }
     }
 


### PR DESCRIPTION
The foot of the sidebar was clipped by the transport bar — during a sync you saw the task label and nothing else.

The transport is a `safeAreaInset` on the `NavigationSplitView`. That reserves space in the *window*, but not inside a column's own scroll view — which is exactly the trap `RootView` already documents and works around for the detail column with a measured `.safeAreaPadding(.bottom, transportHeight)`. The sidebar never got the same treatment, so its `List` footer was positioned against a frame whose bottom edge sits behind the bar. The footer therefore rendered top-down into the visible strip and lost everything past it: the progress bar, the cancel button, the detail line, and the library counts underneath.

The sidebar takes the same measurement, passed in from `RootView` rather than written as a constant, for the reason the existing comment gives — the bar's height is a stack of paddings and a control size, and any number typed here would be right until one of them changed.

## Verifying

`just macos-run`. The library counts at the foot of the sidebar sit clear of the transport bar; start a sync (Server ▸ Full sync) and the activity row shows its progress bar and cancel button rather than a bare label. The footer grows upward from the top of the bar as tasks are added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L2QYGXTN6dYC7MX5KNY8a5