### PR TITLE
chore(macos): drop leftover debug logging

### DIFF
--- a/apps/macos/Sources/Koan/Support/Hotkeys.swift
+++ b/apps/macos/Sources/Koan/Support/Hotkeys.swift
@@ -134,7 +134,6 @@ extension Hotkeys {
                 ui.showingPicker = true
             },
             Hotkey(keys: ["/"], label: "Search library", group: .navigation) {
-                NSLog("HOTKEY slash -> focusSearch")
                 ui.focusSearch()
             },
             Hotkey(keys: ["l", "a"], label: "Albums", group: .navigation) {

--- a/apps/macos/Sources/Koan/Views/SidebarView.swift
+++ b/apps/macos/Sources/Koan/Views/SidebarView.swift
@@ -92,10 +92,8 @@ struct SidebarView: View {
         // `/`, the way it works in the TUI. The field is somewhere else on
         // screen, so the key can only ask for it by token.
         .onChange(of: ui.searchFocusToken) { _, _ in
-            NSLog("SIDEBAR token change -> searchFocused = true")
             searchFocused = true
         }
-        .onChange(of: searchFocused) { _, new in NSLog("SIDEBAR searchFocused = \(new)") }
         .safeAreaInset(edge: .bottom) {
             footer
                 .padding(.bottom, bottomInset)


### PR DESCRIPTION
Three `NSLog` calls left over from tracing the `/` key through to the search field:

```
HOTKEY slash -> focusSearch
SIDEBAR token change -> searchFocused = true
SIDEBAR searchFocused = <bool>
```

They ship in release builds. The third fires on every focus change — every time you tab between the sidebar and the stage — and the `.onChange(of: searchFocused)` modifier carrying it existed for no other reason, so it goes with it.

No behaviour change; the `/` path itself is untouched.

## Verifying

`just macos-build`, then `log stream --predicate 'process == "kōan"'` while pressing `/` and clicking between the sidebar and the queue — silent now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L2QYGXTN6dYC7MX5KNY8a5