### PR TITLE
fix(macos): drag an artist's name, not just its row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@
 
 ### Fixed
 
+- **Dragging an artist's name in the artists list dragged nothing.** The name was a `Button`, and a button consumes the press a drag starts from — so the row queued when dragged and the link on it, standing for the same artist, did not. The app now has one kind of link text rather than two, and every name that navigates to something playable is also a drag source for it.
+
 - **Menu shortcuts no longer reach past a field you are typing in.** ⌘← and ⌥← skipped tracks instead of moving the caret or the word, and ⌘Z undid a queue edit instead of the typing — in the search field, a filter, Settings, anywhere. Every shortcut whose key also means something while typing is now *disabled* while a field has focus, which releases its key equivalent to the responder chain; declining the action instead would leave the menu swallowing the key, so the shortcut would stop working without the field ever hearing it. The bare-key shortcuts already asked what had focus; the modified ones never did.
 
 - **The sync fetched 1,725 artists and threw the list away.** `get_artists` was called, counted, logged as "syncing 1725 artists" and then dropped — artists only ever came into being as a side effect of a track upsert, which saw nothing but a name and an id. That is why not one artist in a synced library had a MusicBrainz id or a sort name, and why the reported artist count was theatre. The list is applied now, and the count is what was actually written.

--- a/apps/macos/Sources/Koan/Views/ArtistBrowser.swift
+++ b/apps/macos/Sources/Koan/Views/ArtistBrowser.swift
@@ -26,7 +26,12 @@ struct ArtistBrowser: View {
                 .frame(width: 18, height: 18)
                 // The name is the way in — a link, so a single click opens the
                 // artist while the rest of the row selects.
-                RowLink(artist.name) { library.reveal(artist: artist.id) }
+                LinkText(
+                    text: artist.name,
+                    target: .artist(artist.id),
+                    font: .body,
+                    prominent: true
+                )
                 FavouriteButton(
                     isOn: library.isFavourite(artist: artist.id),
                     showing: hovered == artist.id,

--- a/apps/macos/Sources/Koan/Views/LinkText.swift
+++ b/apps/macos/Sources/Koan/Views/LinkText.swift
@@ -1,3 +1,4 @@
+import AppKit
 import KoanFFI
 import SwiftUI
 
@@ -16,6 +17,9 @@ struct LinkText: View {
     let text: String
     let target: Target?
     var font: Font = .callout
+    /// The link is the row's own subject rather than a reference out of it —
+    /// an artist in the artists list, not the artist credited on a track.
+    var prominent = false
 
     @Environment(LibraryModel.self) private var library
     @State private var hovering = false
@@ -32,10 +36,22 @@ struct LinkText: View {
             Text(text)
                 .font(font)
                 .underline(hovering)
-                .foregroundStyle(hovering ? AnyShapeStyle(.primary) : AnyShapeStyle(.secondary))
+                .foregroundStyle(
+                    hovering || prominent ? AnyShapeStyle(.primary) : AnyShapeStyle(.secondary)
+                )
                 .lineLimit(1)
                 .contentShape(.rect)
-                .onHover { hovering = $0 }
+                .onHover { inside in
+                    hovering = inside
+                    // `.pointerStyle(.link)` needs macOS 15; the app targets 14.
+                    if inside { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+                }
+                // A row that scrolls or filters away while hovered never sees
+                // the exit, and the hand cursor would be left on the stack.
+                .onDisappear {
+                    if hovering { NSCursor.pop() }
+                    hovering = false
+                }
                 .onTapGesture {
                     switch target {
                     case .artist(let id): library.reveal(artist: id)
@@ -51,7 +67,7 @@ struct LinkText: View {
         } else {
             Text(text)
                 .font(font)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(prominent ? AnyShapeStyle(.primary) : AnyShapeStyle(.secondary))
                 .lineLimit(1)
         }
     }

--- a/apps/macos/Sources/Koan/Views/RowBehaviour.swift
+++ b/apps/macos/Sources/Koan/Views/RowBehaviour.swift
@@ -1,4 +1,3 @@
-import AppKit
 import KoanFFI
 import SwiftUI
 
@@ -46,47 +45,6 @@ extension View {
     /// something playable.
     func rowBehaviour(playable: Playable? = nil) -> some View {
         modifier(RowBehaviour(playable: playable))
-    }
-}
-
-/// A link inside a row.
-///
-/// A `Button` wins hit-testing within its own frame, so the row's selection and
-/// primary action don't fire when you hit the link — which is what makes
-/// "click the artist name to go to the artist, click the row to select it"
-/// possible at all. It has to be a Button for that reason; it just shouldn't
-/// look like one.
-///
-/// Styled to match the links elsewhere in the app: ordinary text that underlines
-/// on hover. Link blue in a list of names reads as decoration rather than
-/// emphasis.
-struct RowLink: View {
-    let title: String
-    let font: Font
-    let action: () -> Void
-
-    @State private var hovering = false
-
-    init(_ title: String, font: Font = .body, action: @escaping () -> Void) {
-        self.title = title
-        self.font = font
-        self.action = action
-    }
-
-    var body: some View {
-        Button(action: action) {
-            Text(title)
-                .font(font)
-                .underline(hovering)
-                .foregroundStyle(.primary)
-                .lineLimit(1)
-        }
-        .buttonStyle(.plain)
-        .onHover { inside in
-            hovering = inside
-            // `.pointerStyle(.link)` needs macOS 15; the app targets 14.
-            if inside { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-        }
     }
 }
 


### PR DESCRIPTION
Dragging an artist's name in the artists list did nothing, while dragging the row beside it queued the artist. The name was a `Button`, and a button consumes the press a drag starts from — the same thing `ArtistPill` had already run into and worked around by not being one.

Rather than bolt a payload onto the button, this collapses the two link types into one. `RowLink` (Button, primary text, hand cursor) is gone; `LinkText` (plain text, tap gesture, already draggable, used everywhere else) gains a `prominent` flag for when the link is the row's own subject rather than a credit off it. Every name that navigates to something playable is now also a drag source for it, so playlists get this for free when they land.

`LinkText` also pops the hand cursor in `onDisappear` — a hovered row that scrolls or filters away never sees the exit, and the cursor would stick. One link type meant fixing that once.

### Verifying

Artists list, in the built app:
- drag an artist's name onto the queue — it queues the artist, same as dragging the row
- click the name — goes to the artist; click elsewhere in the row — selects it. That split used to be enforced by the link being a Button winning hit-testing, and is now a tap gesture, as it already is for the artist links in the track list.
- hover a name, then filter the list out from under the pointer — cursor returns to normal

No Rust touched; `just macos-build` is the whole check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBPfTttHJfEBPqMtq6Zjmo