### PR TITLE
release: v0.28.1

### DIFF
--- a/.!33071!Cargo.toml
+++ b/.!33071!Cargo.toml
@@ -1,0 +1,13 @@
+[workspace]
+resolver = "2"
+members = ["crates/koan-core", "crates/koan-ffi", "crates/koan-server", "crates/koan-tui", "crates/koan-cli"]
+
+[workspace.package]
+version = "0.28.1"
+edition = "2024"
+rust-version = "1.89"
+homepage = "https://github.com/radiosilence/koan"
+repository = "https://github.com/radiosilence/koan"
+license = "MIT"
+
+[workspace.dependencies]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Changelog
 
-## Unreleased
+## v0.28.1 (2026-08-24)
 
 ### Changed
 
 - **The queue's album headings carry the record, not a label.** The cover was 22pt — too small to recognise a sleeve by — and the heading read as one run-on line of artist, album and year. Art is 52pt, and the text is the album, its artist, then year · track count · running time · codec, so a run in the queue says what it is without counting rows. The codec only shows when the whole run shares one.
+
+### Fixed
+
+- **Everything but the TUI downloaded one track at a time.** `remote.download_workers` defaults to 5 and the macOS settings pane offers it, but the code path behind it ignored the value: the download queue — a worker pool, a permit-limited priority lane, and a watcher that reorders around the playback cursor — lived in the TUI crate, and `koan-ffi` cannot import `koan-tui`. What everything else got instead was a stand-in that spawned one thread per batch and walked it with a `for` loop. Queue an album from the macOS app and it fetched track after track, in submission order, ignoring where you actually were in the queue.
+
+  The queue moves to `koan-core`, where it should have been — it imported nothing but `koan-core` already. The macOS app, the GraphQL server and radio's auto-extend all reach it through the same helper they already called, so all three now download in parallel and promote what you jump to, and several tracks report progress at once instead of one.
 
 ## v0.28.0 (2026-08-24)
 
@@ -57,10 +63,6 @@
   The lit row is now the section being browsed and nothing else. Opening an album from search results keeps Results lit, and Back returns you to them.
 
 - **Picking from the search dropdown landed on an empty results page instead of what you picked.** Choosing a suggestion pushes its album or artist and then empties the field, and both happened in one update: the results page is the stack's root at that moment, so clearing the query changed what that root drew while the destination was still landing, and it was discarded against the root it had been pushed onto. Emptying the field is its own update now, so the push settles first.
-
-- **Everything but the TUI downloaded one track at a time.** `remote.download_workers` defaults to 5 and the macOS settings pane offers it, but the code path behind it ignored the value: the download queue — a worker pool, a permit-limited priority lane, and a watcher that reorders around the playback cursor — lived in the TUI crate, and `koan-ffi` cannot import `koan-tui`. What everything else got instead was a stand-in that spawned one thread per batch and walked it with a `for` loop. Queue an album from the macOS app and it fetched track after track, in submission order, ignoring where you actually were in the queue.
-
-  The queue moves to `koan-core`, where it should have been — it imported nothing but `koan-core` already. The macOS app, the GraphQL server and radio's auto-extend all reach it through the same helper they already called, so all three now download in parallel and promote what you jump to, and several tracks report progress at once instead of one.
 
 ## v0.27.0 (2026-08-24)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2744,7 +2744,7 @@ dependencies = [
 
 [[package]]
 name = "koan-cli"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "chrono",
  "clap",
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "koan-core"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "argon2",
  "bliss-audio",
@@ -2810,7 +2810,7 @@ dependencies = [
 
 [[package]]
 name = "koan-ffi"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "chrono",
  "crossbeam-channel",
@@ -2830,7 +2830,7 @@ dependencies = [
 
 [[package]]
 name = "koan-server"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",
@@ -2863,7 +2863,7 @@ dependencies = [
 
 [[package]]
 name = "koan-tui"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "core-foundation 0.10.1",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/koan-core", "crates/koan-ffi", "crates/koan-server", "crates/koan-tui", "crates/koan-cli"]
 
 [workspace.package]
-version = "0.28.0"
+version = "0.28.1"
 edition = "2024"
 rust-version = "1.89"
 homepage = "https://github.com/radiosilence/koan"
@@ -13,9 +13,9 @@ license = "MIT"
 [workspace.dependencies]
 # Internal crates. Keep the version in step with [workspace.package] above —
 # a stale pin here publishes members that resolve against the wrong sibling.
-koan-core = { path = "crates/koan-core", version = "0.28.0" }
-koan-server = { path = "crates/koan-server", version = "0.28.0" }
-koan-tui = { path = "crates/koan-tui", version = "0.28.0" }
+koan-core = { path = "crates/koan-core", version = "0.28.1" }
+koan-server = { path = "crates/koan-server", version = "0.28.1" }
+koan-tui = { path = "crates/koan-tui", version = "0.28.1" }
 # Feature set is the union every member needs; `default-tls` is an alias for
 # `rustls`, so there is exactly one TLS stack.
 reqwest = { version = "0.13", default-features = false, features = [


### PR DESCRIPTION
Patch release for the download queue fix (#266) and the queue album headings.

- `[workspace.package]` and the three internal pins (`koan-core`, `koan-server`, `koan-tui`) all move to `0.28.1` together — `Check Version` hard-fails if they drift.
- `Cargo.lock` regenerated.
- `## Unreleased` becomes `## v0.28.1`.

## One correction folded in

The download queue entry had been written into **v0.28.0's** section rather than Unreleased. I anchored the insert on `v0.27.x` while `main` had already cut 0.28.0, so it landed at the tail of the released notes — describing work that shipped a release later than it claims. Moved to `### Fixed` under v0.28.1, where it belongs.

## Merging this publishes

`Check Version` compares `Cargo.toml` against the latest GitHub release, so merging is what cuts the release: crates.io publish, GitHub release, homebrew tap update. Not armed for auto-merge — that call is yours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L2QYGXTN6dYC7MX5KNY8a5