### PR TITLE
refactor(macos): one drag path, not two

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,8 @@
 
   The sidebar takes the same measured inset the detail column takes, so the footer grows upward from the top of the bar.
 
+- **Drag sources outside list rows went through `.onDrag`.** It claims the press outright, which costs the tap underneath it — `RowBehaviour` had already found this and moved list rows to `.draggable`, whose recogniser has a movement threshold and leaves a press that never moves as a click. Album tiles, artist pills and artist names were still on the old path. `PlayableTransfer` is `Transferable` with the two representations the item provider was registering by hand, so drops inside koan and the plain-text fallback out of it are unchanged.
+
 ## v0.26.0 (2026-08-23)
 
 ### Added

--- a/apps/macos/Sources/Koan/Support/PlayableTransfer.swift
+++ b/apps/macos/Sources/Koan/Support/PlayableTransfer.swift
@@ -71,11 +71,6 @@ struct PlayableTransfer: Codable, Transferable, Hashable {
 
 extension View {
     /// Make this view a drag source for `playable`.
-    ///
-    /// `.onDrag` rather than `.draggable`: the newer Transferable API does not
-    /// take effect on List rows here, while the older item-provider one does.
-    /// Same identifier and same JSON on the wire, so `.dropDestination(for:)`
-    /// still decodes it.
     func draggablePlayable(_ playable: Playable) -> some View {
         draggableTransfer(PlayableTransfer(playable))
     }
@@ -83,25 +78,13 @@ extension View {
     /// The payload directly, for a view that stands for something playable but
     /// has no `Playable` to hand — an artist name inside an album tile knows an
     /// id and a name and nothing else.
+    ///
+    /// `.draggable`, not `.onDrag`: the drag recogniser behind it has a movement
+    /// threshold, so a press that never moves is still a click. `.onDrag` claims
+    /// the press outright and any tap underneath it never fires. The
+    /// `Transferable` conformance puts the same two representations on the wire
+    /// that the item provider used to register by hand.
     func draggableTransfer(_ transfer: PlayableTransfer) -> some View {
-        onDrag {
-            let provider = NSItemProvider()
-            provider.registerDataRepresentation(
-                forTypeIdentifier: UTType.koanPlayable.identifier,
-                visibility: .ownProcess
-            ) { completion in
-                completion(try? JSONEncoder().encode(transfer), nil)
-                return nil
-            }
-            // So a drag that leaves koan still says something useful.
-            provider.registerDataRepresentation(
-                forTypeIdentifier: UTType.plainText.identifier,
-                visibility: .all
-            ) { completion in
-                completion(Data(transfer.name.utf8), nil)
-                return nil
-            }
-            return provider
-        }
+        draggable(transfer)
     }
 }

--- a/apps/macos/Sources/Koan/Views/ArtistPill.swift
+++ b/apps/macos/Sources/Koan/Views/ArtistPill.swift
@@ -36,8 +36,6 @@ struct ArtistPill: View {
         .padding(.vertical, 6)
         .fixedSize(horizontal: true, vertical: false)
         .background(hovering ? AnyShapeStyle(.tertiary) : AnyShapeStyle(.quaternary), in: Capsule())
-        // Not a Button: a Button consumes the press that starts a drag, so the
-        // pill would never be draggable.
         .contentShape(Capsule())
         .onHover { hovering = $0 }
         .onTapGesture { library.reveal(artist: artistId) }


### PR DESCRIPTION
Two ways to start the same drag: `RowBehaviour` uses `.draggable`, `draggableTransfer` hand-rolled an `NSItemProvider` through `.onDrag`. This converges them on the first.

`RowBehaviour.swift:24` already documents why:

> `.draggable` — not `.onDrag`. The underlying AppKit drag recogniser has a movement threshold, so it coexists with selection; `.onDrag` claims the press outright and leaves clicks landing about one in twenty.

List rows were moved over; the standalone helper never was, and #255 put it on artist names as well. Album tiles, artist pills and artist names were all still on the path that costs the tap underneath it.

`PlayableTransfer` already conforms to `Transferable` with `CodableRepresentation(.koanPlayable)` and `ProxyRepresentation(\.name)` — the same two representations the item provider was registering by hand — so the wire format is byte-identical. Drops inside koan and the plain-text fallback out of koan both keep working. Net −24 lines.

**This is not the search results fix.** I thought it was; it is not — clicks there registered visually, so the gesture was firing all along. That was the sidebar selection echo, fixed in #257. This stands on its own as removing the second way to do one thing.

Also drops the comment on `ArtistPill` explaining why it avoids a `Button` — dodging the press-stealing was the reason, and `.draggable` does not steal it.

## Verifying

`just macos-run`. Drag an album tile, an artist pill and an artist name onto the queue — all three still enqueue. Drag one into a text field in another app and you get the name. Clicking them still navigates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L2QYGXTN6dYC7MX5KNY8a5