### PR TITLE
fix(remote): say when koan cannot reach its server

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,7 @@
 {
+  "env": {
+    "KOAN_NO_KEYCHAIN": "1"
+  },
   "hooks": {
     "PreToolUse": [
       {
@@ -6,7 +9,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "if echo \"$TOOL_INPUT\" | grep -q 'git push'; then cd \"$(git rev-parse --show-toplevel)\" && echo 'Pre-push: formatting...' && cargo fmt --all 2>&1 && if ! git diff --quiet; then echo 'Pre-push: cargo fmt changed files. Review and commit them yourself \u2014 refusing to amend.'; exit 1; fi && echo 'Pre-push: running clippy...' && cargo clippy --workspace --all-targets -- -D warnings 2>&1 || { echo 'Clippy failed \u2014 fix before pushing'; exit 1; } && echo 'fmt + clippy clean'; fi"
+            "command": "if echo \"$TOOL_INPUT\" | grep -q 'git push'; then cd \"$(git rev-parse --show-toplevel)\" && echo 'Pre-push: formatting...' && cargo fmt --all 2>&1 && if ! git diff --quiet; then echo 'Pre-push: cargo fmt changed files. Review and commit them yourself — refusing to amend.'; exit 1; fi && echo 'Pre-push: running clippy...' && cargo clippy --workspace --all-targets -- -D warnings 2>&1 || { echo 'Clippy failed — fix before pushing'; exit 1; } && echo 'fmt + clippy clean'; fi"
           }
         ]
       }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@
 
 ### Fixed
 
+- **`just` ran everything with the credential store switched off.** `export KOAN_NO_KEYCHAIN := "1"` sat directly above `check:`, reading as though it belonged to it — but a top-level `export` in a justfile reaches every recipe, so `just macos-run` launched the app with no keychain. With no password there is no server, and koan degraded three ways at once: nothing played, no downloads started, and every record came back with no artwork, which reads as an empty library rather than as being signed out. It is set per-recipe now, on the two that run unsigned test binaries.
+
+- **A client that cannot reach its server says so.** `remote_unavailable()` has produced the right sentence since v0.27 and was called in exactly one place — a `warn:` in the download queue that only a log reader would ever see. `KoanEngine::remote_problem()` asks the question directly, the macOS app asks at startup and reports through the error toast it already had, and `cover_art` returns an error when the server is configured but unusable instead of answering "no art" for every record in the library.
+
+- **A failed artwork fetch is no longer remembered as "this record has no art".** The cache could not tell a server that said no from one that could not be reached, so a blip during a scroll left permanent holes until relaunch. Only a definite answer is recorded now.
+
 - **Dragging an artist's name in the artists list dragged nothing.** The name was a `Button`, and a button consumes the press a drag starts from — so the row queued when dragged and the link on it, standing for the same artist, did not. The app now has one kind of link text rather than two, and every name that navigates to something playable is also a drag source for it.
 
 - **The Homebrew cask warned on every `brew` command.** `depends_on macos: ">= :tahoe"` is a deprecated string comparison; the bare symbol has always meant "that version or newer", so the requirement is unchanged. The workflow that regenerates the cask on release is fixed too, not just the published tap.

--- a/apps/macos/Sources/Koan/KoanApp.swift
+++ b/apps/macos/Sources/Koan/KoanApp.swift
@@ -52,6 +52,17 @@ final class AppState {
 
         // Single-key shortcuts, caught before the focused list eats them.
         self.hotkeys = Hotkeys.standard(player: player, library: library, ui: ui)
+
+        // A client that cannot reach its server fails at everything quietly:
+        // nothing plays, nothing downloads, and every record comes back with no
+        // artwork — which reads as an empty library rather than as being signed
+        // out. The engine knows why; this is it saying so. Off the launch path,
+        // since the answer can involve the credential store.
+        Task { [weak player] in
+            if let problem = await engine.remoteProblem() {
+                player?.lastError = problem
+            }
+        }
     }
 }
 

--- a/apps/macos/Sources/Koan/Support/CoverArtCache.swift
+++ b/apps/macos/Sources/Koan/Support/CoverArtCache.swift
@@ -81,25 +81,29 @@ final class CoverArtCache {
             // writing the file would otherwise happen on the main actor. The
             // hash comes back with the bytes because it is a pass over the
             // whole payload and the main actor has no business doing it.
-            let payload = await Task.detached(priority: .utility) { () -> (Data, String)? in
+            let payload = await Task.detached(priority: .utility) { () -> Fetched in
                 if let file, let cached = try? Data(contentsOf: file) {
-                    return (cached, Self.digest(cached))
+                    return .art(cached, hash: Self.digest(cached))
                 }
-                guard let fetched = await Self.fetch(source, engine) else { return nil }
-                if let file {
+                let fetched = await Self.fetch(source, engine)
+                if case .art(let bytes, _) = fetched, let file {
                     // Best effort: a cache that fails to write is still a cache.
-                    try? fetched.write(to: file, options: .atomic)
+                    try? bytes.write(to: file, options: .atomic)
                 }
-                return (fetched, Self.digest(fetched))
+                return fetched
             }.value
 
             guard let self else { return nil }
             self.tasks[key] = nil
-            guard let payload, self.accept(hash: payload.1, for: key) else {
+            // Nothing recorded: the next tile that asks tries again.
+            guard case .art(let data, let hash) = payload else {
+                if case .none = payload { self.memory[key] = NSImage?.none }
+                return nil
+            }
+            guard self.accept(hash: hash, for: key) else {
                 self.memory[key] = NSImage?.none
                 return nil
             }
-            let data = payload.0
             let image = await Task.detached(priority: .utility) {
                 Self.decode(data, source: source)
             }.value
@@ -117,22 +121,40 @@ final class CoverArtCache {
         }
     }
 
+    /// What an attempt learned.
+    ///
+    /// A server that answers and says it has no art is worth remembering. One
+    /// that could not be reached is not: recording that as "no art" is why a
+    /// scroll during a blip left permanent holes in the grid until relaunch.
+    private enum Fetched {
+        case art(Data, hash: String)
+        case none
+        case failed
+    }
+
     private nonisolated static func fetch(
         _ source: AlbumArtwork.Source,
         _ engine: KoanEngine
-    ) async -> Data? {
-        switch source {
-        case .album(let albumId):
-            // Any track off the record will do — they share the artwork.
-            guard let tracks = try? await engine.tracks(
-                albumId: albumId, artistId: nil, sort: .album, limit: 1, offset: 0
-            ) else { return nil }
-            guard let first = tracks.first(where: { $0.path != nil }) ?? tracks.first else {
-                return nil
+    ) async -> Fetched {
+        do {
+            let data: Data?
+            switch source {
+            case .album(let albumId):
+                // Any track off the record will do — they share the artwork.
+                let tracks = try await engine.tracks(
+                    albumId: albumId, artistId: nil, sort: .album, limit: 1, offset: 0
+                )
+                guard let first = tracks.first(where: { $0.path != nil }) ?? tracks.first else {
+                    return .none
+                }
+                data = try await engine.coverArt(trackId: first.id, size: 400)?.data
+            case .track(let trackId):
+                data = try await engine.coverArt(trackId: trackId, size: 600)?.data
             }
-            return (try? await engine.coverArt(trackId: first.id, size: 400))?.data
-        case .track(let trackId):
-            return (try? await engine.coverArt(trackId: trackId, size: 600))?.data
+            guard let data, !data.isEmpty else { return .none }
+            return .art(data, hash: digest(data))
+        } catch {
+            return .failed
         }
     }
 

--- a/crates/koan-ffi/src/lib.rs
+++ b/crates/koan-ffi/src/lib.rs
@@ -30,6 +30,7 @@ use koan_core::player::commands::PlayerCommand;
 use koan_core::player::state::{
     LoadState, PlaybackState, PlaylistItem, QueueItemId, SharedPlayerState,
 };
+use koan_core::remote::client::SubsonicError;
 use uuid::Uuid;
 
 mod offload;
@@ -642,20 +643,59 @@ impl KoanEngine {
                 return Ok(None);
             };
             let cfg = Config::cached();
+            // No server configured: this record simply has no art.
             if !cfg.remote.enabled {
                 return Ok(None);
             }
+            // Configured but unusable — signed out, or the password cannot be
+            // read. Reported rather than shrugged off: answering "no art" for
+            // every record makes a signed-out client look like a library that
+            // has no covers, which is a long way from where the problem is.
             let Some(client) = koan_core::helpers::subsonic_client(&cfg) else {
-                return Ok(None);
+                return Err(KoanError::Remote {
+                    message: koan_core::helpers::remote_unavailable(&cfg),
+                });
             };
             match client.get_cover_art(&remote_id, size) {
                 Ok(data) if !data.is_empty() => {
                     let mime = sniff_mime(&data).to_string();
                     Ok(Some(CoverArt { data, mime }))
                 }
-                // No art on the server is normal, not a failure worth surfacing.
-                _ => Ok(None),
+                // The server answered and it has nothing. Normal, and worth
+                // remembering: this record has no art and never will.
+                Ok(_) | Err(SubsonicError::Api { .. }) | Err(SubsonicError::BadResponse) => {
+                    Ok(None)
+                }
+                // A timeout or a dropped connection says nothing about whether
+                // art exists. Reported rather than swallowed, so the caller can
+                // ask again instead of recording "this album has none" for the
+                // rest of the session — and so it appears in the log at all.
+                Err(e) => {
+                    log::warn!("cover art for track {track_id} failed: {e}");
+                    Err(KoanError::Remote {
+                        message: e.to_string(),
+                    })
+                }
             }
+        })
+        .await
+    }
+
+    /// Why the configured server cannot be used, if it cannot.
+    ///
+    /// `None` means there is nothing to say: either no server is configured, or
+    /// the one that is works. A client should not have to watch playback fail
+    /// and artwork come back empty to work out that it is signed out — the
+    /// engine already knows, and every front end asks the same question.
+    pub async fn remote_problem(self: Arc<Self>) -> Option<String> {
+        offload::offload(move || {
+            let cfg = Config::cached();
+            if !cfg.remote.enabled || cfg.remote.url.is_empty() {
+                return None;
+            }
+            koan_core::helpers::subsonic_auth(&cfg)
+                .is_none()
+                .then(|| koan_core::helpers::remote_unavailable(&cfg))
         })
         .await
     }

--- a/crates/koan-ffi/src/types.rs
+++ b/crates/koan-ffi/src/types.rs
@@ -593,6 +593,10 @@ pub enum KoanError {
     NotFound { message: String },
     #[error("bad argument: {message}")]
     BadArgument { message: String },
+    /// The server could not be reached, or gave up part way. Distinct from a
+    /// server that answered and said no — this one is worth retrying.
+    #[error("remote: {message}")]
+    Remote { message: String },
 }
 
 pub(crate) fn year_of(date: &str) -> Option<i32> {

--- a/justfile
+++ b/justfile
@@ -9,14 +9,18 @@ cli *ARGS:
     cargo run --release -p koan-cli -- {{ARGS}}
 
 # Run tests + clippy
-# KOAN_NO_KEYCHAIN: a cargo test binary is unsigned and rebuilt under a new hash
-# every compile, so a keychain ACL can never match it — every run would prompt
-# for the login password, and "Always Allow" would grant it to a binary that is
-# about to stop existing.
-export KOAN_NO_KEYCHAIN := "1"
-
+#
+# KOAN_NO_KEYCHAIN: a test binary is unsigned and rebuilt under a new hash every
+# compile, so a keychain ACL can never match it — every run would prompt for the
+# login password, and "Always Allow" would grant it to a binary that is about to
+# stop existing.
+#
+# Set per-recipe, not at the top of the file. A top-level `export` reaches every
+# recipe, so `just macos-run` launched the app with its credential store switched
+# off: the keychain is where the remote password lives, and without it koan has
+# no server — nothing plays, nothing downloads and no artwork loads.
 check:
-    cargo test --all-targets
+    KOAN_NO_KEYCHAIN=1 cargo test --all-targets
     cargo clippy --all-targets -- -D warnings
 
 # Format
@@ -337,4 +341,4 @@ macos-dmg: macos-bundle
 
 # Run the macOS app's tests.
 macos-test: macos-ffi
-    cd {{app_dir}} && swift test
+    cd {{app_dir}} && KOAN_NO_KEYCHAIN=1 swift test


### PR DESCRIPTION
Stacked on #263 — review that first; this diff is only the commit on top.

## The bug

`justfile` had a top-level `export KOAN_NO_KEYCHAIN := "1"`. It sits directly above `check:` and reads as though it belongs to it, but a top-level `export` in a justfile reaches **every** recipe — so `just macos-run` launched the app with its credential store switched off.

The remote password lives only in the keychain (`config.local.toml` has `password = ""`), so `remote_password()` had nowhere to look and koan silently had no server. Nothing played, no downloads started, and every album returned no artwork. Three symptoms, one cause, and the only evidence anywhere was a single `warn:` line in `koan.log`.

## What it does

**Scopes the keychain opt-out** to the two recipes that run unsigned test binaries, which is what the comment above it always described. `.claude/settings.json` sets it for Claude sessions so agent runs still never prompt for the login keychain.

**Makes the reason reachable.** `remote_unavailable()` already produced the right sentence and was called in exactly one place. `KoanEngine::remote_problem()` asks it directly — `None` when there is nothing to say — and the macOS app asks at startup and reports through the error toast it already had.

**`cover_art` stops lying.** It mapped every failure to `Ok(None)`, so a timeout, a dropped connection and a signed-out client were all indistinguishable from "this record has no art". Now: a server that answers and says no is still `Ok(None)`; one that is configured but unusable, or that could not be reached, is an error — and it gets logged.

**A failed fetch is no longer cached as absence.** `CoverArtCache` wrote `memory[key] = nil` ("looked, nothing there") on any failure, so one blip during a scroll left that album showing the ensō until relaunch. Only a definite answer is recorded; anything else retries when the tile next appears.

## Load-bearing decisions

- The error toast auto-dismisses after 6s. Fine as a nudge, weak for a persistent signed-out state — a proper banner would be better and is not here.
- Only startup asks. Signing in from Settings does not re-check yet.

## Verifying

- `just check` — clippy clean.
- `just --evaluate | grep KOAN_NO_KEYCHAIN` returns nothing; it is no longer a global.
- `just macos-run` now launches with the keychain, and playback, downloads and artwork all work again — which is how this was found.