### PR TITLE
fix(macos): a search result click was undone by the sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,12 @@
 
   The sidebar takes the same measured inset the detail column takes, so the footer grows upward from the top of the bar.
 
+- **Clicking a search result did nothing.** Albums, artists and tracks on the results page all registered the click and stayed put; the same tiles and pills worked in the album and artist browsers, which is what made it look like a hit-testing problem rather than a navigation one.
+
+  The sidebar's lit row was derived from the detail stack, so that an album opened from anywhere lit Albums. Opening one therefore *moved* the sidebar selection — and a `List` writes a moved selection back through its binding. That setter pops to the section root, which is right when you click a sidebar row and wrong when the List is echoing a move the app just made: it threw away the destination that had only just been pushed. The browsers were unaffected because the lit row was already the right one, so nothing moved and nothing echoed.
+
+  The lit row is now the section being browsed and nothing else. Opening an album from search results keeps Results lit, and Back returns you to them.
+
 ## v0.26.0 (2026-08-23)
 
 ### Added

--- a/apps/macos/Sources/Koan/Support/LibraryModel.swift
+++ b/apps/macos/Sources/Koan/Support/LibraryModel.swift
@@ -338,15 +338,6 @@ final class LibraryModel {
     /// the queue pushes a detail view without changing section, so the sidebar
     /// went on pointing at wherever you started — which is not where you are.
     /// The row an album lives under is Albums, whichever door you came through.
-    var navSelection: Section {
-        guard !path.isEmpty else { return section }
-        switch history.indices.contains(historyCursor) ? history[historyCursor] : .section(section) {
-        case .album: return .albums
-        case .artist: return .artists
-        case .section(let s): return s
-        }
-    }
-
     private(set) var history: [Destination] = [.section(.queue)]
     private(set) var historyCursor = 0
     /// Set while replaying history, so applying a destination doesn't record it

--- a/apps/macos/Sources/Koan/Views/SidebarView.swift
+++ b/apps/macos/Sources/Koan/Views/SidebarView.swift
@@ -23,15 +23,19 @@ struct SidebarView: View {
         @Bindable var library = library
         @Bindable var search = search
 
+        // The lit row is the section being browsed, and nothing else. Deriving
+        // it from the detail stack — so that an album reached from anywhere lit
+        // Albums — meant pushing a destination moved the selection, and a List
+        // writes a moved selection back through its binding. The setter below
+        // then popped the path it had just been given, so a click on a search
+        // result registered and went nowhere.
         List(selection: Binding(
-            get: { library.navSelection },
+            get: { library.section },
             set: { chosen in
                 guard let chosen else { return }
                 // Choosing a section always lands on its root — including the
                 // one you are already in, which is otherwise a trip out to
-                // another section and back. `navSelection` follows the detail
-                // stack, so this also covers choosing Albums from inside an
-                // album you reached through Favourites.
+                // another section and back.
                 library.section = chosen
                 library.popToRoot()
             }


### PR DESCRIPTION
Clicking anything on the search results page — album tile, artist pill, track row — registered the click and went nowhere. The same components worked in the album and artist browsers, which is what made this look like hit-testing rather than navigation.

## What was happening

The sidebar's lit row was derived from the detail stack (`LibraryModel.navSelection`), so that an album opened from any section lit **Albums**. That means pushing a destination *moves* the sidebar selection — and a `List` writes a moved selection back through its binding.

The setter takes that write as a row click:

```swift
library.section = chosen
library.popToRoot()          // discards the path
```

Popping to root is right when you click a sidebar row and destructive when the List is echoing a move the app itself just made. `reveal()` pushed the route, the echo popped it, and the page sat still.

Only the results page could trigger it: everywhere else the lit row already matched where the push landed, so the selection never moved and nothing was echoed back. That asymmetry is the whole tell.

## The fix

The lit row is the section being browsed and nothing else. `navSelection` is then just an alias for `section`, so it goes with it.

Behaviour change worth knowing: opening an album from search results keeps **Results** lit rather than jumping to Albums. That reads better anyway — you are still in the search flow, and Back returns you to the results.

## Verifying

`just macos-run`. Search, then click an album tile, an artist pill and a track row — each opens. Check the album and artist browsers still navigate, and that clicking the section you are already in still pops you to its root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L2QYGXTN6dYC7MX5KNY8a5