### PR TITLE
release: v0.28.0 — the library lists stop redoing their work

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,7 @@
 {
+  "env": {
+    "KOAN_NO_KEYCHAIN": "1"
+  },
   "hooks": {
     "PreToolUse": [
       {
@@ -6,7 +9,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "if echo \"$TOOL_INPUT\" | grep -q 'git push'; then cd \"$(git rev-parse --show-toplevel)\" && echo 'Pre-push: formatting...' && cargo fmt --all 2>&1 && if ! git diff --quiet; then echo 'Pre-push: cargo fmt changed files. Review and commit them yourself \u2014 refusing to amend.'; exit 1; fi && echo 'Pre-push: running clippy...' && cargo clippy --workspace --all-targets -- -D warnings 2>&1 || { echo 'Clippy failed \u2014 fix before pushing'; exit 1; } && echo 'fmt + clippy clean'; fi"
+            "command": "if echo \"$TOOL_INPUT\" | grep -q 'git push'; then cd \"$(git rev-parse --show-toplevel)\" && echo 'Pre-push: formatting...' && cargo fmt --all 2>&1 && if ! git diff --quiet; then echo 'Pre-push: cargo fmt changed files. Review and commit them yourself — refusing to amend.'; exit 1; fi && echo 'Pre-push: running clippy...' && cargo clippy --workspace --all-targets -- -D warnings 2>&1 || { echo 'Clippy failed — fix before pushing'; exit 1; } && echo 'fmt + clippy clean'; fi"
           }
         ]
       }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@
 
 ### Changed
 
+- **Filtering the album and artist lists is a query, not a pass over everything the client is holding.** The macOS app narrowed its own copy of the library with `localizedCaseInsensitiveContains`: on a 5,500-album, 7,000-artist library that is 26ms of main thread per keystroke — and it ran for every section, not the one on screen. `find_albums` joins `find_artists` in koan-core so every front end narrows the same way, the FFI's `albums()` takes a `search`, and the GraphQL resolver stops filtering a fully-loaded list in Rust. The app debounces and cancels, so holding a key down is one round trip.
+
+  Matching is ASCII case-insensitive now, as `find_artists` already was — SQLite's `NOCASE` does not fold accented letters, so `MÖTLEY` no longer finds `Mötley`. A folded search column is the fix and is not here yet.
+
+- **The `LIBRARY` collation folds each name once per thread rather than once per comparison.** Building a sort key means an NFD pass and a `Vec` of fresh `String`s, and a collation is asked about the same name once per level of the sort — around two dozen times in a five-thousand-row list. Sorting an album list built roughly 140,000 keys where 5,500 would do. Every client's lists load faster for it.
+
+- **`koan-ffi` sorts albums with `sort_by_cached_key`.** `sort_by_key` recomputes its key on every comparison, so sorting by title lowercased each one a couple of dozen times over.
+
+- **Album artwork is decoded and downsampled off the main actor.** `NSImage(data:)` defers the decode until the image is drawn, which put it on the main thread mid-scroll — and embedded artwork is routinely 1500px square for a tile shown at under 200pt. Grid tiles are downsampled to 512px; a cover opened on its own is left alone.
+
+- **The artist list's hover state lives on the row.** It was on the browser, so every pointer move across the list invalidated all of it. The album and artist detail views also scanned the whole catalogue to find the record they were already showing; there is an index for that.
+
 - **Engine events are an async sequence rather than a callback interface.** `PlayerEvents` was a trait the client implemented and registered; it is now `next_event()`, awaited in a loop, and `PlayerEvent` carries what changed. The loop *is* the subscription, so its lifetime is the client's task and there is nothing to register or unregister.
 
   The macOS app loses the object that existed only to bridge the two worlds — a callback has to be `Sendable` while the model is main-actor isolated, so every one of its three methods did nothing but hop back with `Task { @MainActor }`. It also loses an FFI round trip per event: the change already carries the new state, and the app was re-fetching it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@
 
 ### Fixed
 
+- **`just` ran everything with the credential store switched off.** `export KOAN_NO_KEYCHAIN := "1"` sat directly above `check:`, reading as though it belonged to it — but a top-level `export` in a justfile reaches every recipe, so `just macos-run` launched the app with no keychain. With no password there is no server, and koan degraded three ways at once: nothing played, no downloads started, and every record came back with no artwork, which reads as an empty library rather than as being signed out. It is set per-recipe now, on the two that run unsigned test binaries.
+
+- **A client that cannot reach its server says so.** `remote_unavailable()` has produced the right sentence since v0.27 and was called in exactly one place — a `warn:` in the download queue that only a log reader would ever see. `KoanEngine::remote_problem()` asks the question directly, the macOS app asks at startup and reports through the error toast it already had, and `cover_art` returns an error when the server is configured but unusable instead of answering "no art" for every record in the library.
+
+- **A failed artwork fetch is no longer remembered as "this record has no art".** The cache could not tell a server that said no from one that could not be reached, so a blip during a scroll left permanent holes until relaunch. Only a definite answer is recorded now.
+
 - **Dragging an artist's name in the artists list dragged nothing.** The name was a `Button`, and a button consumes the press a drag starts from — so the row queued when dragged and the link on it, standing for the same artist, did not. The app now has one kind of link text rather than two, and every name that navigates to something playable is also a drag source for it.
 
 - **The Homebrew cask warned on every `brew` command.** `depends_on macos: ">= :tahoe"` is a deprecated string comparison; the bare symbol has always meant "that version or newer", so the requirement is unchanged. The workflow that regenerates the cask on release is fixed too, not just the published tap.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.28.0 (2026-08-24)
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2744,7 +2744,7 @@ dependencies = [
 
 [[package]]
 name = "koan-cli"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "koan-core"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "argon2",
  "bliss-audio",
@@ -2810,7 +2810,7 @@ dependencies = [
 
 [[package]]
 name = "koan-ffi"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "chrono",
  "crossbeam-channel",
@@ -2830,7 +2830,7 @@ dependencies = [
 
 [[package]]
 name = "koan-server"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",
@@ -2863,7 +2863,7 @@ dependencies = [
 
 [[package]]
 name = "koan-tui"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "core-foundation 0.10.1",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/koan-core", "crates/koan-ffi", "crates/koan-server", "crates/koan-tui", "crates/koan-cli"]
 
 [workspace.package]
-version = "0.27.0"
+version = "0.28.0"
 edition = "2024"
 rust-version = "1.89"
 homepage = "https://github.com/radiosilence/koan"
@@ -13,9 +13,9 @@ license = "MIT"
 [workspace.dependencies]
 # Internal crates. Keep the version in step with [workspace.package] above —
 # a stale pin here publishes members that resolve against the wrong sibling.
-koan-core = { path = "crates/koan-core", version = "0.27.0" }
-koan-server = { path = "crates/koan-server", version = "0.27.0" }
-koan-tui = { path = "crates/koan-tui", version = "0.27.0" }
+koan-core = { path = "crates/koan-core", version = "0.28.0" }
+koan-server = { path = "crates/koan-server", version = "0.28.0" }
+koan-tui = { path = "crates/koan-tui", version = "0.28.0" }
 # Feature set is the union every member needs; `default-tls` is an alias for
 # `rustls`, so there is exactly one TLS stack.
 reqwest = { version = "0.13", default-features = false, features = [

--- a/apps/macos/Sources/Koan/KoanApp.swift
+++ b/apps/macos/Sources/Koan/KoanApp.swift
@@ -52,6 +52,17 @@ final class AppState {
 
         // Single-key shortcuts, caught before the focused list eats them.
         self.hotkeys = Hotkeys.standard(player: player, library: library, ui: ui)
+
+        // A client that cannot reach its server fails at everything quietly:
+        // nothing plays, nothing downloads, and every record comes back with no
+        // artwork — which reads as an empty library rather than as being signed
+        // out. The engine knows why; this is it saying so. Off the launch path,
+        // since the answer can involve the credential store.
+        Task { [weak player] in
+            if let problem = await engine.remoteProblem() {
+                player?.lastError = problem
+            }
+        }
     }
 }
 

--- a/apps/macos/Sources/Koan/Support/CoverArtCache.swift
+++ b/apps/macos/Sources/Koan/Support/CoverArtCache.swift
@@ -1,5 +1,6 @@
 import AppKit
 import CryptoKit
+import ImageIO
 import KoanFFI
 
 /// Album art, cached in memory and on disk.
@@ -77,24 +78,31 @@ final class CoverArtCache {
         let file = directory?.appendingPathComponent(Self.filename(for: key))
         let task = Task<NSImage?, Never> { [weak self] in
             // Detached for the disk cache, not for the engine: reading and
-            // writing the file would otherwise happen on the main actor.
-            let data = await Task.detached(priority: .utility) { () -> Data? in
-                if let file, let cached = try? Data(contentsOf: file) { return cached }
+            // writing the file would otherwise happen on the main actor. The
+            // hash comes back with the bytes because it is a pass over the
+            // whole payload and the main actor has no business doing it.
+            let payload = await Task.detached(priority: .utility) { () -> (Data, String)? in
+                if let file, let cached = try? Data(contentsOf: file) {
+                    return (cached, Self.digest(cached))
+                }
                 guard let fetched = await Self.fetch(source, engine) else { return nil }
                 if let file {
                     // Best effort: a cache that fails to write is still a cache.
                     try? fetched.write(to: file, options: .atomic)
                 }
-                return fetched
+                return (fetched, Self.digest(fetched))
             }.value
 
             guard let self else { return nil }
             self.tasks[key] = nil
-            guard let data else {
+            guard let payload, self.accept(hash: payload.1, for: key) else {
                 self.memory[key] = NSImage?.none
                 return nil
             }
-            let image = self.accept(data, for: key)
+            let data = payload.0
+            let image = await Task.detached(priority: .utility) {
+                Self.decode(data, source: source)
+            }.value
             self.memory[key] = image
             return image
         }
@@ -128,26 +136,56 @@ final class CoverArtCache {
         }
     }
 
-    /// Store the image unless it turns out to be the server's placeholder.
-    private func accept(_ data: Data, for key: String) -> NSImage? {
-        let hash = Self.digest(data)
-        if placeholderHashes.contains(hash) { return nil }
+    /// Whether this is real artwork, or the server's placeholder.
+    private func accept(hash: String, for key: String) -> Bool {
+        if placeholderHashes.contains(hash) { return false }
 
         // Track lookups never teach: a track's cover is its album's cover, so
         // counting it would make every played album look like a repeat.
-        guard key.hasPrefix("album-") else { return NSImage(data: data) }
+        guard key.hasPrefix("album-") else { return true }
 
         hashOwners[hash, default: []].insert(key)
-        guard hashOwners[hash]?.count ?? 0 >= 3 else {
-            return NSImage(data: data)
-        }
+        guard hashOwners[hash]?.count ?? 0 >= 3 else { return true }
 
         // Three unrelated albums with byte-identical art is a placeholder.
         placeholderHashes.insert(hash)
         for owner in hashOwners[hash] ?? [] {
             memory[owner] = NSImage?.none
         }
-        return nil
+        return false
+    }
+
+    /// Decode off the main actor, and downsample a grid tile while we are there.
+    ///
+    /// `NSImage(data:)` defers the decode until the image is drawn, which puts
+    /// it on the main thread in the middle of a scroll — and embedded artwork is
+    /// routinely fifteen hundred pixels square for a tile shown at under two
+    /// hundred points. A cover opened on its own is left at full size; there is
+    /// only ever one of those and it is the one place the detail shows.
+    private nonisolated static func decode(
+        _ data: Data,
+        source: AlbumArtwork.Source
+    ) -> NSImage? {
+        let limit: Int? = switch source {
+        case .album: 512
+        case .track: nil
+        }
+        guard let limit,
+              let cgSource = CGImageSourceCreateWithData(data as CFData, nil),
+              let scaled = CGImageSourceCreateThumbnailAtIndex(
+                  cgSource, 0,
+                  [
+                      kCGImageSourceCreateThumbnailFromImageAlways: true,
+                      kCGImageSourceCreateThumbnailWithTransform: true,
+                      kCGImageSourceShouldCacheImmediately: true,
+                      kCGImageSourceThumbnailMaxPixelSize: limit,
+                  ] as CFDictionary
+              )
+        else { return NSImage(data: data) }
+        return NSImage(
+            cgImage: scaled,
+            size: NSSize(width: scaled.width, height: scaled.height)
+        )
     }
 
     // MARK: - Disk
@@ -165,7 +203,7 @@ final class CoverArtCache {
         }
     }
 
-    private static func digest(_ data: Data) -> String {
+    private nonisolated static func digest(_ data: Data) -> String {
         SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
     }
 

--- a/apps/macos/Sources/Koan/Support/CoverArtCache.swift
+++ b/apps/macos/Sources/Koan/Support/CoverArtCache.swift
@@ -81,25 +81,29 @@ final class CoverArtCache {
             // writing the file would otherwise happen on the main actor. The
             // hash comes back with the bytes because it is a pass over the
             // whole payload and the main actor has no business doing it.
-            let payload = await Task.detached(priority: .utility) { () -> (Data, String)? in
+            let payload = await Task.detached(priority: .utility) { () -> Fetched in
                 if let file, let cached = try? Data(contentsOf: file) {
-                    return (cached, Self.digest(cached))
+                    return .art(cached, hash: Self.digest(cached))
                 }
-                guard let fetched = await Self.fetch(source, engine) else { return nil }
-                if let file {
+                let fetched = await Self.fetch(source, engine)
+                if case .art(let bytes, _) = fetched, let file {
                     // Best effort: a cache that fails to write is still a cache.
-                    try? fetched.write(to: file, options: .atomic)
+                    try? bytes.write(to: file, options: .atomic)
                 }
-                return (fetched, Self.digest(fetched))
+                return fetched
             }.value
 
             guard let self else { return nil }
             self.tasks[key] = nil
-            guard let payload, self.accept(hash: payload.1, for: key) else {
+            // Nothing recorded: the next tile that asks tries again.
+            guard case .art(let data, let hash) = payload else {
+                if case .none = payload { self.memory[key] = NSImage?.none }
+                return nil
+            }
+            guard self.accept(hash: hash, for: key) else {
                 self.memory[key] = NSImage?.none
                 return nil
             }
-            let data = payload.0
             let image = await Task.detached(priority: .utility) {
                 Self.decode(data, source: source)
             }.value
@@ -117,22 +121,40 @@ final class CoverArtCache {
         }
     }
 
+    /// What an attempt learned.
+    ///
+    /// A server that answers and says it has no art is worth remembering. One
+    /// that could not be reached is not: recording that as "no art" is why a
+    /// scroll during a blip left permanent holes in the grid until relaunch.
+    private enum Fetched {
+        case art(Data, hash: String)
+        case none
+        case failed
+    }
+
     private nonisolated static func fetch(
         _ source: AlbumArtwork.Source,
         _ engine: KoanEngine
-    ) async -> Data? {
-        switch source {
-        case .album(let albumId):
-            // Any track off the record will do — they share the artwork.
-            guard let tracks = try? await engine.tracks(
-                albumId: albumId, artistId: nil, sort: .album, limit: 1, offset: 0
-            ) else { return nil }
-            guard let first = tracks.first(where: { $0.path != nil }) ?? tracks.first else {
-                return nil
+    ) async -> Fetched {
+        do {
+            let data: Data?
+            switch source {
+            case .album(let albumId):
+                // Any track off the record will do — they share the artwork.
+                let tracks = try await engine.tracks(
+                    albumId: albumId, artistId: nil, sort: .album, limit: 1, offset: 0
+                )
+                guard let first = tracks.first(where: { $0.path != nil }) ?? tracks.first else {
+                    return .none
+                }
+                data = try await engine.coverArt(trackId: first.id, size: 400)?.data
+            case .track(let trackId):
+                data = try await engine.coverArt(trackId: trackId, size: 600)?.data
             }
-            return (try? await engine.coverArt(trackId: first.id, size: 400))?.data
-        case .track(let trackId):
-            return (try? await engine.coverArt(trackId: trackId, size: 600))?.data
+            guard let data, !data.isEmpty else { return .none }
+            return .art(data, hash: digest(data))
+        } catch {
+            return .failed
         }
     }
 

--- a/apps/macos/Sources/Koan/Support/LibraryModel.swift
+++ b/apps/macos/Sources/Koan/Support/LibraryModel.swift
@@ -8,10 +8,12 @@ private let historyPageSize: UInt32 = 500
 
 /// Library browsing state.
 ///
-/// Albums and artists are loaded once and filtered in memory — a few thousand
-/// rows is nothing, and it makes the filter field feel instant. Tracks are
-/// never loaded wholesale; there are tens of thousands of them and you only
-/// ever look at one album's worth at a time.
+/// The full album and artist lists are loaded once, because search and the
+/// detail views resolve ids against them. Narrowing them is the database's job:
+/// filtering a few thousand rows in Swift cost sixteen milliseconds of main
+/// thread per keystroke, which is a filter field that visibly lags the typing.
+/// Tracks are never loaded wholesale; there are tens of thousands of them and
+/// you only ever look at one album's worth at a time.
 @MainActor
 @Observable
 final class LibraryModel {
@@ -48,6 +50,11 @@ final class LibraryModel {
             refilter()
         }
     }
+
+    /// In flight for the sections whose filter is a query. Long enough that a
+    /// burst of typing is one round trip, short enough not to read as lag.
+    private var filterQuery: Task<Void, Never>?
+    private static let filterDebounce = Duration.milliseconds(120)
 
     /// Newest first by default: the record you just added is the one you're
     /// looking for. Persisted so it survives a relaunch.
@@ -89,17 +96,8 @@ final class LibraryModel {
     func popToRoot() {
         guard !path.isEmpty else { return }
         path = NavigationPath()
-        selectedAlbumId = nil
-        selectedArtistId = nil
     }
 
-    var selectedArtistId: Int64? {
-        didSet {
-            guard selectedArtistId != oldValue else { return }
-            refilter()
-        }
-    }
-    var selectedAlbumId: Int64?
     private(set) var detailTracks: [Track] = []
 
     /// Set while a scan runs so the UI can show progress and refuse a second one.
@@ -127,7 +125,7 @@ final class LibraryModel {
         let engine = self.engine
         let sort = albumSort
         Task {
-            albums = (try? await engine.albums(artistId: nil, sort: sort)) ?? []
+            albums = (try? await engine.albums(artistId: nil, sort: sort, search: nil)) ?? []
             reindex()
         }
     }
@@ -135,10 +133,10 @@ final class LibraryModel {
     // MARK: - Filtered views
 
     /// Stored rather than computed. A `List` reads its collection far more than
-    /// once per update, and re-filtering forty thousand rows on every read
-    /// froze the artist list for a second or two whenever the filter changed.
-    /// The album grid is lazy and never noticed, which is what made it look
-    /// like a bug in the artist view specifically.
+    /// once per update, and narrowing it on every read froze the artist list for
+    /// a second or two whenever the filter changed. The album grid is lazy and
+    /// never noticed, which is what made it look like a bug in the artist view
+    /// specifically.
     private(set) var visibleAlbums: [Album] = []
     private(set) var visibleArtists: [Artist] = []
     private(set) var visibleFavourites: [Track] = []
@@ -146,36 +144,61 @@ final class LibraryModel {
 
     /// Recompute what each section shows. Called whenever the filter or any of
     /// the underlying collections change.
+    ///
+    /// Switching section clears the filter, so only the section on screen can
+    /// hold one and every other collection is handed over whole. Albums and
+    /// artists are unbounded and go to the database; favourites and a page of
+    /// history are small enough to narrow here.
     private func refilter() {
-        let scoped = selectedArtistId.map { id in albums.filter { $0.artistId == id } } ?? albums
-        guard !filter.isEmpty else {
-            visibleAlbums = scoped
+        visibleFavourites = section == .favourites
+            ? matching(favourites) { [$0.title, $0.artistName, $0.albumTitle] }
+            : favourites
+        visiblePlayHistory = section == .playHistory
+            ? matching(playHistory) { [$0.track.title, $0.track.artistName, $0.track.albumTitle] }
+            : playHistory
+
+        guard section == .albums || section == .artists, !filter.isEmpty else {
+            filterQuery?.cancel()
+            visibleAlbums = albums
             visibleArtists = artists
-            visibleFavourites = favourites
-            visiblePlayHistory = playHistory
             return
         }
-        visibleAlbums = scoped.filter {
-            $0.title.localizedCaseInsensitiveContains(filter)
-                || $0.artistName.localizedCaseInsensitiveContains(filter)
-        }
-        visibleArtists = artists.filter {
-            $0.name.localizedCaseInsensitiveContains(filter)
-        }
-        visibleFavourites = favourites.filter {
-            $0.title.localizedCaseInsensitiveContains(filter)
-                || $0.artistName.localizedCaseInsensitiveContains(filter)
-                || $0.albumTitle.localizedCaseInsensitiveContains(filter)
-        }
-        visiblePlayHistory = playHistory.filter {
-            $0.track.title.localizedCaseInsensitiveContains(filter)
-                || $0.track.artistName.localizedCaseInsensitiveContains(filter)
-                || $0.track.albumTitle.localizedCaseInsensitiveContains(filter)
+        runFilterQuery()
+    }
+
+    /// Ask the database for the matches.
+    ///
+    /// Debounced and cancellable, so holding a key down is one query rather than
+    /// one per character and an answer to a filter you have already typed past
+    /// never lands.
+    private func runFilterQuery() {
+        filterQuery?.cancel()
+        let engine = self.engine
+        let wantsAlbums = section == .albums
+        let sort = albumSort
+        let query = filter
+        filterQuery = Task {
+            try? await Task.sleep(for: Self.filterDebounce)
+            guard !Task.isCancelled else { return }
+            if wantsAlbums {
+                let rows = try? await engine.albums(
+                    artistId: nil, sort: sort, search: query
+                )
+                guard !Task.isCancelled else { return }
+                visibleAlbums = rows ?? []
+            } else {
+                let rows = try? await engine.artists(search: query)
+                guard !Task.isCancelled else { return }
+                visibleArtists = rows ?? []
+            }
         }
     }
 
-    var selectedAlbum: Album? {
-        selectedAlbumId.flatMap { id in albums.first { $0.id == id } }
+    private func matching<T>(_ rows: [T], _ fields: (T) -> [String]) -> [T] {
+        guard !filter.isEmpty else { return rows }
+        return rows.filter { row in
+            fields(row).contains { $0.localizedCaseInsensitiveContains(filter) }
+        }
     }
 
     // MARK: - Loading
@@ -199,7 +222,7 @@ final class LibraryModel {
         let sort = albumSort
         Task {
             if albums.isEmpty {
-                albums = (try? await engine.albums(artistId: nil, sort: sort)) ?? []
+                albums = (try? await engine.albums(artistId: nil, sort: sort, search: nil)) ?? []
             }
             if artists.isEmpty {
                 artists = (try? await engine.artists(search: nil)) ?? []
@@ -227,7 +250,7 @@ final class LibraryModel {
                 break  // owned by the player and search models respectively
             case .albums:
                 if albums.isEmpty {
-                    albums = (try? await engine.albums(artistId: nil, sort: sort)) ?? []
+                    albums = (try? await engine.albums(artistId: nil, sort: sort, search: nil)) ?? []
                     reindex()
                 }
             case .artists:

--- a/apps/macos/Sources/Koan/Views/AlbumBrowser.swift
+++ b/apps/macos/Sources/Koan/Views/AlbumBrowser.swift
@@ -35,7 +35,7 @@ struct AlbumDetailView: View {
     @Environment(LibraryModel.self) private var library
     @Environment(PlayerModel.self) private var player
 
-    private var album: Album? { library.albums.first { $0.id == albumId } }
+    private var album: Album? { library.album(id: albumId) }
 
     var body: some View {
         TrackListView(

--- a/apps/macos/Sources/Koan/Views/ArtistBrowser.swift
+++ b/apps/macos/Sources/Koan/Views/ArtistBrowser.swift
@@ -3,58 +3,13 @@ import SwiftUI
 
 struct ArtistBrowser: View {
     @Environment(LibraryModel.self) private var library
-    @State private var hovered: Int64?
     /// Without a selection binding a List row has nothing to do with a click —
     /// which is why this list felt completely dead.
     @State private var selection: Set<Int64> = []
 
     var body: some View {
         List(library.visibleArtists, id: \.id, selection: $selection) { artist in
-            HStack(spacing: 10) {
-                Group {
-                    if hovered == artist.id {
-                        RowPlayButton(
-                            playable: .artist(id: artist.id, name: artist.name),
-                            visible: true
-                        )
-                    } else {
-                        Image(systemName: "music.mic")
-                            .font(.caption)
-                            .foregroundStyle(.tertiary)
-                    }
-                }
-                .frame(width: 18, height: 18)
-                // The name is the way in — a link, so a single click opens the
-                // artist while the rest of the row selects.
-                LinkText(
-                    text: artist.name,
-                    target: .artist(artist.id),
-                    font: .body,
-                    prominent: true
-                )
-                FavouriteButton(
-                    isOn: library.isFavourite(artist: artist.id),
-                    showing: hovered == artist.id,
-                    size: .caption
-                ) {
-                    library.toggleFavourite(artist: artist.id)
-                }
-                .frame(width: 16)
-                Spacer(minLength: 12)
-                Text(Format.count(artist.albumCount, "album"))
-                    .font(.caption.monospacedDigit())
-                    .foregroundStyle(.secondary)
-                    .frame(width: 78, alignment: .trailing)
-                Text(Format.count(artist.trackCount, "track"))
-                    .font(.caption.monospacedDigit())
-                    .foregroundStyle(.tertiary)
-                    .frame(width: 78, alignment: .trailing)
-            }
-            .onHover { inside in
-                if inside { hovered = artist.id } else if hovered == artist.id { hovered = nil }
-            }
-            .frame(height: 24)
-            .rowBehaviour(playable: .artist(id: artist.id, name: artist.name))
+            ArtistRow(artist: artist)
         }
         .contextMenu(forSelectionType: Int64.self) { ids in
             if let id = ids.first,
@@ -72,6 +27,63 @@ struct ArtistBrowser: View {
     }
 }
 
+/// One artist.
+///
+/// Its own view so that hovering it invalidates one row. With the hover state
+/// on the browser, every pointer move across the list rebuilt all of it —
+/// thousands of rows diffed to light up a play button.
+private struct ArtistRow: View {
+    let artist: Artist
+
+    @Environment(LibraryModel.self) private var library
+    @State private var hovered = false
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Group {
+                if hovered {
+                    RowPlayButton(playable: playable, visible: true)
+                } else {
+                    Image(systemName: "music.mic")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                }
+            }
+            .frame(width: 18, height: 18)
+            // The name is the way in — a link, so a single click opens the
+            // artist while the rest of the row selects.
+            LinkText(
+                text: artist.name,
+                target: .artist(artist.id),
+                font: .body,
+                prominent: true
+            )
+            FavouriteButton(
+                isOn: library.isFavourite(artist: artist.id),
+                showing: hovered,
+                size: .caption
+            ) {
+                library.toggleFavourite(artist: artist.id)
+            }
+            .frame(width: 16)
+            Spacer(minLength: 12)
+            Text(Format.count(artist.albumCount, "album"))
+                .font(.caption.monospacedDigit())
+                .foregroundStyle(.secondary)
+                .frame(width: 78, alignment: .trailing)
+            Text(Format.count(artist.trackCount, "track"))
+                .font(.caption.monospacedDigit())
+                .foregroundStyle(.tertiary)
+                .frame(width: 78, alignment: .trailing)
+        }
+        .onHover { hovered = $0 }
+        .frame(height: 24)
+        .rowBehaviour(playable: playable)
+    }
+
+    private var playable: Playable { .artist(id: artist.id, name: artist.name) }
+}
+
 /// An artist's records as a grid, since that's how people think about a
 /// discography — the flat track list is a click away on each album.
 struct ArtistDetailView: View {
@@ -85,7 +97,7 @@ struct ArtistDetailView: View {
 
     private let columns = [GridItem(.adaptive(minimum: 150, maximum: 210), spacing: 18)]
 
-    private var artist: Artist? { library.artists.first { $0.id == artistId } }
+    private var artist: Artist? { library.artist(id: artistId) }
 
     var body: some View {
         ScrollView {
@@ -150,7 +162,7 @@ struct ArtistDetailView: View {
     private func load() async {
         let engine = library.engine
         let id = artistId
-        albums = (try? await engine.albums(artistId: id, sort: .year)) ?? []
+        albums = (try? await engine.albums(artistId: id, sort: .year, search: nil)) ?? []
         similar = (try? await engine.similarArtists(artistId: id)) ?? []
     }
 

--- a/crates/koan-core/src/db/connection.rs
+++ b/crates/koan-core/src/db/connection.rs
@@ -1,4 +1,7 @@
+use std::cell::RefCell;
+use std::collections::HashMap;
 use std::path::Path;
+use std::rc::Rc;
 
 use rusqlite::Connection;
 use thiserror::Error;
@@ -107,7 +110,34 @@ fn configure(conn: &Connection) -> Result<(), DbError> {
 /// than quietly sorting some other way.
 pub(crate) fn register_library_collation(conn: &Connection) -> rusqlite::Result<()> {
     conn.create_collation("LIBRARY", |a, b| {
-        sort_key(a).cmp(&sort_key(b)).then(a.cmp(b))
+        cached_sort_key(a).cmp(&cached_sort_key(b)).then(a.cmp(b))
+    })
+}
+
+thread_local! {
+    /// Sort keys, kept for the life of the thread.
+    ///
+    /// A collation sees the same name once per level of the sort — around two
+    /// dozen times in a five-thousand-row list — and building a key means an
+    /// NFD pass and a `Vec` of freshly allocated `String`s. Cached, each name is
+    /// folded once per thread instead of once per comparison.
+    static SORT_KEYS: RefCell<HashMap<Box<str>, Rc<[Chunk]>>> = RefCell::new(HashMap::new());
+}
+
+fn cached_sort_key(s: &str) -> Rc<[Chunk]> {
+    SORT_KEYS.with_borrow_mut(|cache| {
+        if let Some(key) = cache.get(s) {
+            return Rc::clone(key);
+        }
+        // A library's worth of names is tens of thousands of entries. Anything
+        // beyond that is a query sorting something other than names, and it
+        // should not grow this without bound.
+        if cache.len() >= 50_000 {
+            cache.clear();
+        }
+        let key: Rc<[Chunk]> = sort_key(s).into();
+        cache.insert(s.into(), Rc::clone(&key));
+        key
     })
 }
 

--- a/crates/koan-core/src/db/queries/albums.rs
+++ b/crates/koan-core/src/db/queries/albums.rs
@@ -4,6 +4,23 @@ use crate::db::connection::DbError;
 
 use super::AlbumRow;
 
+/// The album column list, read the same way by every query that selects it.
+fn album_row(row: &rusqlite::Row) -> rusqlite::Result<AlbumRow> {
+    Ok(AlbumRow {
+        id: row.get(0)?,
+        title: row.get(1)?,
+        artist_id: row.get(2)?,
+        artist_name: row.get::<_, Option<String>>(3)?.unwrap_or_default(),
+        date: row.get(4)?,
+        total_discs: row.get(5)?,
+        total_tracks: row.get(6)?,
+        codec: row.get(7)?,
+        label: row.get(8)?,
+        remote_id: row.get(9)?,
+        added_at: row.get(10)?,
+    })
+}
+
 /// Get or create an album by title + artist. Returns the album ID.
 #[allow(clippy::too_many_arguments)]
 pub fn get_or_create_album(
@@ -68,21 +85,7 @@ pub fn albums_for_artist(conn: &Connection, artist_id: i64) -> Result<Vec<AlbumR
          ORDER BY al.date, al.title COLLATE LIBRARY",
     )?;
     let rows = stmt
-        .query_map(params![artist_id], |row| {
-            Ok(AlbumRow {
-                id: row.get(0)?,
-                title: row.get(1)?,
-                artist_id: row.get(2)?,
-                artist_name: row.get::<_, Option<String>>(3)?.unwrap_or_default(),
-                date: row.get(4)?,
-                total_discs: row.get(5)?,
-                total_tracks: row.get(6)?,
-                codec: row.get(7)?,
-                label: row.get(8)?,
-                remote_id: row.get(9)?,
-                added_at: row.get(10)?,
-            })
-        })?
+        .query_map(params![artist_id], album_row)?
         .collect::<Result<Vec<_>, _>>()?;
     Ok(rows)
 }
@@ -98,21 +101,7 @@ pub fn get_album(conn: &Connection, album_id: i64) -> Result<Option<AlbumRow>, D
              LEFT JOIN artists a ON al.artist_id = a.id
              WHERE al.id = ?1",
             params![album_id],
-            |row| {
-                Ok(AlbumRow {
-                    id: row.get(0)?,
-                    title: row.get(1)?,
-                    artist_id: row.get(2)?,
-                    artist_name: row.get::<_, Option<String>>(3)?.unwrap_or_default(),
-                    date: row.get(4)?,
-                    total_discs: row.get(5)?,
-                    total_tracks: row.get(6)?,
-                    codec: row.get(7)?,
-                    label: row.get(8)?,
-                    remote_id: row.get(9)?,
-                    added_at: row.get(10)?,
-                })
-            },
+            album_row,
         )
         .ok();
     Ok(result)
@@ -130,6 +119,32 @@ pub fn album_date(conn: &Connection, album_id: i64) -> Result<Option<String>, Db
         .flatten())
 }
 
+/// Albums whose title or artist matches, case-insensitive substring.
+///
+/// The narrowing belongs here rather than in each client: every front end wants
+/// the same answer, and the ones that filtered a fully-loaded list in their own
+/// language paid for reading the whole table to throw most of it away. Matching
+/// is ASCII case-insensitive, like `find_artists` — SQLite's `NOCASE` does not
+/// fold accented letters, so `MOTLEY` finds `Motley` but `MÖTLEY` does not find
+/// `Mötley`.
+pub fn find_albums(conn: &Connection, query: &str) -> Result<Vec<AlbumRow>, DbError> {
+    let pattern = format!("%{}%", super::artists::escape_like(query));
+    let mut stmt = conn.prepare(
+        "SELECT al.id, al.title, al.artist_id, a.name, al.date,
+                al.total_discs, al.total_tracks, al.codec, al.label, al.remote_id,
+                al.added_at
+         FROM albums al
+         LEFT JOIN artists a ON al.artist_id = a.id
+         WHERE al.title LIKE ?1 COLLATE NOCASE ESCAPE '\\'
+            OR a.name LIKE ?1 COLLATE NOCASE ESCAPE '\\'
+         ORDER BY a.name COLLATE LIBRARY, al.date, al.title COLLATE LIBRARY",
+    )?;
+    let rows = stmt
+        .query_map(params![pattern], album_row)?
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(rows)
+}
+
 /// Get all albums with their artist name, sorted.
 pub fn all_albums(conn: &Connection) -> Result<Vec<AlbumRow>, DbError> {
     let mut stmt = conn.prepare(
@@ -142,21 +157,7 @@ pub fn all_albums(conn: &Connection) -> Result<Vec<AlbumRow>, DbError> {
     )?;
 
     let rows = stmt
-        .query_map([], |row| {
-            Ok(AlbumRow {
-                id: row.get(0)?,
-                title: row.get(1)?,
-                artist_id: row.get(2)?,
-                artist_name: row.get::<_, Option<String>>(3)?.unwrap_or_default(),
-                date: row.get(4)?,
-                total_discs: row.get(5)?,
-                total_tracks: row.get(6)?,
-                codec: row.get(7)?,
-                label: row.get(8)?,
-                remote_id: row.get(9)?,
-                added_at: row.get(10)?,
-            })
-        })?
+        .query_map([], album_row)?
         .collect::<Result<Vec<_>, _>>()?;
 
     Ok(rows)

--- a/crates/koan-ffi/src/lib.rs
+++ b/crates/koan-ffi/src/lib.rs
@@ -405,16 +405,24 @@ impl KoanEngine {
         .await
     }
 
+    /// The library's albums, narrowed by `search` if given.
+    ///
+    /// The search runs in SQL rather than over the returned list: a client that
+    /// filters what it has already been handed still pays to read and marshal
+    /// every album in the library on each keystroke.
     pub async fn albums(
         self: Arc<Self>,
         artist_id: Option<i64>,
         sort: AlbumSort,
+        search: Option<String>,
     ) -> Result<Vec<Album>, KoanError> {
         offload::offload(move || {
             let db = self.db()?;
-            let rows = match artist_id {
-                Some(id) => queries::albums_for_artist(&db.conn, id),
-                None => queries::all_albums(&db.conn),
+            let query = search.as_deref().map(str::trim).filter(|s| !s.is_empty());
+            let rows = match (artist_id, query) {
+                (Some(id), _) => queries::albums_for_artist(&db.conn, id),
+                (None, Some(q)) => queries::find_albums(&db.conn, q),
+                (None, None) => queries::all_albums(&db.conn),
             }
             .map_err(db_err)?;
 
@@ -428,10 +436,12 @@ impl KoanEngine {
                         .unwrap_or("")
                         .cmp(a.added_at.as_deref().unwrap_or(""))
                 }),
-                AlbumSort::Title => albums.sort_by_key(|a| a.title.to_lowercase()),
-                AlbumSort::Artist => {
-                    albums.sort_by_key(|a| (a.artist_name.to_lowercase(), a.year.unwrap_or(0)))
-                }
+                // Cached: `sort_by_key` recomputes the key on every
+                // comparison, so a plain sort lowercases each title a couple of
+                // dozen times over.
+                AlbumSort::Title => albums.sort_by_cached_key(|a| a.title.to_lowercase()),
+                AlbumSort::Artist => albums
+                    .sort_by_cached_key(|a| (a.artist_name.to_lowercase(), a.year.unwrap_or(0))),
                 AlbumSort::Year => albums.sort_by_key(|a| std::cmp::Reverse(a.year.unwrap_or(0))),
                 AlbumSort::Random => shuffle(&mut albums),
             }

--- a/crates/koan-ffi/src/lib.rs
+++ b/crates/koan-ffi/src/lib.rs
@@ -30,6 +30,7 @@ use koan_core::player::commands::PlayerCommand;
 use koan_core::player::state::{
     LoadState, PlaybackState, PlaylistItem, QueueItemId, SharedPlayerState,
 };
+use koan_core::remote::client::SubsonicError;
 use uuid::Uuid;
 
 mod offload;
@@ -642,20 +643,59 @@ impl KoanEngine {
                 return Ok(None);
             };
             let cfg = Config::cached();
+            // No server configured: this record simply has no art.
             if !cfg.remote.enabled {
                 return Ok(None);
             }
+            // Configured but unusable — signed out, or the password cannot be
+            // read. Reported rather than shrugged off: answering "no art" for
+            // every record makes a signed-out client look like a library that
+            // has no covers, which is a long way from where the problem is.
             let Some(client) = koan_core::helpers::subsonic_client(&cfg) else {
-                return Ok(None);
+                return Err(KoanError::Remote {
+                    message: koan_core::helpers::remote_unavailable(&cfg),
+                });
             };
             match client.get_cover_art(&remote_id, size) {
                 Ok(data) if !data.is_empty() => {
                     let mime = sniff_mime(&data).to_string();
                     Ok(Some(CoverArt { data, mime }))
                 }
-                // No art on the server is normal, not a failure worth surfacing.
-                _ => Ok(None),
+                // The server answered and it has nothing. Normal, and worth
+                // remembering: this record has no art and never will.
+                Ok(_) | Err(SubsonicError::Api { .. }) | Err(SubsonicError::BadResponse) => {
+                    Ok(None)
+                }
+                // A timeout or a dropped connection says nothing about whether
+                // art exists. Reported rather than swallowed, so the caller can
+                // ask again instead of recording "this album has none" for the
+                // rest of the session — and so it appears in the log at all.
+                Err(e) => {
+                    log::warn!("cover art for track {track_id} failed: {e}");
+                    Err(KoanError::Remote {
+                        message: e.to_string(),
+                    })
+                }
             }
+        })
+        .await
+    }
+
+    /// Why the configured server cannot be used, if it cannot.
+    ///
+    /// `None` means there is nothing to say: either no server is configured, or
+    /// the one that is works. A client should not have to watch playback fail
+    /// and artwork come back empty to work out that it is signed out — the
+    /// engine already knows, and every front end asks the same question.
+    pub async fn remote_problem(self: Arc<Self>) -> Option<String> {
+        offload::offload(move || {
+            let cfg = Config::cached();
+            if !cfg.remote.enabled || cfg.remote.url.is_empty() {
+                return None;
+            }
+            koan_core::helpers::subsonic_auth(&cfg)
+                .is_none()
+                .then(|| koan_core::helpers::remote_unavailable(&cfg))
         })
         .await
     }

--- a/crates/koan-ffi/src/types.rs
+++ b/crates/koan-ffi/src/types.rs
@@ -593,6 +593,10 @@ pub enum KoanError {
     NotFound { message: String },
     #[error("bad argument: {message}")]
     BadArgument { message: String },
+    /// The server could not be reached, or gave up part way. Distinct from a
+    /// server that answered and said no — this one is worth retrying.
+    #[error("remote: {message}")]
+    Remote { message: String },
 }
 
 pub(crate) fn year_of(date: &str) -> Option<i32> {

--- a/crates/koan-server/src/graphql/queries.rs
+++ b/crates/koan-server/src/graphql/queries.rs
@@ -126,6 +126,10 @@ impl QueryRoot {
                     .into_values()
                     .flatten()
                     .collect()
+            } else if let Some(ref query) = search {
+                // Narrowed in SQL rather than over every album in the library —
+                // the same core helper the native client's filter runs through.
+                queries::find_albums(&db.conn, query).map_err(|e| super::internal_error("db", e))?
             } else {
                 queries::all_albums(&db.conn).map_err(|e| super::internal_error("db", e))?
             };

--- a/justfile
+++ b/justfile
@@ -9,14 +9,18 @@ cli *ARGS:
     cargo run --release -p koan-cli -- {{ARGS}}
 
 # Run tests + clippy
-# KOAN_NO_KEYCHAIN: a cargo test binary is unsigned and rebuilt under a new hash
-# every compile, so a keychain ACL can never match it — every run would prompt
-# for the login password, and "Always Allow" would grant it to a binary that is
-# about to stop existing.
-export KOAN_NO_KEYCHAIN := "1"
-
+#
+# KOAN_NO_KEYCHAIN: a test binary is unsigned and rebuilt under a new hash every
+# compile, so a keychain ACL can never match it — every run would prompt for the
+# login password, and "Always Allow" would grant it to a binary that is about to
+# stop existing.
+#
+# Set per-recipe, not at the top of the file. A top-level `export` reaches every
+# recipe, so `just macos-run` launched the app with its credential store switched
+# off: the keychain is where the remote password lives, and without it koan has
+# no server — nothing plays, nothing downloads and no artwork loads.
 check:
-    cargo test --all-targets
+    KOAN_NO_KEYCHAIN=1 cargo test --all-targets
     cargo clippy --all-targets -- -D warnings
 
 # Format
@@ -337,4 +341,4 @@ macos-dmg: macos-bundle
 
 # Run the macOS app's tests.
 macos-test: macos-ffi
-    cd {{app_dir}} && swift test
+    cd {{app_dir}} && KOAN_NO_KEYCHAIN=1 swift test


### PR DESCRIPTION
Rolls up two changes and bumps to v0.28.0. #264 is merged into this branch.

**Minor, not patch:** Unreleased carries breaking FFI changes — `albums()` gained a `search` parameter, `PlayerEvents` became an async sequence (#252), and `KoanError` has a new variant.

## Library list performance

Measured against a 5,510-album / 7,138-artist library.

**Filtering moves into koan-core.** The macOS app narrowed its own copy with `localizedCaseInsensitiveContains` — 16ms for albums plus 10ms for artists per keystroke, and it ran for all four sections regardless of which was on screen. `find_albums()` joins the existing `find_artists()`, so the FFI, GraphQL and any future client narrow the same way. The app debounces (120ms) and cancels in flight.

**The `LIBRARY` collation memoizes its sort keys per thread.** Building one means an NFD pass plus a `Vec` of freshly allocated `String`s, and a collation is asked about the same name once per level of the sort — roughly 140,000 key builds to sort 5,510 albums where 5,510 would do. Every client's lists load faster for it.

**`koan-ffi` uses `sort_by_cached_key`** — `sort_by_key` recomputes the key on every comparison.

**Artist hover state moved onto the row.** It lived on the browser, so every pointer move invalidated the whole list.

**Artwork decodes and downsamples off the main actor.** `NSImage(data:)` defers the decode to draw time, putting a full-size JPEG through the main thread mid-scroll.

Also drops `selectedAlbumId` / `selectedArtistId` / `selectedAlbum` — nothing set them non-nil, and one made `refilter()` do an extra pass over every album.

## Saying when the server is unreachable

`justfile` had a top-level `export KOAN_NO_KEYCHAIN := "1"`. It sits above `check:` and reads as though it belongs to it, but a top-level `export` reaches **every** recipe — so `just macos-run` launched the app with no credential store. The remote password lives only in the keychain, so koan silently had no server: nothing played, no downloads started, every album returned no artwork. Three symptoms, one cause, and the only evidence was a single `warn:` line in `koan.log`.

Now scoped to the two recipes that run unsigned test binaries. `KoanEngine::remote_problem()` exposes the reason `remote_unavailable()` has produced since v0.27 and that nothing surfaced; the app asks at startup and reports through its existing error toast. `cover_art` returns an error when the server is configured but unusable, instead of answering "no art" for every record. And a failed fetch is no longer cached as absence — one blip during a scroll used to leave that album blank until relaunch.

## Load-bearing decisions

- Matching is ASCII case-insensitive, as `find_artists` already was. SQLite's `NOCASE` does not fold accented letters, so `MÖTLEY` no longer finds `Mötley`. A folded search column is the real fix and is not here.
- Grid tiles downsample to 512px; a cover opened on its own stays full size.
- Favourites and play history still filter in memory — both bounded, and only the section on screen can hold a filter.
- The error toast auto-dismisses after 6s, and only startup asks. A persistent banner, and a re-check after signing in from Settings, are not here.

## Verifying

- `just check` — 881 tests, clippy clean.
- The SQL filter returns the same 97 matches for "live" that the old in-memory filter did on the same library.
- `just --evaluate | grep KOAN_NO_KEYCHAIN` returns nothing; it is no longer a global.
- `just macos-run` launches with the keychain, and playback, downloads and artwork work — which is how the second bug was found.

## Not measured

The collation and artwork changes are reasoned from the code, not timed. The waste is structural — a rebuilt allocating key per comparison, a decode on the main thread — but there are no before/after numbers for those two. The filter numbers are real.