### PR TITLE
fix(macos): picking a suggestion landed on an empty results page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,8 @@
 
   The lit row is now the section being browsed and nothing else. Opening an album from search results keeps Results lit, and Back returns you to them.
 
+- **Picking from the search dropdown landed on an empty results page instead of what you picked.** Choosing a suggestion pushes its album or artist and then empties the field, and both happened in one update: the results page is the stack's root at that moment, so clearing the query changed what that root drew while the destination was still landing, and it was discarded against the root it had been pushed onto. Emptying the field is its own update now, so the push settles first.
+
 ## v0.26.0 (2026-08-23)
 
 ### Added

--- a/apps/macos/Sources/Koan/Views/RootView.swift
+++ b/apps/macos/Sources/Koan/Views/RootView.swift
@@ -223,7 +223,12 @@ struct RootView: View {
         case .artist(let id):
             library.reveal(artist: id)
         }
-        search.reset()
+        // Emptying the field is its own update. The results page is the stack's
+        // root when a suggestion is picked, and clearing the query swaps what
+        // that root draws in the same pass as the push — the case `reveal()`
+        // warns about, where the destination is discarded against the root it
+        // was pushed onto and you are left looking at an empty results page.
+        Task { @MainActor in search.reset() }
     }
 
     @ViewBuilder


### PR DESCRIPTION
Choosing anything from the search dropdown — track, album or artist — dropped you on an empty "Search your library" page instead of the thing you picked.

`handleSubmit()` pushes the destination and then clears the field:

```swift
library.reveal(album: id)
search.reset()          // query = "" → the results page flips to its empty state
```

Both land in one update. The results page is the stack's root when a suggestion is picked, so emptying the query changed what that root drew at the same moment the destination was being pushed onto it, and SwiftUI discarded the push.

`reveal()` already documents this trap from the other direction:

> Deliberately does *not* switch `section` first. Doing so swaps the stack's root view in the same update, and SwiftUI discards the path against the old root.

Same failure, reached by gutting what the current root renders rather than by swapping which root it is. Clearing the field is now its own update, so the push settles first.

Predates the recent search work — the results-page click bug (#257) was a different mechanism.

## Verifying

`just macos-run`. Type into the sidebar search and pick from the dropdown:
- an album suggestion → that album, field cleared
- an artist suggestion → that artist
- a track suggestion → its album with the track highlighted
- Return without picking → the full results page, as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L2QYGXTN6dYC7MX5KNY8a5