### PR TITLE
feat(macos): the queue's album headings show the record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- **The queue's album headings carry the record, not a label.** The cover was 22pt — too small to recognise a sleeve by — and the heading read as one run-on line of artist, album and year. Art is 52pt, and the text is the album, its artist, then year · track count · running time · codec, so a run in the queue says what it is without counting rows. The codec only shows when the whole run shares one.
+
 ## v0.28.0 (2026-08-24)
 
 ### Added

--- a/apps/macos/Sources/Koan/Views/QueueView.swift
+++ b/apps/macos/Sources/Koan/Views/QueueView.swift
@@ -441,28 +441,59 @@ private struct QueueAlbumHeader: View {
     let group: QueueGroup
 
     var body: some View {
-        HStack(spacing: 9) {
+        HStack(spacing: 12) {
+            // No tap-to-view here, unlike the album page: this cover sits in a
+            // selectable, draggable row, and a tap gesture on it would eat the
+            // click that selects the row.
             if let trackId = group.items.first?.trackId {
-                AlbumArtwork(source: .track(trackId), cornerRadius: 3)
-                    .frame(width: 22, height: 22)
+                AlbumArtwork(source: .track(trackId), cornerRadius: 5)
+                    .frame(width: 52, height: 52)
+                    .shadow(color: .black.opacity(0.28), radius: 4, y: 2)
             }
-            Text(group.albumArtist.isEmpty ? "Unknown Artist" : group.albumArtist)
-                .foregroundStyle(.primary)
-            if !group.album.isEmpty {
-                Text("—")
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+
+                // Only when the line above is the record: a group with no album
+                // title already leads with the artist.
+                if !group.album.isEmpty {
+                    Text(group.albumArtist.isEmpty ? "Unknown Artist" : group.albumArtist)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+
+                Text(detail)
+                    .font(.caption2.monospacedDigit())
                     .foregroundStyle(.tertiary)
-                Text(group.album)
-                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
             }
-            if let year = group.year, !year.isEmpty {
-                Text(year)
-                    .foregroundStyle(.tertiary)
-            }
+
             Spacer()
         }
-        .font(.caption.weight(.medium))
         .textCase(nil)
-        .padding(.vertical, 3)
+        .padding(.vertical, 6)
+    }
+
+    private var title: String {
+        if !group.album.isEmpty { return group.album }
+        return group.albumArtist.isEmpty ? "Unknown Artist" : group.albumArtist
+    }
+
+    /// "2007 · 11 tracks · 59:10 · FLAC". The codec only earns its place when
+    /// the whole run shares one — a mixed group would be lying.
+    private var detail: String {
+        var parts: [String] = []
+        if let year = group.year, !year.isEmpty { parts.append(year) }
+        parts.append(Format.count(Int64(group.items.count), "track"))
+        let total = group.items.compactMap(\.durationMs).reduce(0, +)
+        if total > 0 { parts.append(Format.duration(total)) }
+        let codecs = Set(group.items.compactMap(\.codec))
+        if let codec = codecs.first, codecs.count == 1 { parts.append(codec.uppercased()) }
+        return parts.joined(separator: " · ")
     }
 }
 


### PR DESCRIPTION
The queue's album heading was a 22pt thumbnail and one run-on line of `Artist — Album — Year`. Too small to recognise a sleeve by, and nothing about the run itself.

**What changed** (`QueueAlbumHeader`, `QueueView.swift`):

- Cover at 76pt with the same drop shadow the album page's cover uses — a sleeve, not a thumbnail.
- Three lines: **album** (16pt semibold) → **album artist** (subheadline, secondary) → **year · N tracks · running time · CODEC** (caption, monospaced digits, tertiary).
- A group with no album title leads with the artist and drops the now-redundant second line — those are the standalone items, one per row.

**Decisions worth checking:**

- **Codec only when the whole run shares one.** `Set(items.compactMap(\.codec))` of size 1. A mixed run showing "FLAC" would be lying about the tracks under it.
- **No tap-to-view artwork here**, unlike the album page. `showsArtworkFullSize` is an `onTapGesture`, and this cover lives in a selectable, draggable List row — the gesture would eat the click that selects the row, which is the conclusion `RowBehaviour` already documents for `.onDrag`. Commented in place.
- Running time is summed from `durationMs` and omitted when nothing in the run has one.

**How to confirm:** `just macos-run`, queue a couple of albums. Headings should show big art and the detail line; clicking a heading still selects it, dragging still moves the album, and the context menu is unchanged. Queue a loose file (no album tag) to see the artist-led variant.
