### PR TITLE
feat(macos): search track results drag and right-click like every other row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,8 @@
 
   The sidebar takes the same measured inset the detail column takes, so the footer grows upward from the top of the bar.
 
+- **Track results could not be dragged or right-clicked.** The album tiles and artist pills beside them could do both; the track row was a `Button`, which claims the press, so it was the one result you could only click. It takes the same row behaviour the library lists use — full-width hit area, drag to enqueue — and the same context menu the tiles and pills already had. Clicking still goes to the album.
+
 ## v0.26.0 (2026-08-23)
 
 ### Added

--- a/apps/macos/Sources/Koan/Views/SearchResultsView.swift
+++ b/apps/macos/Sources/Koan/Views/SearchResultsView.swift
@@ -90,6 +90,11 @@ private struct SectionHeading: View {
 
 /// A track result points at its album — that's "the place in the library" the
 /// track lives, and where you'd play it from.
+///
+/// Behaves like any other row: click to go where it lives, drag it to enqueue,
+/// right-click for the same menu the tiles and pills have. It was a `Button`,
+/// which claims the press and left the row as the one result you could neither
+/// drag nor right-click.
 private struct SearchTrackRow: View {
     let track: Track
 
@@ -97,56 +102,53 @@ private struct SearchTrackRow: View {
     @State private var hovering = false
 
     var body: some View {
-        Button {
-            if let albumId = track.albumId {
-                library.reveal(album: albumId, highlighting: track.id)
-            }
-        } label: {
-            HStack(spacing: 10) {
-                // The cover is what you recognise a track by, and a results
-                // list is exactly where you are trying to recognise something.
-                Group {
-                    if let albumId = track.albumId {
-                        AlbumArtwork(source: .album(albumId), cornerRadius: 3)
-                    } else {
-                        Image(systemName: "music.note")
-                            .font(.caption)
-                            .foregroundStyle(.tertiary)
-                    }
-                }
-                .frame(width: 40, height: 40)
-
-                VStack(alignment: .leading, spacing: 1) {
-                    Text(track.title).lineLimit(1)
-                    Text("\(track.artistName) — \(track.albumTitle)")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                    SourceBadges(track: track)
-                }
-
-                Spacer(minLength: 8)
-
-                if track.albumId != nil && hovering {
-                    Text("Go to album")
+        HStack(spacing: 10) {
+            // The cover is what you recognise a track by, and a results
+            // list is exactly where you are trying to recognise something.
+            Group {
+                if let albumId = track.albumId {
+                    AlbumArtwork(source: .album(albumId), cornerRadius: 3)
+                } else {
+                    Image(systemName: "music.note")
                         .font(.caption)
                         .foregroundStyle(.tertiary)
                 }
+            }
+            .frame(width: 40, height: 40)
 
-                Text(Format.duration(track.durationMs))
-                    .font(.caption.monospacedDigit())
+            VStack(alignment: .leading, spacing: 1) {
+                Text(track.title).lineLimit(1)
+                Text("\(track.artistName) — \(track.albumTitle)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                SourceBadges(track: track)
+            }
+
+            Spacer(minLength: 8)
+
+            if track.albumId != nil && hovering {
+                Text("Go to album")
+                    .font(.caption)
                     .foregroundStyle(.tertiary)
             }
-            .padding(.horizontal, 10)
-            .padding(.vertical, 5)
-            .contentShape(.rect)
-            .background {
-                RoundedRectangle(cornerRadius: 6)
-                    .fill(hovering ? AnyShapeStyle(.quaternary.opacity(0.5)) : AnyShapeStyle(.clear))
-            }
+
+            Text(Format.duration(track.durationMs))
+                .font(.caption.monospacedDigit())
+                .foregroundStyle(.tertiary)
         }
-        .buttonStyle(.plain)
-        .disabled(track.albumId == nil)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 5)
+        .background {
+            RoundedRectangle(cornerRadius: 6)
+                .fill(hovering ? AnyShapeStyle(.quaternary.opacity(0.5)) : AnyShapeStyle(.clear))
+        }
+        .rowBehaviour(playable: .track(track))
+        .onTapGesture {
+            guard let albumId = track.albumId else { return }
+            library.reveal(album: albumId, highlighting: track.id)
+        }
+        .contextMenu { PlayableMenu(playable: .track(track)) }
         .onHover { hovering = $0 }
     }
 }


### PR DESCRIPTION
On the search results page the album tiles and artist pills are draggable and carry a context menu. The track rows beside them had neither — no drag onto the queue, no right-click at all.

The cause was structural: the row was a `Button` wrapping its whole content, and a `Button` claims the press. That is the same lesson `RowBehaviour` records for list rows, arrived at from the other direction.

The row now takes `.rowBehaviour(playable:)` — the full-width hit area and drag payload every library list row gets — with the go-to-album tap moved onto the row itself and `PlayableMenu` attached, which is the menu the tiles and pills were already using.

Clicking still goes to the album, so nothing that worked stops working.

## Verifying

`just macos-run`, search for something with track hits:
- click a track row → its album, with the track highlighted
- drag one onto the queue → it enqueues
- right-click one → Play / Play Next / Add to Queue / Go to Album / share, as on the tiles
- a track with no album still shows the music-note glyph and does nothing on click

## Follow-up

This keeps the results row as its own view. It and `TrackRow` and `QueueRow` are three rows with overlapping jobs and different models — `Track` vs `QueueItem` — and are worth collapsing into one presentational row with artwork as an option. Separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L2QYGXTN6dYC7MX5KNY8a5