### PR TITLE
feat(macos): group the queue by album, or list every track

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,19 @@
 
 ## Unreleased
 
+### Added
+
+- **The queue groups by album or gives every track its own row, and remembers which you chose.** Grouped is what it was: a heading per contiguous run of a record, tracks underneath carrying a number. Ungrouped drops the headings and gives each row its own sleeve and its full attribution, because there is no heading above it to say what record it is. Each suits a different queue — an album listen wants the headings, a long shuffled queue wants every row to identify itself — so it is a toggle in the queue bar rather than a decision made for you, and it persists.
+
+  Both modes are shown with the active one lit, the way Finder switches view. One icon would have had to choose between naming the mode you are in and the mode you would get, and whichever it named, the other reading is available and wrong.
+
 ### Changed
 
 - **The queue's album headings carry the record, not a label.** The cover was 22pt — too small to recognise a sleeve by — and the heading read as one run-on line of artist, album and year. Art is 52pt, and the text is the album, its artist, then year · track count · running time · codec, so a run in the queue says what it is without counting rows. The codec only shows when the whole run shares one.
+
+### Fixed
+
+- **A macOS build made without Xcode had invisible controls.** The accent is read from the asset catalog, compiling it needs `actool`, and that ships with Xcode proper rather than the command line tools. Without it the colour resolved to nothing and the whole app was tinted with nothing — which does not merely lose the colour: every borderless button and the playing row's title and speaker are drawn in `.tint`, so they were invisible rather than uncoloured. It falls back to the system accent, which is visible and still visibly not koan's.
 
 ## v0.28.0 (2026-08-24)
 

--- a/apps/macos/Sources/Koan/Support/Palette.swift
+++ b/apps/macos/Sources/Koan/Support/Palette.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 /// koan's accent, read from the asset catalog.
@@ -11,6 +12,12 @@ import SwiftUI
 ///
 /// `NSAccentColorName` in the bundle's Info.plist points at this colour set;
 /// see the `macos-bundle` recipe.
+/// Falls back to the system accent when the catalog is not in the bundle.
+/// Compiling it needs `actool`, which ships with Xcode proper rather than the
+/// command line tools, so a build made without Xcode has no colour to find.
+/// Resolving to nothing tints the app with nothing, which does not merely lose
+/// the colour — every borderless control and the playing row's title are drawn
+/// in `.tint`, and they become invisible rather than uncoloured.
 extension Color {
-    static let koanAccent = Color("AccentColor")
+    static let koanAccent = NSColor(named: "AccentColor").map(Color.init) ?? .accentColor
 }

--- a/apps/macos/Sources/Koan/Views/QueueView.swift
+++ b/apps/macos/Sources/Koan/Views/QueueView.swift
@@ -17,6 +17,12 @@ struct QueueView: View {
     @State private var savingSnapshot = false
     @State private var snapshotName = ""
 
+    /// Grouped or one row per track. Persisted because it is a preference about
+    /// how you listen rather than about the queue in front of you: an album
+    /// listen wants the headings, a long shuffled queue wants every row to say
+    /// what it is and show its own sleeve.
+    @AppStorage("queueGrouped") private var grouped = true
+
     /// Selection is local `@State`, deliberately.
     ///
     /// It lived on `PlayerModel` so the Edit menu could reach it, but reading an
@@ -30,7 +36,9 @@ struct QueueView: View {
     /// the first track. That is what lets an album be selected and dragged as a
     /// unit — and stops selecting a track from lighting up the heading above it,
     /// which is what happened while they shared a row.
-    private var rows: [Row] { Row.build(from: player.queue) }
+    private var rows: [Row] {
+        grouped ? Row.build(from: player.queue) : player.queue.map(Row.track)
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -125,6 +133,19 @@ struct QueueView: View {
                 Button("Remove", role: .destructive) { removeSelected() }
             }
 
+            // Both modes shown with the active one lit, the way Finder switches
+            // view. A single icon has to choose between naming the mode you are
+            // in and the mode you would get, and whichever it picks the other
+            // reading is available and wrong.
+            Picker("Queue layout", selection: $grouped) {
+                Image(systemName: "square.stack").tag(true)
+                Image(systemName: "list.bullet").tag(false)
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            .fixedSize()
+            .help("Group by album, or one row per track")
+
             Button { player.undo() } label: { Image(systemName: "arrow.uturn.backward") }
                 .help("Undo (⌘Z)")
             Button { player.redo() } label: { Image(systemName: "arrow.uturn.forward") }
@@ -167,7 +188,10 @@ struct QueueView: View {
                 item: item,
                 isCurrent: item.queueItemId == player.currentItemId,
                 isSelected: selection.contains(item.queueItemId),
-                showArtist: item.artist != item.albumArtist
+                // Ungrouped there is no heading above to say what record this
+                // is, so the row says it itself.
+                showArtist: !grouped || item.artist != item.albumArtist,
+                artwork: !grouped
             )
             .rowBehaviour()
         }
@@ -502,6 +526,8 @@ private struct QueueRow: View {
     let isCurrent: Bool
     let isSelected: Bool
     let showArtist: Bool
+    /// Its own sleeve, for when there is no album heading above carrying one.
+    var artwork = false
 
     @Environment(PlayerModel.self) private var player
     @Environment(LibraryModel.self) private var library
@@ -513,13 +539,18 @@ private struct QueueRow: View {
                 .font(.caption)
                 .frame(width: 16)
 
-            // Always occupies its column, number or not: a missing track
-            // number would otherwise shift the title left and break the
-            // alignment down the list.
-            Text(item.trackNumber.map(String.init) ?? "")
-                .font(.caption.monospacedDigit())
-                .foregroundStyle(.tertiary)
-                .frame(width: 20, alignment: .trailing)
+            if artwork, let trackId = item.trackId {
+                AlbumArtwork(source: .track(trackId), cornerRadius: 3)
+                    .frame(width: 28, height: 28)
+            } else {
+                // Always occupies its column, number or not: a missing track
+                // number would otherwise shift the title left and break the
+                // alignment down the list.
+                Text(item.trackNumber.map(String.init) ?? "")
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(.tertiary)
+                    .frame(width: artwork ? 28 : 20, alignment: .trailing)
+            }
 
             VStack(alignment: .leading, spacing: 1) {
                 Text(item.title)
@@ -534,7 +565,9 @@ private struct QueueRow: View {
                 // Only worth a second line when it differs from the album
                 // artist — compilations and features, not every track.
                 if showArtist && !item.artist.isEmpty {
-                    Text(item.artist)
+                    Text(artwork && !item.album.isEmpty
+                        ? "\(item.artist) — \(item.album)"
+                        : item.artist)
                         .font(.caption)
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
@@ -579,7 +612,7 @@ private struct QueueRow: View {
         }
         // Fixed height so a row doesn't grow when a download indicator appears
         // and shrink when it finishes, reflowing the list each time.
-        .frame(height: 34)
+        .frame(height: artwork ? 40 : 34)
         // Without this the row is only clickable where a view actually sits —
         // the Spacer between the title and the duration is a dead zone, and
         // clicks landing there select nothing.


### PR DESCRIPTION
A queue of one record and a queue of two hundred shuffled tracks want different rows, so this is a toggle in the queue bar rather than a decision made for you. It persists — it is a preference about how you listen, not about the queue currently in front of you.

**Grouped** is what it was: a heading per contiguous run of a record, tracks underneath carrying a track number.

**Ungrouped** drops the headings, gives every row its own sleeve where the track number sat, and puts `artist — album` on the second line — because there is no heading above it to say what record it is.

## Notes for the reviewer

- **Grouping was already app-side.** `Row.build(from: player.queue)` folds a flat queue into runs, so ungrouped is `player.queue.map(Row.track)`. Nothing changed in core or the FFI.
- **The status icon stays in both modes.** The sleeve replaces the track-number column, not the icon — load state matters however you are grouping.
- **Artwork keys off `trackId`**, so a queue item with no library row falls back to the number column rather than leaving a hole.
- **Both modes are shown with the active one lit**, as Finder does its view switcher. A single icon has to choose between naming the mode you are in and the mode you would get, and whichever it names the other reading is available and wrong.

## The accent fallback, rolled in

`Color("AccentColor")` reads the asset catalog. Compiling it needs `actool`, which ships with Xcode proper and not with the command line tools, so a build made without Xcode found no colour and tinted the whole app with nothing.

That does not merely lose the colour. Every borderless control, and the playing row's title and speaker, are drawn in `.tint` — so they rendered **invisible rather than uncoloured**, which is how this toggle managed to ship into a test build that could not display it. It falls back to the system accent: visible, and still visibly not koan's, so a dev build is still tellable from a release one.

## Verifying

`just macos-run`. Toggle the control at the left of the queue bar:
- grouped → album headings, numbers, artist only when it differs from the album artist
- ungrouped → no headings, a sleeve per row, `artist — album` under each title
- relaunch → the mode you left it in
- an item with no library row keeps its number rather than showing a gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L2QYGXTN6dYC7MX5KNY8a5