### PR TITLE
fix(core): move the download queue out of the TUI so everything can use it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,10 @@
 
 - **Picking from the search dropdown landed on an empty results page instead of what you picked.** Choosing a suggestion pushes its album or artist and then empties the field, and both happened in one update: the results page is the stack's root at that moment, so clearing the query changed what that root drew while the destination was still landing, and it was discarded against the root it had been pushed onto. Emptying the field is its own update now, so the push settles first.
 
+- **Everything but the TUI downloaded one track at a time.** `remote.download_workers` defaults to 5 and the macOS settings pane offers it, but the code path behind it ignored the value: the download queue — a worker pool, a permit-limited priority lane, and a watcher that reorders around the playback cursor — lived in the TUI crate, and `koan-ffi` cannot import `koan-tui`. What everything else got instead was a stand-in that spawned one thread per batch and walked it with a `for` loop. Queue an album from the macOS app and it fetched track after track, in submission order, ignoring where you actually were in the queue.
+
+  The queue moves to `koan-core`, where it should have been — it imported nothing but `koan-core` already. The macOS app, the GraphQL server and radio's auto-extend all reach it through the same helper they already called, so all three now download in parallel and promote what you jump to, and several tracks report progress at once instead of one.
+
 ## v0.27.0 (2026-08-24)
 
 ### Added

--- a/crates/koan-cli/src/commands/play.rs
+++ b/crates/koan-cli/src/commands/play.rs
@@ -66,7 +66,8 @@ pub fn cmd_play(
 
     let (state, _timeline, viz_snapshot, tx) = Player::spawn();
 
-    let download_queue = koan_core::remote::queue::shared(&tx, &state, Some(log_buffer.clone())).clone();
+    let download_queue =
+        koan_core::remote::queue::shared(&tx, &state, Some(log_buffer.clone())).clone();
 
     // Radio's top-up loop lives in koan-core so every client behaves the same.
     // The TUI used to carry its own copy, which meant a second implementation

--- a/crates/koan-cli/src/commands/play.rs
+++ b/crates/koan-cli/src/commands/play.rs
@@ -10,7 +10,6 @@ use koan_core::player::state::LoadState;
 use owo_colors::OwoColorize;
 
 use koan_tui::app::PickerAction;
-use koan_tui::download_queue::DownloadQueue;
 use koan_tui::enqueue::enqueue_playlist;
 use koan_tui::play::TuiCallbacks;
 
@@ -67,7 +66,7 @@ pub fn cmd_play(
 
     let (state, _timeline, viz_snapshot, tx) = Player::spawn();
 
-    let download_queue = DownloadQueue::spawn(tx.clone(), state.clone(), log_buffer.clone());
+    let download_queue = koan_core::remote::queue::shared(&tx, &state, Some(log_buffer.clone())).clone();
 
     // Radio's top-up loop lives in koan-core so every client behaves the same.
     // The TUI used to carry its own copy, which meant a second implementation
@@ -251,7 +250,8 @@ pub fn cmd_play_remote(server_url: &str, jukebox: bool) {
     let log_buffer: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
     BufferedLogger::set_buffer(log_buffer.clone());
 
-    let download_queue = DownloadQueue::spawn(cmd_tx.clone(), state.clone(), log_buffer.clone());
+    let download_queue =
+        koan_core::remote::queue::shared(&cmd_tx, &state, Some(log_buffer.clone())).clone();
 
     std::thread::sleep(Duration::from_millis(300));
 

--- a/crates/koan-core/src/helpers.rs
+++ b/crates/koan-core/src/helpers.rs
@@ -1224,35 +1224,23 @@ pub fn remote_unavailable(cfg: &Config) -> String {
 }
 
 /// Spawn background downloads for remote tracks with LoadState::Pending.
+/// Submit tracks for download.
+///
+/// Everything that is not the TUI reaches downloads through here — the FFI, the
+/// GraphQL server and radio's auto-extend. It used to spawn a thread per batch
+/// and walk it with a `for` loop, which meant one track at a time no matter
+/// what `download_workers` said, and no reordering when the cursor moved. It
+/// hands the batch to the shared queue now, which is the same pool, priority
+/// lane and cursor watcher the TUI has always used.
 pub fn spawn_downloads(
     pending: Vec<(i64, QueueItemId)>,
     tx: crossbeam_channel::Sender<PlayerCommand>,
     state: Arc<SharedPlayerState>,
 ) {
-    let log_buf: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
-    if let Err(e) = std::thread::Builder::new()
-        .name("koan-download".into())
-        .spawn(move || {
-            let cfg = Config::load().unwrap_or_default();
-            let Some(client) = subsonic_client(&cfg) else {
-                // Marked failed rather than left Pending. A track that cannot
-                // be fetched will never become Ready, and the player waits for
-                // Ready — so returning here quietly meant a queue that sat
-                // saying nothing until it ran off the end.
-                let why = remote_unavailable(&cfg);
-                log::warn!("skipping {} downloads: {}", pending.len(), why);
-                for (_, queue_id) in pending {
-                    state.update_load_state(queue_id, LoadState::Failed(why.clone()));
-                }
-                return;
-            };
-            for (db_id, queue_id) in pending {
-                download_track(db_id, queue_id, &tx, &log_buf, &state, &cfg, &client);
-            }
-        })
-    {
-        log::error!("failed to spawn download thread: {}", e);
+    if pending.is_empty() {
+        return;
     }
+    crate::remote::queue::shared(&tx, &state, None).enqueue(pending);
 }
 
 #[cfg(test)]

--- a/crates/koan-core/src/remote/mod.rs
+++ b/crates/koan-core/src/remote/mod.rs
@@ -3,4 +3,5 @@ pub mod download;
 pub mod listenbrainz;
 pub mod lrclib;
 pub mod musicbrainz;
+pub mod queue;
 pub mod sync;

--- a/crates/koan-core/src/remote/queue.rs
+++ b/crates/koan-core/src/remote/queue.rs
@@ -4,12 +4,12 @@ use std::sync::{Arc, Mutex as StdMutex};
 
 use parking_lot::{Condvar, Mutex};
 
-use koan_core::config;
-use koan_core::player::commands::PlayerCommand;
-use koan_core::player::state::{LoadState, QueueItemId, SharedPlayerState};
-use koan_core::remote::client::SubsonicClient;
+use crate::config;
+use crate::player::commands::PlayerCommand;
+use crate::player::state::{LoadState, QueueItemId, SharedPlayerState};
+use crate::remote::client::SubsonicClient;
 
-use koan_core::helpers::download_track;
+use crate::helpers::download_track;
 
 /// Concurrent downloads the priority lane may run outside the worker pool.
 /// Small on purpose: its job is to get the track under the cursor playing, and
@@ -112,7 +112,7 @@ impl DownloadQueue {
     ) -> Self {
         let cfg = config::Config::load().unwrap_or_default();
         let num_workers = cfg.remote.download_workers.max(1);
-        let client = koan_core::helpers::subsonic_client(&cfg);
+        let client = crate::helpers::subsonic_client(&cfg);
         if client.is_none() {
             log::info!("remote not configured — download queue will idle");
         }
@@ -214,9 +214,12 @@ fn dispatch_priority(inner: &Arc<Inner>, item: (i64, QueueItemId)) {
 /// Run one download, containing any panic so the worker pool never shrinks.
 fn run_download(inner: &Arc<Inner>, (db_id, queue_id): (i64, QueueItemId)) {
     let Some(client) = inner.client.as_ref() else {
-        inner
-            .state
-            .update_load_state(queue_id, LoadState::Failed("remote not configured".into()));
+        // Failed, not left Pending: the player waits for Ready, so a queue of
+        // tracks that can never arrive would otherwise sit saying nothing.
+        inner.state.update_load_state(
+            queue_id,
+            LoadState::Failed(crate::helpers::remote_unavailable(&inner.cfg)),
+        );
         return;
     };
 
@@ -318,6 +321,30 @@ fn cursor_watcher(inner: Arc<Inner>) {
             dispatch_priority(&inner, item);
         }
     }
+}
+
+/// The process's download queue.
+///
+/// One player means one pool, one priority lane and one cursor watcher; a
+/// second set would compete with the first for the same link and the same
+/// cursor. Every front end reaches downloads through here — the TUI directly,
+/// the FFI and the GraphQL server through `helpers::spawn_downloads`.
+///
+/// `log_buf` is only honoured by whoever initialises it, which is the TUI when
+/// it is running, since it is the only front end that shows the buffer.
+pub fn shared(
+    cmd_tx: &crossbeam_channel::Sender<PlayerCommand>,
+    state: &Arc<SharedPlayerState>,
+    log_buf: Option<Arc<StdMutex<Vec<String>>>>,
+) -> &'static DownloadQueue {
+    static QUEUE: std::sync::OnceLock<DownloadQueue> = std::sync::OnceLock::new();
+    QUEUE.get_or_init(|| {
+        DownloadQueue::spawn(
+            cmd_tx.clone(),
+            state.clone(),
+            log_buf.unwrap_or_else(|| Arc::new(StdMutex::new(Vec::new()))),
+        )
+    })
 }
 
 #[cfg(test)]

--- a/crates/koan-tui/src/app.rs
+++ b/crates/koan-tui/src/app.rs
@@ -14,7 +14,7 @@ use koan_core::player::state::{
     VisibleQueueSnapshot,
 };
 
-use crate::download_queue::DownloadQueue;
+use koan_core::remote::queue::DownloadQueue;
 
 use super::library::LibraryState;
 use super::lyrics::LyricsState;

--- a/crates/koan-tui/src/enqueue.rs
+++ b/crates/koan-tui/src/enqueue.rs
@@ -10,7 +10,7 @@ use koan_core::player::commands::PlayerCommand;
 use koan_core::player::state::{LoadState, QueueItemId};
 
 use crate::app::PickerAction;
-use crate::download_queue::DownloadQueue;
+use koan_core::remote::queue::DownloadQueue;
 
 /// Build PlaylistItems from track IDs and enqueue according to the action:
 /// - Append: add to end of queue, don't play.

--- a/crates/koan-tui/src/lib.rs
+++ b/crates/koan-tui/src/lib.rs
@@ -7,7 +7,6 @@ pub mod app;
 pub mod context_menu;
 pub mod cover_art;
 pub mod device_selector;
-pub mod download_queue;
 pub mod enqueue;
 pub mod help_modal;
 pub mod keys;

--- a/crates/koan-tui/src/play.rs
+++ b/crates/koan-tui/src/play.rs
@@ -12,7 +12,7 @@ use koan_core::player::commands::PlayerCommand;
 use koan_core::player::state::LoadState;
 
 use crate::app::{self, PickerAction};
-use crate::download_queue::DownloadQueue;
+use koan_core::remote::queue::DownloadQueue;
 use crate::enqueue::enqueue_playlist;
 use crate::picker::{
     PickerItem, PickerKind, PickerPartKind, PickerState, all_tracks_sentinel,

--- a/crates/koan-tui/src/play.rs
+++ b/crates/koan-tui/src/play.rs
@@ -12,13 +12,13 @@ use koan_core::player::commands::PlayerCommand;
 use koan_core::player::state::LoadState;
 
 use crate::app::{self, PickerAction};
-use koan_core::remote::queue::DownloadQueue;
 use crate::enqueue::enqueue_playlist;
 use crate::picker::{
     PickerItem, PickerKind, PickerPartKind, PickerState, all_tracks_sentinel,
     artist_id_from_sentinel, is_all_tracks_sentinel,
 };
 use crate::picker_items::{load_picker_items, make_album_picker_items};
+use koan_core::remote::queue::DownloadQueue;
 
 /// Callbacks for CLI integration. The TUI library crate doesn't own
 /// the logger or signal handler — koan-cli provides those.

--- a/crates/koan-tui/src/ui.rs
+++ b/crates/koan-tui/src/ui.rs
@@ -510,7 +510,7 @@ mod tests {
         let state = SharedPlayerState::new();
         let (tx, _rx) = crossbeam_channel::unbounded();
         let log_buffer = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
-        let download_queue = crate::download_queue::DownloadQueue::spawn(
+        let download_queue = koan_core::remote::queue::DownloadQueue::spawn(
             tx.clone(),
             state.clone(),
             log_buffer.clone(),


### PR DESCRIPTION
Queue an album in the macOS app and it downloads one track at a time, in submission order, ignoring which track you jumped to.

## Why

The real download queue — a worker pool sized by `remote.download_workers`, a permit-limited priority lane, and a `cursor_watcher` that reorders around playback — has always existed, in `koan-tui/src/download_queue.rs`. `koan-ffi` cannot import `koan-tui` (the crate graph forbids it), so `helpers::spawn_downloads` was written as a stand-in:

```rust
for (db_id, queue_id) in pending {
    download_track(...);      // one thread, one at a time
}
```

**The macOS app, the GraphQL server and radio's auto-extend were all on the stand-in.** Only the TUI had the real queue. `download_workers` defaults to 5 and the macOS settings pane offers it, while the path behind it ignored the value entirely — so downloads ran at a fifth of the configured concurrency, with no reordering when the cursor moved, and one progress bar at a time instead of several.

## What changed

`download_queue.rs` imported nothing but `koan-core`, so it moves to `koan-core/src/remote/queue.rs` essentially verbatim. `spawn_downloads` keeps its exact signature and submits to the shared queue instead of spawning a serial thread — so **koan-ffi, koan-server and radio are unchanged** and pick up the pool, the priority lane and the cursor watcher for free.

One queue per process, behind a `OnceLock`: one player wants one pool competing for one link, not several sets fighting each other and the cursor.

Two details worth the reviewer's attention:

- The no-client path now reports `remote_unavailable(&cfg)` rather than a flat `"remote not configured"`. The stand-in gave callers that reason and the queue did not, so without this the 0.27.0 "say why the remote is unavailable" work would regress for the FFI, the server and radio.
- `ui.rs`'s construction site is a **test** building a throwaway queue on a dummy channel. It stays on `DownloadQueue::spawn` rather than the process-global, which a test must not touch.

## Verifying

`just check` — 683 core tests plus the rest, clippy clean.

In the app: queue an album from a remote library and several tracks should download at once with progress on each, rather than one bar walking down the list. Jump to a track further down and it, plus its album-mates, should be pulled to the front. `remote.download_workers` should visibly change how many run at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L2QYGXTN6dYC7MX5KNY8a5