### PR TITLE
fix(macos): the detail stack's navigation path gets an owner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Fixed
+
+- **Clicks that registered and did nothing.** Four separate things cleared or replaced the detail column's navigation path — a section switch, the sidebar's selection setter, a history move, and the push itself — and none knew about the others, so a push could be undone by an unrelated update landing in the same pass. `Navigator` owns it now: one `Location` value holding the section and the stack pushed on top of it, one history of locations behind it, and a single move that writes both. The sidebar's highlight is stored rather than derived from the stack, so a `List` writing its selection back can no longer pop what was just pushed, and the stack's root is a view of its own, so changing section cannot make SwiftUI discard the path against it.
+
+  Two consequences worth knowing. Back and Forward now restore the whole location, so returning to a section you had pushed into puts you back where you were rather than at its top. And clicking the sidebar row you are already on does nothing — that write is indistinguishable from one SwiftUI makes itself, and honouring it was half the bug. Back, from the toolbar or ⌘[, is the way out of a detail view.
+
+- **Picking a search suggestion lands in the section the thing lives in.** It used to push onto the results page and then empty the field, which left you standing on a root that no longer had anything in it. An album opens under Albums, an artist under Artists, and Back returns to whatever you were doing before you searched.
+
 ### Changed
 
 - **The queue's album headings carry the record, not a label.** The cover was 22pt — too small to recognise a sleeve by — and the heading read as one run-on line of artist, album and year. Art is 52pt, and the text is the album, its artist, then year · track count · running time · codec, so a run in the queue says what it is without counting rows. The codec only shows when the whole run shares one.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,7 +165,8 @@ Swift bindings are generated, not checked in — `just macos-ffi` builds the lib
 | `Support/ActivityModel.swift` | The one place that knows what koan is busy with. Library tasks are exclusive — they queue behind SQLite's single writer — and each is cancellable |
 | `Support/SettingsModel.swift` | Settings state over `config.toml`. Commits on edit, re-reads on focus |
 | `Support/PlayerModel.swift` | Polls `now_playing()` at 10 Hz; refetches the queue only when `playlistVersion` moves |
-| `Support/LibraryModel.swift` | Browse state. Albums/artists loaded once and filtered in memory; tracks never loaded wholesale |
+| `Support/Navigator.swift` | Where the app is. One `Location` — a section plus the stack pushed on it — and the only thing that writes the detail stack's path or the history behind it |
+| `Support/LibraryModel.swift` | Browse state. Albums/artists loaded once and filtered in memory; tracks never loaded wholesale. Follows the navigator; never moves it |
 | `Support/CoverArtCache.swift` | Album-keyed art cache. Each miss is an HTTP round trip on remote libraries |
 | `Views/QueueView.swift` | The main stage — album-grouped queue, drag reorder, multi-select |
 | `Views/PickerSheet.swift` | ⌘K picker: multi-select, add / add-and-play / replace queue |

--- a/apps/macos/Sources/Koan/KoanApp.swift
+++ b/apps/macos/Sources/Koan/KoanApp.swift
@@ -11,6 +11,7 @@ final class AppState {
     let engine: KoanEngine
     let player: PlayerModel
     let library: LibraryModel
+    let nav: Navigator
     let search: SearchModel
     let art: CoverArtCache
     let organize: OrganizeModel
@@ -27,7 +28,9 @@ final class AppState {
         self.player = player
         let library = LibraryModel(engine: engine)
         self.library = library
-        self.search = SearchModel(engine: engine, library: library)
+        let nav = Navigator(library: library)
+        self.nav = nav
+        self.search = SearchModel(engine: engine, library: library, nav: nav)
         let art = CoverArtCache(engine: engine)
         self.art = art
         self.organize = OrganizeModel(engine: engine)
@@ -51,7 +54,7 @@ final class AppState {
         player.onTick = { [weak centre] in centre?.refresh() }
 
         // Single-key shortcuts, caught before the focused list eats them.
-        self.hotkeys = Hotkeys.standard(player: player, library: library, ui: ui)
+        self.hotkeys = Hotkeys.standard(player: player, nav: nav, ui: ui)
 
         // A client that cannot reach its server fails at everything quietly:
         // nothing plays, nothing downloads, and every record comes back with no
@@ -89,6 +92,7 @@ struct KoanApp: App {
                         .environment(state.ui)
                         .environment(state.player)
                         .environment(state.library)
+                        .environment(state.nav)
                         .environment(state.search)
                         .environment(state.art)
                         .environment(state.organize)
@@ -131,14 +135,14 @@ struct KoanApp: App {
 
             CommandGroup(replacing: .sidebar) {
                 ForEach(NavigationCommand.all, id: \.section) { command in
-                    Button(command.title) { state?.library.section = command.section }
+                    Button(command.title) { state?.nav.show(command.section) }
                         .keyboardShortcut(command.key, modifiers: .command)
                 }
                 Divider()
-                Button("Back") { state?.library.goBack() }
+                Button("Back") { state?.nav.goBack() }
                     .keyboardShortcut("[", modifiers: .command)
                     .disabled(isTyping)
-                Button("Forward") { state?.library.goForward() }
+                Button("Forward") { state?.nav.goForward() }
                     .keyboardShortcut("]", modifiers: .command)
                     .disabled(isTyping)
                 Divider()
@@ -222,7 +226,7 @@ struct KoanApp: App {
                 Divider()
                 Button("Find") {
                     guard let state else { return }
-                    switch state.library.section {
+                    switch state.nav.section {
                     case .albums, .artists: state.ui.focusFilter()
                     default: state.ui.focusSearch()
                     }
@@ -307,7 +311,7 @@ struct KoanApp: App {
 private struct NavigationCommand {
     let title: String
     let key: KeyEquivalent
-    let section: LibraryModel.Section
+    let section: Navigator.Section
 
     static let all: [NavigationCommand] = [
         .init(title: "Queue", key: "1", section: .queue),
@@ -317,10 +321,6 @@ private struct NavigationCommand {
         .init(title: "History", key: "5", section: .playHistory),
         .init(title: "Snapshots", key: "6", section: .snapshots),
     ]
-}
-
-extension LibraryModel.Section: Identifiable {
-    public var id: Self { self }
 }
 
 /// The library is a file on disk; if it can't be opened there is no app to show.

--- a/apps/macos/Sources/Koan/Support/AlbumSort.swift
+++ b/apps/macos/Sources/Koan/Support/AlbumSort.swift
@@ -1,17 +1,3 @@
-import Foundation
-
-/// Navigation values are distinct types, never raw IDs.
-///
-/// A `NavigationStack` matches destinations by type, so two `Int64` routes in
-/// one stack collide silently and send you to whichever was registered first.
-struct AlbumRoute: Hashable {
-    let id: Int64
-}
-
-struct ArtistRoute: Hashable {
-    let id: Int64
-}
-
 import KoanFFI
 
 /// Stable strings for `UserDefaults`, so the stored preference survives the

--- a/apps/macos/Sources/Koan/Support/Hotkeys.swift
+++ b/apps/macos/Sources/Koan/Support/Hotkeys.swift
@@ -104,7 +104,7 @@ extension Hotkeys {
     /// ⌘ shortcuts in the menu bar cover what the menus already say.
     static func standard(
         player: PlayerModel,
-        library: LibraryModel,
+        nav: Navigator,
         ui: UIState
     ) -> Hotkeys {
         Hotkeys([
@@ -137,17 +137,17 @@ extension Hotkeys {
                 ui.focusSearch()
             },
             Hotkey(keys: ["l", "a"], label: "Albums", group: .navigation) {
-                library.section = .albums
+                nav.show(.albums)
             },
             Hotkey(keys: ["r"], label: "Artists", group: .navigation) {
-                library.section = .artists
+                nav.show(.artists)
             },
             Hotkey(keys: ["g"], label: "Top of the queue", group: .navigation) {
-                library.section = .queue
+                nav.show(.queue)
                 ui.jumpQueue(to: .top)
             },
             Hotkey(keys: ["G"], label: "End of the queue", group: .navigation) {
-                library.section = .queue
+                nav.show(.queue)
                 ui.jumpQueue(to: .bottom)
             },
 

--- a/apps/macos/Sources/Koan/Support/LibraryModel.swift
+++ b/apps/macos/Sources/Koan/Support/LibraryModel.swift
@@ -17,30 +17,22 @@ private let historyPageSize: UInt32 = 500
 @MainActor
 @Observable
 final class LibraryModel {
-    enum Section: Hashable {
-        case queue
-        case searchResults
-        case albums
-        case artists
-        case favourites
-        case playHistory
-        case snapshots
-    }
+    typealias Section = Navigator.Section
 
     let engine: KoanEngine
 
-    var section: Section = .queue {
-        didSet {
-            guard section != oldValue else { return }
-            // Each section is its own stack conceptually; carrying a path
-            // across a switch would strand you on an unrelated detail view.
-            path = NavigationPath()
-            // A filter you left behind on another view is invisible here, and
-            // an apparently empty library is the result.
-            filter = ""
-            load()
-            if !navigatingHistory { record(.section(section)) }
-        }
+    /// What is on screen. Written only by the navigator, which owns it — the
+    /// library follows where you are, it does not decide it.
+    private(set) var section: Section = .queue
+
+    /// The navigator moved. Catch up.
+    func showing(_ section: Section) {
+        guard section != self.section else { return }
+        self.section = section
+        // A filter you left behind on another view is invisible here, and an
+        // apparently empty library is the result.
+        filter = ""
+        load()
     }
 
     /// Substring filter over whatever the current section is showing.
@@ -87,16 +79,6 @@ final class LibraryModel {
     private(set) var snapshots: [Snapshot] = []
     private(set) var stats: Stats?
     private(set) var isLoading = false
-
-    /// The browse stack's path. Lives here so search can push a destination
-    /// rather than each browser owning a stack nothing else can reach.
-    var path = NavigationPath()
-
-    /// Back to the top of the current section, without leaving it.
-    func popToRoot() {
-        guard !path.isEmpty else { return }
-        path = NavigationPath()
-    }
 
     private(set) var detailTracks: [Track] = []
 
@@ -305,125 +287,6 @@ final class LibraryModel {
                 albumId: albumId, artistId: nil, sort: .album, limit: 500, offset: 0
             )) ?? []
         }
-    }
-
-    /// Show the queue. Called after anything that starts playback outright, so
-    /// you end up looking at what you just started. Not called for "add to
-    /// queue" or "play next" — those are things you do while browsing, and
-    /// being thrown across the app for them would be rude.
-    func showQueue() {
-        section = .queue
-    }
-
-    /// Show the queue once it holds what was just started.
-    ///
-    /// Queue mutations run off the main actor, so switching immediately shows
-    /// the old queue for a frame or two and then flickers. Waiting for the
-    /// engine to confirm avoids that — but only briefly: if the mutation is
-    /// slow enough to notice, jumping to the queue after the fact would feel
-    /// like the app moving on its own, so it stays put instead.
-    func showQueueWhenReady(watching player: PlayerModel) {
-        let before = player.queueVersion
-        Task {
-            let deadline = ContinuousClock.now + .milliseconds(50)
-            while ContinuousClock.now < deadline {
-                if player.queueVersion != before {
-                    section = .queue
-                    return
-                }
-                try? await Task.sleep(for: .milliseconds(5))
-            }
-        }
-    }
-
-    /// Jump straight to a thing from search: switch to the section it lives in,
-    /// then push its detail view.
-    /// The track that search sent you here for, so the album view can single it
-    /// out. Cleared once the view has scrolled to it.
-    var highlightedTrackId: Int64?
-
-    // MARK: - History
-    //
-    // A NavigationStack only goes back within one stack, so it can't return you
-    // across a section switch or a jump from search. This records every
-    // destination the user actually reached, which is what "back" means to
-    // someone using the app.
-
-    enum Destination: Hashable {
-        case section(Section)
-        case album(Int64)
-        case artist(Int64)
-    }
-
-    /// What the sidebar should highlight.
-    ///
-    /// Reaching an album from Favourites, from search, or from "Go to Album" in
-    /// the queue pushes a detail view without changing section, so the sidebar
-    /// went on pointing at wherever you started — which is not where you are.
-    /// The row an album lives under is Albums, whichever door you came through.
-    private(set) var history: [Destination] = [.section(.queue)]
-    private(set) var historyCursor = 0
-    /// Set while replaying history, so applying a destination doesn't record it
-    /// again and trap the user in a loop.
-    private var navigatingHistory = false
-
-    var canGoBack: Bool { historyCursor > 0 }
-    var canGoForward: Bool { historyCursor < history.count - 1 }
-
-    private func record(_ destination: Destination) {
-        // A new move discards anything ahead, the way a browser does.
-        if historyCursor < history.count - 1 {
-            history.removeSubrange((historyCursor + 1)...)
-        }
-        guard history.last != destination else { return }
-        history.append(destination)
-        historyCursor = history.count - 1
-    }
-
-    func goBack() {
-        guard canGoBack else { return }
-        historyCursor -= 1
-        apply(history[historyCursor])
-    }
-
-    func goForward() {
-        guard canGoForward else { return }
-        historyCursor += 1
-        apply(history[historyCursor])
-    }
-
-    private func apply(_ destination: Destination) {
-        navigatingHistory = true
-        defer { navigatingHistory = false }
-        switch destination {
-        case .section(let target):
-            section = target
-            path = NavigationPath()
-        case .album(let id):
-            path = NavigationPath()
-            path.append(AlbumRoute(id: id))
-        case .artist(let id):
-            path = NavigationPath()
-            path.append(ArtistRoute(id: id))
-        }
-    }
-
-    /// Push a destination onto the current stack.
-    ///
-    /// Deliberately does *not* switch `section` first. Doing so swaps the
-    /// stack's root view in the same update, and SwiftUI discards the path
-    /// against the old root — which landed you on the plain album list instead
-    /// of the album. Pushing onto whatever stack is showing also gives you a
-    /// Back button to the results you came from.
-    func reveal(album id: Int64, highlighting trackId: Int64? = nil) {
-        highlightedTrackId = trackId
-        path.append(AlbumRoute(id: id))
-        if !navigatingHistory { record(.album(id)) }
-    }
-
-    func reveal(artist id: Int64) {
-        path.append(ArtistRoute(id: id))
-        if !navigatingHistory { record(.artist(id)) }
     }
 
     // MARK: - Mutations

--- a/apps/macos/Sources/Koan/Support/Navigator.swift
+++ b/apps/macos/Sources/Koan/Support/Navigator.swift
@@ -1,0 +1,234 @@
+import SwiftUI
+
+/// A pushed destination.
+///
+/// One enum rather than a type per kind. A `NavigationStack` matches
+/// destinations by type, so two `Int64`-shaped routes in one stack collide
+/// silently and send you to whichever was registered first. It also makes the
+/// stack a plain `Equatable` array, which is what lets the navigator tell a
+/// real move from SwiftUI echoing back what is already there.
+enum Route: Hashable {
+    case album(Int64)
+    case artist(Int64)
+
+    /// The section this thing lives in, for jumps that arrive from outside any
+    /// section — search, mainly.
+    var home: Navigator.Section {
+        switch self {
+        case .album: .albums
+        case .artist: .artists
+        }
+    }
+}
+
+/// Where the app is, as one value.
+///
+/// The section and the stack pushed on top of it move together or not at all.
+/// Splitting them is what made navigation unpredictable: a push could be undone
+/// by an unrelated update that only meant to change the section, and the
+/// symptom was always the same and always misleading — the click registered and
+/// nothing happened.
+struct Location: Hashable {
+    var section: Navigator.Section
+    var stack: [Route] = []
+}
+
+/// The one owner of where you are.
+///
+/// Nothing else writes the detail stack's path, and nothing derives state from
+/// it that can be written back. Every move — a section, a push, a pop, a
+/// history replay — goes through `go(to:)`, which is also the only place that
+/// records history, so back and forward can never disagree with the screen.
+///
+/// The library follows the location rather than the other way round: what is
+/// loaded is a consequence of where you are.
+@MainActor
+@Observable
+final class Navigator {
+    enum Section: Hashable, Identifiable {
+        case queue
+        case searchResults
+        case albums
+        case artists
+        case favourites
+        case playHistory
+        case snapshots
+
+        var id: Self { self }
+    }
+
+    private(set) var location = Location(section: .queue)
+
+    /// The track a jump was aimed at, so the album view can single it out
+    /// rather than dropping you at the top of a twenty-track record. Cleared by
+    /// the view once it has scrolled to it.
+    var highlightedTrackId: Int64?
+
+    /// Every location actually reached. A `NavigationStack` only goes back
+    /// within one stack, so it cannot return you across a section switch or a
+    /// jump from search — which is what "back" means to someone using the app.
+    private var history: [Location] = [Location(section: .queue)]
+    private var cursor = 0
+
+    private let library: LibraryModel
+
+    init(library: LibraryModel) {
+        self.library = library
+    }
+
+    var section: Section { location.section }
+    var canGoBack: Bool { cursor > 0 }
+    var canGoForward: Bool { cursor < history.count - 1 }
+
+    // MARK: - Moves
+
+    /// A section, at its root. Asking for the section you are already in comes
+    /// back out of whatever you pushed onto it, which is what ⌘2 on an album
+    /// page should do.
+    func show(_ section: Section) {
+        go(to: Location(section: section))
+    }
+
+    /// Push onto whatever is showing, so Back returns you to the door you came
+    /// through rather than to a list you never visited.
+    func open(album id: Int64, highlighting trackId: Int64? = nil) {
+        highlightedTrackId = trackId
+        push(.album(id))
+    }
+
+    func open(artist id: Int64) {
+        push(.artist(id))
+    }
+
+    /// Land in the section a thing lives in, with the thing pushed.
+    ///
+    /// For arrivals from search: the results page exists only while there is a
+    /// query, so pushing onto it would leave you standing on a root that is
+    /// about to empty. Back returns to what you were doing before you searched.
+    func jump(to route: Route, highlighting trackId: Int64? = nil) {
+        highlightedTrackId = trackId
+        go(to: Location(section: route.home, stack: [route]))
+    }
+
+    func goBack() {
+        guard canGoBack else { return }
+        cursor -= 1
+        apply(history[cursor])
+    }
+
+    func goForward() {
+        guard canGoForward else { return }
+        cursor += 1
+        apply(history[cursor])
+    }
+
+    /// Go somewhere recorded earlier, stack and all.
+    func go(to next: Location) {
+        guard next != location else { return }
+        apply(next)
+        // The cursor can already point here: `forget` prunes history without
+        // moving the screen, and what follows is usually a move back onto the
+        // entry it left the cursor on.
+        guard history[cursor] != next else { return }
+        // A new move discards anything ahead, the way a browser does.
+        if cursor < history.count - 1 {
+            history.removeSubrange((cursor + 1)...)
+        }
+        history.append(next)
+        cursor = history.count - 1
+    }
+
+    /// Drop a section from history. Search results only exist while there is a
+    /// query; once it is gone, they are not somewhere Back can return to.
+    func forget(_ section: Section) {
+        guard history.contains(where: { $0.section == section }) else { return }
+        // Whatever survives behind the cursor keeps its order, so the cursor
+        // lands on the entry it was on — or on the last one, if that entry was
+        // itself forgotten.
+        let surviving = history[..<cursor].filter { $0.section != section }.count
+        history.removeAll { $0.section == section }
+        if history.isEmpty { history = [location] }
+        cursor = min(surviving, history.count - 1)
+    }
+
+    private func push(_ route: Route) {
+        var next = location
+        next.stack.append(route)
+        go(to: next)
+    }
+
+    private func apply(_ next: Location) {
+        let changedSection = next.section != location.section
+        location = next
+        if changedSection { library.showing(next.section) }
+    }
+
+    // MARK: - Bindings
+
+    /// The detail stack's path.
+    ///
+    /// SwiftUI writes back through this whenever the stack believes its
+    /// contents changed, including writes carrying what is already there.
+    /// Comparing first is what makes those harmless — only a real change moves
+    /// anything, and a real change is a move like any other.
+    var stack: Binding<[Route]> {
+        Binding(
+            get: { self.location.stack },
+            set: { [weak self] written in
+                guard let self, written != location.stack else { return }
+                var next = location
+                next.stack = written
+                go(to: next)
+            }
+        )
+    }
+
+    /// What the sidebar highlights, and what clicking it means.
+    ///
+    /// Stored, never derived from the stack: deriving the highlight from the
+    /// path turned every push into a write, and the write popped the thing just
+    /// pushed. A write carrying the section already showing is discarded for
+    /// the same reason — a `List` writes back whenever it decides its selection
+    /// moved, which includes rebuilds it does for its own reasons, and the
+    /// Results row appearing or vanishing is one of those.
+    ///
+    /// So clicking the lit row does nothing. Back is the way out of a detail
+    /// view, from the toolbar or ⌘[, wherever you reached it from.
+    var sidebarSelection: Binding<Section?> {
+        Binding(
+            get: { self.location.section },
+            set: { [weak self] chosen in
+                guard let self, let chosen, chosen != location.section else { return }
+                show(chosen)
+            }
+        )
+    }
+
+    // MARK: - Playback
+
+    /// Show the queue once it holds what was just started.
+    ///
+    /// Called after anything that starts playback outright, so you end up
+    /// looking at what you started. Not called for "add to queue" or "play
+    /// next" — those are things you do while browsing, and being thrown across
+    /// the app for them would be rude.
+    ///
+    /// Queue mutations run off the main actor, so switching immediately shows
+    /// the old queue for a frame or two and then flickers. Waiting for the
+    /// engine to confirm avoids that — but only briefly: if the mutation is
+    /// slow enough to notice, jumping to the queue after the fact would feel
+    /// like the app moving on its own, so it stays put instead.
+    func showQueueWhenReady(watching player: PlayerModel) {
+        let before = player.queueVersion
+        Task {
+            let deadline = ContinuousClock.now + .milliseconds(50)
+            while ContinuousClock.now < deadline {
+                if player.queueVersion != before {
+                    show(.queue)
+                    return
+                }
+                try? await Task.sleep(for: .milliseconds(5))
+            }
+        }
+    }
+}

--- a/apps/macos/Sources/Koan/Support/SearchModel.swift
+++ b/apps/macos/Sources/Koan/Support/SearchModel.swift
@@ -16,6 +16,7 @@ import KoanFFI
 final class SearchModel {
     private let engine: KoanEngine
     private let library: LibraryModel
+    private let nav: Navigator
 
     var query: String = ""
 
@@ -25,12 +26,14 @@ final class SearchModel {
     private(set) var isSearching = false
 
     private var task: Task<Void, Never>?
-    /// Where to put the user back when they clear the field.
-    private var sectionBeforeSearch: LibraryModel.Section?
+    /// Where to put the user back when they clear the field — the whole
+    /// location, so a detail view you searched from is still there afterwards.
+    private var locationBeforeSearch: Location?
 
-    init(engine: KoanEngine, library: LibraryModel) {
+    init(engine: KoanEngine, library: LibraryModel, nav: Navigator) {
         self.engine = engine
         self.library = library
+        self.nav = nav
     }
 
     var isEmpty: Bool { artists.isEmpty && albums.isEmpty && tracks.isEmpty }
@@ -89,16 +92,16 @@ final class SearchModel {
         let text = query.trimmingCharacters(in: .whitespaces)
         guard !text.isEmpty else {
             clear()
-            if let previous = sectionBeforeSearch {
-                library.section = previous
-                sectionBeforeSearch = nil
+            if let previous = locationBeforeSearch {
+                nav.go(to: previous)
+                locationBeforeSearch = nil
             }
             return
         }
 
-        if library.section != .searchResults {
-            sectionBeforeSearch = library.section
-            library.section = .searchResults
+        if nav.section != .searchResults {
+            locationBeforeSearch = nav.location
+            nav.show(.searchResults)
         }
 
         isSearching = true
@@ -125,6 +128,9 @@ final class SearchModel {
 
     func clear() {
         task?.cancel()
+        // The results page only exists while there is a query, so it stops
+        // being somewhere Back can return to.
+        nav.forget(.searchResults)
         artists = []
         albums = []
         tracks = []
@@ -136,6 +142,6 @@ final class SearchModel {
     func reset() {
         query = ""
         clear()
-        sectionBeforeSearch = nil
+        locationBeforeSearch = nil
     }
 }

--- a/apps/macos/Sources/Koan/Views/AlbumGridCell.swift
+++ b/apps/macos/Sources/Koan/Views/AlbumGridCell.swift
@@ -10,6 +10,7 @@ struct AlbumGridCell: View {
     var showArtist: Bool = true
 
     @Environment(PlayerModel.self) private var player
+    @Environment(Navigator.self) private var nav
     @Environment(LibraryModel.self) private var library
 
     @State private var titleHovering = false
@@ -53,7 +54,7 @@ struct AlbumGridCell: View {
                 .lineLimit(1)
                 .contentShape(.rect)
                 .onHover { titleHovering = $0 }
-                .onTapGesture { library.reveal(album: album.id) }
+                .onTapGesture { nav.open(album: album.id) }
 
             HStack(spacing: 4) {
                 if showArtist {

--- a/apps/macos/Sources/Koan/Views/ArtistBrowser.swift
+++ b/apps/macos/Sources/Koan/Views/ArtistBrowser.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 struct ArtistBrowser: View {
     @Environment(LibraryModel.self) private var library
+    @Environment(Navigator.self) private var nav
     /// Without a selection binding a List row has nothing to do with a click —
     /// which is why this list felt completely dead.
     @State private var selection: Set<Int64> = []
@@ -17,7 +18,7 @@ struct ArtistBrowser: View {
                 PlayableMenu(playable: .artist(id: artist.id, name: artist.name))
             }
         } primaryAction: { ids in
-            if let id = ids.first { library.reveal(artist: id) }
+            if let id = ids.first { nav.open(artist: id) }
         }
         .overlay {
             if library.visibleArtists.isEmpty {
@@ -90,6 +91,7 @@ struct ArtistDetailView: View {
     let artistId: Int64
 
     @Environment(LibraryModel.self) private var library
+    @Environment(Navigator.self) private var nav
     @Environment(PlayerModel.self) private var player
 
     @State private var albums: [Album] = []
@@ -172,7 +174,7 @@ struct ArtistDetailView: View {
         Task {
             let ids = ((try? await engine.randomTracks(count: 50, artistId: id)) ?? []).map(\.id)
             player.playNow(trackIds: ids)
-            library.showQueueWhenReady(watching: player)
+            nav.showQueueWhenReady(watching: player)
         }
     }
 }

--- a/apps/macos/Sources/Koan/Views/ArtistPill.swift
+++ b/apps/macos/Sources/Koan/Views/ArtistPill.swift
@@ -10,6 +10,7 @@ struct ArtistPill: View {
     var detail: String?
 
     @Environment(LibraryModel.self) private var library
+    @Environment(Navigator.self) private var nav
     @State private var hovering = false
 
     var body: some View {
@@ -38,7 +39,7 @@ struct ArtistPill: View {
         .background(hovering ? AnyShapeStyle(.tertiary) : AnyShapeStyle(.quaternary), in: Capsule())
         .contentShape(Capsule())
         .onHover { hovering = $0 }
-        .onTapGesture { library.reveal(artist: artistId) }
+        .onTapGesture { nav.open(artist: artistId) }
         .help("Go to \(name)")
         .contextMenu { PlayableMenu(playable: .artist(id: artistId, name: name)) }
         .draggablePlayable(.artist(id: artistId, name: name))

--- a/apps/macos/Sources/Koan/Views/HistoryView.swift
+++ b/apps/macos/Sources/Koan/Views/HistoryView.swift
@@ -14,6 +14,7 @@ import SwiftUI
 /// usual play/queue menu, but there is nothing here to reorder or remove.
 struct HistoryView: View {
     @Environment(LibraryModel.self) private var library
+    @Environment(Navigator.self) private var nav
     @Environment(PlayerModel.self) private var player
     @State private var selection: Set<Int64> = []
     @State private var confirmingClear = false
@@ -91,7 +92,7 @@ struct HistoryView: View {
         let chosen = tracks(for: ids)
         guard !chosen.isEmpty else { return }
         player.playNow(trackIds: chosen.map(\.id))
-        library.showQueueWhenReady(watching: player)
+        nav.showQueueWhenReady(watching: player)
     }
 
     /// Forgets the selected plays. The tracks themselves are untouched —
@@ -112,7 +113,7 @@ struct HistoryView: View {
             let trackIds = chosen.map(\.id)
             Button("Play") {
                 player.playNow(trackIds: trackIds)
-                library.showQueueWhenReady(watching: player)
+                nav.showQueueWhenReady(watching: player)
             }
             Button("Play Next") { player.playNext(trackIds: trackIds) }
             Button("Add to Queue") { player.enqueue(trackIds: trackIds) }

--- a/apps/macos/Sources/Koan/Views/LinkText.swift
+++ b/apps/macos/Sources/Koan/Views/LinkText.swift
@@ -22,6 +22,7 @@ struct LinkText: View {
     var prominent = false
 
     @Environment(LibraryModel.self) private var library
+    @Environment(Navigator.self) private var nav
     @State private var hovering = false
 
     private func transfer(for target: Target) -> PlayableTransfer {
@@ -54,8 +55,8 @@ struct LinkText: View {
                 }
                 .onTapGesture {
                     switch target {
-                    case .artist(let id): library.reveal(artist: id)
-                    case .album(let id): library.reveal(album: id)
+                    case .artist(let id): nav.open(artist: id)
+                    case .album(let id): nav.open(album: id)
                     }
                 }
                 // Dragging the name drags what it names, which is not
@@ -80,6 +81,7 @@ struct PlayableArtwork: View {
     var cornerRadius: CGFloat = 6
 
     @Environment(PlayerModel.self) private var player
+    @Environment(Navigator.self) private var nav
     @Environment(LibraryModel.self) private var library
     @State private var hovering = false
     @State private var loading = false
@@ -124,7 +126,7 @@ struct PlayableArtwork: View {
             )) ?? []).map(\.id)
             loading = false
             player.playNow(trackIds: ids)
-            library.showQueueWhenReady(watching: player)
+            nav.showQueueWhenReady(watching: player)
         }
     }
 }

--- a/apps/macos/Sources/Koan/Views/PickerSheet.swift
+++ b/apps/macos/Sources/Koan/Views/PickerSheet.swift
@@ -11,6 +11,7 @@ struct PickerSheet: View {
     @Binding var isPresented: Bool
 
     @Environment(PlayerModel.self) private var player
+    @Environment(Navigator.self) private var nav
     @Environment(LibraryModel.self) private var library
 
     @State private var kind: SearchKind = .track
@@ -218,7 +219,7 @@ struct PickerSheet: View {
                 }
             case .replace:
                 player.playNow(trackIds: trackIds)
-                library.showQueueWhenReady(watching: player)
+                nav.showQueueWhenReady(watching: player)
             }
             isPresented = false
         }

--- a/apps/macos/Sources/Koan/Views/PlayableMenu.swift
+++ b/apps/macos/Sources/Koan/Views/PlayableMenu.swift
@@ -47,6 +47,7 @@ struct PlayableMenu: View {
     let playable: Playable
 
     @Environment(PlayerModel.self) private var player
+    @Environment(Navigator.self) private var nav
     @Environment(LibraryModel.self) private var library
     @Environment(OrganizeModel.self) private var organize
     @Environment(\.openWindow) private var openWindow
@@ -55,7 +56,7 @@ struct PlayableMenu: View {
         Button("Play") {
             act {
                 player.playNow(trackIds: $0)
-                library.showQueueWhenReady(watching: player)
+                nav.showQueueWhenReady(watching: player)
             }
         }
         Button("Play Next") { act { player.playNext(trackIds: $0) } }
@@ -64,7 +65,7 @@ struct PlayableMenu: View {
             Button("Shuffle") {
                 act {
                     player.playNow(trackIds: $0.shuffled())
-                    library.showQueueWhenReady(watching: player)
+                    nav.showQueueWhenReady(watching: player)
                 }
             }
         }
@@ -82,15 +83,15 @@ struct PlayableMenu: View {
 
         if case .track(let track) = playable, let albumId = track.albumId {
             Divider()
-            Button("Go to Album") { library.reveal(album: albumId, highlighting: track.id) }
+            Button("Go to Album") { nav.open(album: albumId, highlighting: track.id) }
             if let artistId = track.artistId {
-                Button("Go to Artist") { library.reveal(artist: artistId) }
+                Button("Go to Artist") { nav.open(artist: artistId) }
             }
         }
         if case .album(let album) = playable {
             Divider()
-            Button("Go to Album") { library.reveal(album: album.id) }
-            Button("Go to Artist") { library.reveal(artist: album.artistId) }
+            Button("Go to Album") { nav.open(album: album.id) }
+            Button("Go to Artist") { nav.open(artist: album.artistId) }
         }
     }
 
@@ -267,6 +268,7 @@ struct PlayableHeaderButton: View {
     let playable: Playable
 
     @Environment(PlayerModel.self) private var player
+    @Environment(Navigator.self) private var nav
     @Environment(LibraryModel.self) private var library
     @State private var loading = false
 
@@ -280,7 +282,7 @@ struct PlayableHeaderButton: View {
                 let ids = await playable.trackIds(using: engine)
                 loading = false
                 player.playNow(trackIds: ids)
-                library.showQueueWhenReady(watching: player)
+                nav.showQueueWhenReady(watching: player)
             }
         } label: {
             ZStack {

--- a/apps/macos/Sources/Koan/Views/QueueView.swift
+++ b/apps/macos/Sources/Koan/Views/QueueView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 /// separate visits to the same record into one heading would misrepresent it.
 struct QueueView: View {
     @Environment(PlayerModel.self) private var player
+    @Environment(Navigator.self) private var nav
     @Environment(LibraryModel.self) private var library
     @Environment(OrganizeModel.self) private var organize
     @Environment(\.openWindow) private var openWindow
@@ -209,7 +210,7 @@ struct QueueView: View {
                 player.report("That track is no longer in the library.")
                 return
             }
-            library.reveal(album: albumId, highlighting: highlight ? trackId : nil)
+            nav.open(album: albumId, highlighting: highlight ? trackId : nil)
         }
     }
 

--- a/apps/macos/Sources/Koan/Views/RootView.swift
+++ b/apps/macos/Sources/Koan/Views/RootView.swift
@@ -15,14 +15,15 @@ import SwiftUI
 /// `safeAreaInset` and the lyrics panel an `inspector` for the same reason —
 /// both add chrome without taking the detail column's width away.
 ///
-/// There is one `NavigationStack` for the whole detail column, and its path
-/// lives on `LibraryModel`. Per-browser stacks can't be driven from outside,
-/// and search needs to push you into one.
+/// There is one `NavigationStack` for the whole detail column and one owner of
+/// its path, `Navigator`. Per-browser stacks can't be driven from outside, and
+/// search needs to push you into one.
 struct RootView: View {
     let hotkeys: Hotkeys
 
     @Environment(UIState.self) private var ui
     @Environment(LibraryModel.self) private var library
+    @Environment(Navigator.self) private var nav
     @Environment(SearchModel.self) private var search
     @Environment(PlayerModel.self) private var player
 
@@ -38,8 +39,8 @@ struct RootView: View {
             SidebarView(bottomInset: transportHeight)
                 .navigationSplitViewColumnWidth(min: 190, ideal: 215, max: 290)
         } detail: {
-            NavigationStack(path: $library.path) {
-                stage
+            NavigationStack(path: nav.stack) {
+                StageView()
                     // The transport is a safeAreaInset on the split view, which
                     // reserves space in the *window* but not inside the detail
                     // column's own scroll views — a List draws its last rows
@@ -54,13 +55,15 @@ struct RootView: View {
                     // destinations, next to the pair we already have — three
                     // chevrons in a row. Ours can cross sections and search
                     // jumps, which the stack's cannot, so the stack's goes.
-                    .navigationDestination(for: AlbumRoute.self) { route in
-                        AlbumDetailView(albumId: route.id)
-                            .navigationBarBackButtonHidden(true)
-                    }
-                    .navigationDestination(for: ArtistRoute.self) { route in
-                        ArtistDetailView(artistId: route.id)
-                            .navigationBarBackButtonHidden(true)
+                    .navigationDestination(for: Route.self) { route in
+                        switch route {
+                        case .album(let id):
+                            AlbumDetailView(albumId: id)
+                                .navigationBarBackButtonHidden(true)
+                        case .artist(let id):
+                            ArtistDetailView(artistId: id)
+                                .navigationBarBackButtonHidden(true)
+                        }
                     }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -104,16 +107,16 @@ struct RootView: View {
             // Spans section switches and search jumps, which a NavigationStack's
             // own back button cannot — it only knows about one stack.
             ToolbarItemGroup(placement: .navigation) {
-                Button { library.goBack() } label: {
+                Button { nav.goBack() } label: {
                     Label("Back", systemImage: "chevron.left")
                 }
-                .disabled(!library.canGoBack)
+                .disabled(!nav.canGoBack)
                 .help("Back (⌘[)")
 
-                Button { library.goForward() } label: {
+                Button { nav.goForward() } label: {
                     Label("Forward", systemImage: "chevron.right")
                 }
-                .disabled(!library.canGoForward)
+                .disabled(!nav.canGoForward)
                 .help("Forward (⌘])")
             }
 
@@ -126,10 +129,10 @@ struct RootView: View {
 
             // Filtering what is on screen belongs with it, not in the sidebar
             // search, which navigates away instead of narrowing.
-            if library.section == .albums || library.section == .artists {
+            if nav.section == .albums || nav.section == .artists {
                 ToolbarItem(placement: .primaryAction) {
                     FilterField(
-                        placeholder: library.section == .albums
+                        placeholder: nav.section == .albums
                             ? "Filter albums" : "Filter artists",
                         text: $library.filter,
                         focusToken: ui.filterFocusToken
@@ -139,7 +142,7 @@ struct RootView: View {
             }
 
             // Sort belongs next to what it sorts, so it only appears there.
-            if library.section == .albums {
+            if nav.section == .albums {
                 // A pull-down with the current choice ticked, the way Finder's
                 // arrange control works — rather than a picker forced to a
                 // fixed width, which reads as a control that did not fit.
@@ -211,29 +214,35 @@ struct RootView: View {
     /// naming exactly what was chosen — or it means "show me everything".
     private func handleSubmit() {
         guard let selection = SearchModel.Selection(token: search.query) else {
-            library.section = .searchResults
+            nav.show(.searchResults)
             return
         }
         switch selection {
         case .track(let id, let albumId):
             // A track lives on its album; that's where you'd play it from.
-            if let albumId { library.reveal(album: albumId, highlighting: id) }
+            if let albumId { nav.jump(to: .album(albumId), highlighting: id) }
         case .album(let id):
-            library.reveal(album: id)
+            nav.jump(to: .album(id))
         case .artist(let id):
-            library.reveal(artist: id)
+            nav.jump(to: .artist(id))
         }
-        // Emptying the field is its own update. The results page is the stack's
-        // root when a suggestion is picked, and clearing the query swaps what
-        // that root draws in the same pass as the push — the case `reveal()`
-        // warns about, where the destination is discarded against the root it
-        // was pushed onto and you are left looking at an empty results page.
-        Task { @MainActor in search.reset() }
+        search.reset()
     }
+}
 
-    @ViewBuilder
-    private var stage: some View {
-        switch library.section {
+/// The root of the detail stack.
+///
+/// A view of its own rather than a `switch` written inline: a `NavigationStack`
+/// discards its path when its root changes identity in the same update, and
+/// each branch of a `switch` in a `ViewBuilder` is a different view. Keeping
+/// the switch one level inside gives the stack a root that never changes, which
+/// is what lets the section and the stack move together.
+private struct StageView: View {
+    @Environment(LibraryModel.self) private var library
+    @Environment(Navigator.self) private var nav
+
+    var body: some View {
+        switch nav.section {
         case .queue:
             QueueView()
         case .searchResults:

--- a/apps/macos/Sources/Koan/Views/RowPlayButton.swift
+++ b/apps/macos/Sources/Koan/Views/RowPlayButton.swift
@@ -15,6 +15,7 @@ struct RowPlayButton: View {
     var inContext: (trackIds: [Int64], startAt: Int)?
 
     @Environment(PlayerModel.self) private var player
+    @Environment(Navigator.self) private var nav
     @Environment(LibraryModel.self) private var library
     @State private var loading = false
 
@@ -38,7 +39,7 @@ struct RowPlayButton: View {
         guard !loading else { return }
         if let context = inContext {
             player.playNow(trackIds: context.trackIds, startingAt: context.startAt)
-            library.showQueueWhenReady(watching: player)
+            nav.showQueueWhenReady(watching: player)
             return
         }
         loading = true
@@ -48,7 +49,7 @@ struct RowPlayButton: View {
             let ids = await playable.trackIds(using: engine)
             loading = false
             player.playNow(trackIds: ids)
-            library.showQueueWhenReady(watching: player)
+            nav.showQueueWhenReady(watching: player)
         }
     }
 }

--- a/apps/macos/Sources/Koan/Views/SearchResultsView.swift
+++ b/apps/macos/Sources/Koan/Views/SearchResultsView.swift
@@ -99,6 +99,7 @@ private struct SearchTrackRow: View {
     let track: Track
 
     @Environment(LibraryModel.self) private var library
+    @Environment(Navigator.self) private var nav
     @State private var hovering = false
 
     var body: some View {
@@ -146,7 +147,7 @@ private struct SearchTrackRow: View {
         .rowBehaviour(playable: .track(track))
         .onTapGesture {
             guard let albumId = track.albumId else { return }
-            library.reveal(album: albumId, highlighting: track.id)
+            nav.open(album: albumId, highlighting: track.id)
         }
         .contextMenu { PlayableMenu(playable: .track(track)) }
         .onHover { hovering = $0 }

--- a/apps/macos/Sources/Koan/Views/SidebarView.swift
+++ b/apps/macos/Sources/Koan/Views/SidebarView.swift
@@ -11,6 +11,7 @@ struct SidebarView: View {
     let bottomInset: CGFloat
 
     @Environment(LibraryModel.self) private var library
+    @Environment(Navigator.self) private var nav
     @Environment(PlayerModel.self) private var player
     @Environment(SearchModel.self) private var search
     @Environment(UIState.self) private var ui
@@ -20,26 +21,13 @@ struct SidebarView: View {
     @State private var queueDropTargeted = false
 
     var body: some View {
-        @Bindable var library = library
         @Bindable var search = search
 
-        // The lit row is the section being browsed, and nothing else. Deriving
-        // it from the detail stack — so that an album reached from anywhere lit
-        // Albums — meant pushing a destination moved the selection, and a List
-        // writes a moved selection back through its binding. The setter below
-        // then popped the path it had just been given, so a click on a search
-        // result registered and went nowhere.
-        List(selection: Binding(
-            get: { library.section },
-            set: { chosen in
-                guard let chosen else { return }
-                // Choosing a section always lands on its root — including the
-                // one you are already in, which is otherwise a trip out to
-                // another section and back.
-                library.section = chosen
-                library.popToRoot()
-            }
-        )) {
+        // The lit row is the section you are in, whatever you have pushed on
+        // top of it — that is where Back returns you to. The navigator owns
+        // both halves of the binding; see `sidebarSelection` for why the
+        // highlight is not derived from the stack.
+        List(selection: nav.sidebarSelection) {
             Section {
                 HStack {
                     Label("Queue", systemImage: "list.bullet")
@@ -48,7 +36,7 @@ struct SidebarView: View {
                         ProgressView().controlSize(.small)
                     }
                 }
-                    .tag(LibraryModel.Section.queue)
+                    .tag(Navigator.Section.queue)
                     // Full width, so the target is the row rather than just the
                     // text — dropping onto the empty part of the row should
                     // work, and a target you have to hit precisely is no target.
@@ -67,24 +55,24 @@ struct SidebarView: View {
                     )
                 if search.hasQuery {
                     Label("Results", systemImage: "magnifyingglass")
-                        .tag(LibraryModel.Section.searchResults)
+                        .tag(Navigator.Section.searchResults)
                 }
             }
 
             Section("Library") {
                 Label("Albums", systemImage: "square.stack")
-                    .tag(LibraryModel.Section.albums)
+                    .tag(Navigator.Section.albums)
                 Label("Artists", systemImage: "music.mic")
-                    .tag(LibraryModel.Section.artists)
+                    .tag(Navigator.Section.artists)
                 Label("Favourites", systemImage: "heart")
-                    .tag(LibraryModel.Section.favourites)
+                    .tag(Navigator.Section.favourites)
                 Label("History", systemImage: "clock.arrow.circlepath")
-                    .tag(LibraryModel.Section.playHistory)
+                    .tag(Navigator.Section.playHistory)
             }
 
             Section("Playlists") {
                 Label("Snapshots", systemImage: "bookmark")
-                    .tag(LibraryModel.Section.snapshots)
+                    .tag(Navigator.Section.snapshots)
             }
         }
         .listStyle(.sidebar)

--- a/apps/macos/Sources/Koan/Views/TrackListView.swift
+++ b/apps/macos/Sources/Koan/Views/TrackListView.swift
@@ -14,6 +14,7 @@ struct TrackListView: View {
     var playable: Playable?
 
     @Environment(PlayerModel.self) private var player
+    @Environment(Navigator.self) private var nav
     @Environment(LibraryModel.self) private var library
     @State private var selection: Set<Int64> = []
 
@@ -61,12 +62,12 @@ struct TrackListView: View {
                     // Arriving from search: single out the matched track rather
                     // than dropping the user at the top of a 20-track record.
                     .task(id: tracks.count) {
-                        guard let target = library.highlightedTrackId,
+                        guard let target = nav.highlightedTrackId,
                               tracks.contains(where: { $0.id == target })
                         else { return }
                         selection = [target]
                         withAnimation { proxy.scrollTo(target, anchor: .center) }
-                        library.highlightedTrackId = nil
+                        nav.highlightedTrackId = nil
                     }
                 }
             }
@@ -77,7 +78,7 @@ struct TrackListView: View {
     private func play(_ ids: Set<Int64>) {
         guard let index = tracks.firstIndex(where: { ids.contains($0.id) }) else { return }
         player.playNow(trackIds: tracks.map(\.id), startingAt: index)
-        library.showQueueWhenReady(watching: player)
+        nav.showQueueWhenReady(watching: player)
     }
 
     private func playSelection() { play(selection) }
@@ -92,7 +93,7 @@ struct TrackListView: View {
         } else if !chosen.isEmpty {
             Button("Play") {
                 player.playNow(trackIds: chosen.map(\.id))
-                library.showQueueWhenReady(watching: player)
+                nav.showQueueWhenReady(watching: player)
             }
             Button("Play Next") { player.playNext(trackIds: chosen.map(\.id)) }
             Button("Add to Queue") { player.enqueue(trackIds: chosen.map(\.id)) }


### PR DESCRIPTION
Closes #261

## What it does

`LibraryModel.path` had four independent writers — `section.didSet`, the sidebar's `List(selection:)` setter, history replay, and `reveal()` — and none knew the others existed. A push could be undone by an unrelated update landing in the same pass, and the symptom was always the same: the click registers and nothing happens.

`Navigator` is the single owner. One `Location` value holds `(section, stack)`; they move together or not at all. History is a list of `Location`s, so Back and Forward restore the whole thing rather than replaying a section and a route separately.

## Load-bearing decisions

- **The sidebar's highlight is stored, never derived from the stack.** A `List` writes a moved selection back through its binding, so deriving the highlight from the path turned every push into a write that popped it. On top of that, the setter now discards a write carrying the section already showing — indistinguishable from a click, but a `List` also emits those when it rebuilds for its own reasons (the Results row appearing or vanishing is one). Consequence: clicking the row you are already on does nothing; Back (toolbar or ⌘[) is the way out of a detail view.
- **The stack's root is `StageView`, a view of its own.** A `NavigationStack` discards its path when its root changes identity in the same update, and each branch of a `switch` in a `ViewBuilder` is a different view. Moving the switch one level inside gives the stack a root that never changes, which is what lets a section change and a push land together — and it removes the `Task { @MainActor in search.reset() }` deferral that worked around it.
- **One `Route` enum, not a struct per kind.** Destinations match by type, so two `Int64`-shaped routes collide silently. It also makes the stack an `Equatable` array, which is what lets the binding tell a real write from SwiftUI echoing what is already there.
- **Search jumps land in the thing's home section.** Picking a suggestion pushed onto the results page and then emptied the field, leaving you on a root about to go empty. `jump(to:)` goes to `(albums, [album])` instead, and `forget(.searchResults)` drops the results from history when the query goes — Back returns to what you were doing before you searched.
- **`LibraryModel` follows.** `section` is `private(set)` and written only by `Navigator` via `showing(_:)`; the library no longer navigates. `showQueueWhenReady` and `highlightedTrackId` moved to `Navigator` with it.

`Support/Routes.swift` is gone; the `AlbumSort` extension it also held moved to `Support/AlbumSort.swift` unchanged.

## Confirming it

Builds clean. The behaviour is interaction-shaped and worth a pass by hand:

- Search a track → pick the suggestion → you land on the album with the track selected, under Albums. Back returns to where you were before searching.
- "Go to Album" from the queue, an artist pill on an artist page, a track in Favourites — each pushes and Back returns to the door you came through.
- ⌘1–⌘6 and the sidebar rows switch section; ⌘2 while on an album page comes back out to the album grid.
- ⌘[ / ⌘] across a section switch, a push, and a search jump in sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HuFeu86s9Tvxpq9bMVEKvH