### PR TITLE
refactor(macos): drop the AppKit workarounds a macOS 14 floor needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Changed
 
+- **The macOS app drops the AppKit workarounds its old deployment target needed.** The floor is macOS 26, so: the hand cursor over a link is `.pointerStyle(.link)` rather than pushing and popping `NSCursor` — which leaked a cursor off the stack whenever a hovered row scrolled away; the artwork sheet sizes itself from a window `RootView` measures with `.onGeometryChange` rather than an `NSViewRepresentable` reaching for `sheetParent` and setting state from inside layout; Add Folder is `.fileImporter` rather than `NSOpenPanel.runModal()` spinning a nested run loop under the main actor; and the organize window no longer stamps its own `NSWindow.identifier`, because SwiftUI now puts the scene id there itself.
+
+  The single-key shortcuts ask for the main window by that scene id instead of naming the windows they must ignore, so a new window scene is no longer a bug waiting for someone to add it to the list. Six files stop importing AppKit; the seven that still do — the key monitor, the responder-chain edit commands, the pasteboard, `NSSearchField`, and Now Playing artwork — have no SwiftUI equivalent.
+
 - **The queue's album headings carry the record, not a label.** The cover was 22pt — too small to recognise a sleeve by — and the heading read as one run-on line of artist, album and year. Art is 52pt, and the text is the album, its artist, then year · track count · running time · codec, so a run in the queue says what it is without counting rows. The codec only shows when the whole run shares one.
 
 ## v0.28.0 (2026-08-24)

--- a/apps/macos/Sources/Koan/KoanApp.swift
+++ b/apps/macos/Sources/Koan/KoanApp.swift
@@ -81,7 +81,7 @@ struct KoanApp: App {
     @AppStorage("showLyrics") private var showLyrics = false
 
     var body: some Scene {
-        Window("koan", id: "main") {
+        Window("koan", id: MainWindow.id) {
             Group {
                 if let state {
                     RootView(hotkeys: state.hotkeys)
@@ -346,4 +346,11 @@ private struct StartupErrorView: View {
         .padding(40)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
+}
+
+/// The main window's scene id. SwiftUI puts it on the `NSWindow`, which is how
+/// the single-key shortcuts tell koan's own window from a sheet or one of the
+/// auxiliary scenes.
+enum MainWindow {
+    static let id = "main"
 }

--- a/apps/macos/Sources/Koan/Support/Hotkeys.swift
+++ b/apps/macos/Sources/Koan/Support/Hotkeys.swift
@@ -82,16 +82,16 @@ final class Hotkeys {
     /// The main window, or nil when focus is somewhere these keys have no
     /// business being — a sheet, the settings window, or the organize window,
     /// whose own controls are what a key should reach.
+    ///
+    /// SwiftUI stamps a scene's id onto its window, so asking for the one
+    /// window these keys belong to covers every other case at once: sheets
+    /// carry no identifier and the auxiliary scenes carry their own. Naming
+    /// them instead means each new window is a bug until someone remembers to
+    /// add it to the list.
     private var ownWindow: NSWindow? {
-        guard let window = NSApp.keyWindow else { return nil }
-        guard !window.isSheet, window.attachedSheet == nil else { return nil }
-        guard window.identifier?.rawValue != "com_apple_SwiftUI_Settings_window" else {
-            return nil
-        }
-        // Organize is its own window with its own field and its own Esc. Same
-        // reasoning as the settings window: its controls are what a key there
-        // should reach.
-        guard window.identifier?.rawValue != "organize" else { return nil }
+        guard let window = NSApp.keyWindow,
+              window.identifier?.rawValue == MainWindow.id
+        else { return nil }
         return window
     }
 }

--- a/apps/macos/Sources/Koan/Support/Pasteboard.swift
+++ b/apps/macos/Sources/Koan/Support/Pasteboard.swift
@@ -19,6 +19,13 @@ enum Pasteboard {
         }
     }
 
+    /// Plain text, for things that are only ever text — a share link.
+    static func write(text: String) {
+        let board = NSPasteboard.general
+        board.clearContents()
+        board.setString(text, forType: .string)
+    }
+
     static func readTrackIds() -> [Int64] {
         guard let data = NSPasteboard.general.data(forType: trackType),
               let ids = try? JSONDecoder().decode([Int64].self, from: data)

--- a/apps/macos/Sources/Koan/Support/SettingsModel.swift
+++ b/apps/macos/Sources/Koan/Support/SettingsModel.swift
@@ -1,4 +1,4 @@
-import AppKit
+import Foundation
 import KoanFFI
 import Observation
 
@@ -64,20 +64,10 @@ final class SettingsModel {
 
     // MARK: - Folders
 
-    /// Ask for a folder and add it. Music lives in one place per person, so the
-    /// panel starts at the last folder they picked rather than at the root.
-    func addFolder() {
-        let panel = NSOpenPanel()
-        panel.canChooseDirectories = true
-        panel.canChooseFiles = false
-        panel.allowsMultipleSelection = true
-        panel.prompt = "Add"
-        panel.message = "Choose a folder to scan for music"
-        guard panel.runModal() == .OK else { return }
-
-        let added = panel.urls.map(\.path)
+    /// Add folders to scan, ignoring any already listed.
+    func addFolders(_ paths: [String]) {
         edit { s in
-            for path in added where !s.libraryFolders.contains(where: { $0.path == path }) {
+            for path in paths where !s.libraryFolders.contains(where: { $0.path == path }) {
                 // Count comes back from the engine on the next read; the scan
                 // this kicks off is what fills it in.
                 s.libraryFolders.append(LibraryFolder(path: path, tracks: 0))

--- a/apps/macos/Sources/Koan/Support/UIState.swift
+++ b/apps/macos/Sources/Koan/Support/UIState.swift
@@ -1,3 +1,4 @@
+import CoreGraphics
 import Foundation
 import Observation
 
@@ -13,6 +14,13 @@ final class UIState {
     var showingPicker = false
     var showingArtwork = false
     var showingShortcuts = false
+
+    /// The main window's content size, measured by `RootView`.
+    ///
+    /// A sheet is bounded by the window it hangs from but cannot ask how big
+    /// that is — a `GeometryReader` inside one only ever sees the sheet's own
+    /// proposal. The window measures itself and leaves the answer here.
+    var windowSize: CGSize = .zero
 
     enum Edge { case top, bottom }
 

--- a/apps/macos/Sources/Koan/Views/ArtistBrowser.swift
+++ b/apps/macos/Sources/Koan/Views/ArtistBrowser.swift
@@ -177,7 +177,7 @@ struct ArtistDetailView: View {
     }
 }
 
-/// Wrapping row of chips. SwiftUI has no built-in flow layout on macOS 14.
+/// Wrapping row of chips. SwiftUI still has no built-in flow layout.
 struct FlowRow<Item: Identifiable, Content: View>: View {
     let items: [Item]
     @ViewBuilder let content: (Item) -> Content

--- a/apps/macos/Sources/Koan/Views/ArtworkViewer.swift
+++ b/apps/macos/Sources/Koan/Views/ArtworkViewer.swift
@@ -1,4 +1,3 @@
-import AppKit
 import KoanFFI
 import SwiftUI
 
@@ -13,16 +12,17 @@ struct ArtworkViewer: View {
     let subtitle: String?
 
     @Environment(\.dismiss) private var dismiss
-    @State private var host: CGSize = .zero
+    @Environment(UIState.self) private var ui
 
     /// Room for the caption below the cover, and the margin around the lot.
     private static let caption: CGFloat = 76
     private static let margin: CGFloat = 48
 
-    /// Covers are square, so the sheet has to be too — sized off the host
-    /// window rather than the sheet's own proposal, which AppKit answers with
-    /// a tall narrow box that leaves the cover no wider than a thumbnail.
+    /// Covers are square, so the sheet is too — sized off the window it hangs
+    /// from rather than its own proposal, which SwiftUI answers with a tall
+    /// narrow box that leaves the cover no wider than a thumbnail.
     private var side: CGFloat {
+        let host = ui.windowSize
         guard host != .zero else { return 700 }
         let width = host.width - Self.margin * 2
         let height = host.height - Self.margin * 2 - Self.caption
@@ -50,30 +50,10 @@ struct ArtworkViewer: View {
             .frame(height: Self.caption - 16)
         }
         .padding(Self.margin / 2)
-        .background(HostWindowSize(size: $host))
         // A click anywhere dismisses; there is no close button on a picture.
         .contentShape(.rect)
         .onTapGesture { dismiss() }
         .onExitCommand { dismiss() }
-    }
-}
-
-/// Reports the size of the window the sheet is attached to.
-///
-/// A sheet is bounded by its host window but cannot ask SwiftUI how big that
-/// is — `GeometryReader` only sees the sheet's own proposal. `sheetParent` is
-/// the window the sheet hangs from, which is the constraint that matters.
-private struct HostWindowSize: NSViewRepresentable {
-    @Binding var size: CGSize
-
-    func makeNSView(context: Context) -> NSView { NSView() }
-
-    func updateNSView(_ view: NSView, context: Context) {
-        DispatchQueue.main.async {
-            guard let host = view.window?.sheetParent ?? view.window else { return }
-            let frame = host.contentLayoutRect.size
-            if frame != size { size = frame }
-        }
     }
 }
 

--- a/apps/macos/Sources/Koan/Views/LinkText.swift
+++ b/apps/macos/Sources/Koan/Views/LinkText.swift
@@ -1,4 +1,3 @@
-import AppKit
 import KoanFFI
 import SwiftUI
 
@@ -41,17 +40,11 @@ struct LinkText: View {
                 )
                 .lineLimit(1)
                 .contentShape(.rect)
-                .onHover { inside in
-                    hovering = inside
-                    // `.pointerStyle(.link)` needs macOS 15; the app targets 14.
-                    if inside { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-                }
+                .pointerStyle(.link)
+                .onHover { hovering = $0 }
                 // A row that scrolls or filters away while hovered never sees
-                // the exit, and the hand cursor would be left on the stack.
-                .onDisappear {
-                    if hovering { NSCursor.pop() }
-                    hovering = false
-                }
+                // the exit, so it would come back still underlined.
+                .onDisappear { hovering = false }
                 .onTapGesture {
                     switch target {
                     case .artist(let id): library.reveal(artist: id)

--- a/apps/macos/Sources/Koan/Views/OrganizeSheet.swift
+++ b/apps/macos/Sources/Koan/Views/OrganizeSheet.swift
@@ -1,4 +1,3 @@
-import AppKit
 import KoanFFI
 import SwiftUI
 
@@ -324,12 +323,8 @@ struct OrganizeWindow: View {
 
     @Environment(OrganizeModel.self) private var organize
 
-    var body: some View {
-        content.background(WindowIdentity(Self.id))
-    }
-
     @ViewBuilder
-    private var content: some View {
+    var body: some View {
         if organize.subject != nil {
             OrganizeSheet()
         } else {
@@ -343,31 +338,3 @@ struct OrganizeWindow: View {
     }
 }
 
-/// Stamps an identifier on the hosting window.
-///
-/// The single-key shortcuts are the main window's, and they decide that by
-/// asking the key window what it is. A SwiftUI `Window` scene does not reliably
-/// carry its scene id onto the `NSWindow`, so it is put there rather than
-/// guessed at from the title.
-private struct WindowIdentity: NSViewRepresentable {
-    let id: String
-
-    init(_ id: String) { self.id = id }
-
-    func makeNSView(context: Context) -> NSView {
-        let view = IdentifyingView()
-        view.id = id
-        return view
-    }
-
-    func updateNSView(_ view: NSView, context: Context) {}
-
-    private final class IdentifyingView: NSView {
-        var id = ""
-
-        override func viewDidMoveToWindow() {
-            super.viewDidMoveToWindow()
-            window?.identifier = NSUserInterfaceItemIdentifier(id)
-        }
-    }
-}

--- a/apps/macos/Sources/Koan/Views/PlayableMenu.swift
+++ b/apps/macos/Sources/Koan/Views/PlayableMenu.swift
@@ -1,4 +1,3 @@
-import AppKit
 import KoanFFI
 import SwiftUI
 
@@ -194,8 +193,7 @@ enum Share {
     private static func deliver(_ result: Result<KoanFFI.Share, Error>, to player: PlayerModel) {
         switch result {
         case .success(let share):
-            NSPasteboard.general.clearContents()
-            NSPasteboard.general.setString(share.url, forType: .string)
+            Pasteboard.write(text: share.url)
             if share.skipped > 0 {
                 player.report(
                     "Share link copied — \(share.shared) of \(share.shared + share.skipped) tracks; "

--- a/apps/macos/Sources/Koan/Views/RootView.swift
+++ b/apps/macos/Sources/Koan/Views/RootView.swift
@@ -100,6 +100,7 @@ struct RootView: View {
             )
         }
         .onPreferenceChange(TransportHeightKey.self) { transportHeight = $0 }
+        .onGeometryChange(for: CGSize.self) { $0.size } action: { ui.windowSize = $0 }
         .toolbar {
             // Spans section switches and search jumps, which a NavigationStack's
             // own back button cannot — it only knows about one stack.

--- a/apps/macos/Sources/Koan/Views/SettingsView.swift
+++ b/apps/macos/Sources/Koan/Views/SettingsView.swift
@@ -1,5 +1,6 @@
 import KoanFFI
 import SwiftUI
+import UniformTypeIdentifiers
 
 /// Everything needed to set koan up, without opening a terminal.
 ///
@@ -82,6 +83,7 @@ private struct LibrarySettings: View {
     @Environment(ActivityModel.self) private var activity
     @State private var confirmingRebuild = false
     @State private var removing: LibraryFolder?
+    @State private var choosingFolder = false
 
     var body: some View {
         Form {
@@ -111,7 +113,7 @@ private struct LibrarySettings: View {
                         .help("Stop scanning this folder")
                     }
                 }
-                Button("Add Folder…") { model.addFolder() }
+                Button("Add Folder…") { choosingFolder = true }
                     .disabled(activity.isLibraryBusy)
             } header: {
                 Text("Folders")
@@ -185,6 +187,14 @@ private struct LibrarySettings: View {
             Button("Cancel", role: .cancel) { removing = nil }
         } message: {
             Text("Your files are not touched either way. Keeping them leaves records in the library that koan will not scan again.")
+        }
+        .fileImporter(
+            isPresented: $choosingFolder,
+            allowedContentTypes: [.folder],
+            allowsMultipleSelection: true
+        ) { result in
+            guard case .success(let urls) = result else { return }
+            model.addFolders(urls.map(\.path))
         }
     }
 }

--- a/apps/macos/Sources/Koan/Views/SidebarView.swift
+++ b/apps/macos/Sources/Koan/Views/SidebarView.swift
@@ -1,4 +1,3 @@
-import AppKit
 import KoanFFI
 import SwiftUI
 


### PR DESCRIPTION
The macOS app targets macOS 26. A handful of AppKit stand-ins were written against a macOS 14 floor and no longer earn their place.

Closes #243

## What changed

| Was | Now |
|---|---|
| `NSCursor.pointingHand.push()` / `.pop()` on hover, plus an `onDisappear` to pop the one a scrolled-away row never popped | `.pointerStyle(.link)` |
| `NSViewRepresentable` → `window.sheetParent.contentLayoutRect`, written back from a `DispatchQueue.main.async` inside `updateNSView` | `RootView` measures itself with `.onGeometryChange` into `UIState.windowSize`; the sheet reads it |
| `NSOpenPanel.runModal()` called from a `@MainActor` model | `.fileImporter` on the view |
| `OrganizeWindow` stamping `NSWindow.identifier` from a hosting `NSView` | nothing — SwiftUI puts the scene id on the window itself |
| `Hotkeys.ownWindow` excluding `com_apple_SwiftUI_Settings_window` and `"organize"` by name | asks for `MainWindow.id`, so every other window is excluded by default |
| `Share.deliver` writing `NSPasteboard.general` directly | `Pasteboard.write(text:)`, next to the other copy paths |

Six files stop importing AppKit (`LinkText`, `ArtworkViewer`, `SidebarView` — where it was unused — `OrganizeSheet`, `SettingsModel`, `PlayableMenu`). The seven that keep it have no SwiftUI equivalent: the key-down monitor, the responder-chain edit commands and the text-focus notifications behind them, `NSPasteboard`, `NSSearchField`, Now Playing artwork, and cover-art decode.

## The load-bearing decision

Flipping the hotkey window check from a denylist to `identifier == MainWindow.id` is what lets `WindowIdentity` go, and it rests on SwiftUI stamping scene ids onto `NSWindow`. That was measured, not assumed — a throwaway SwiftUI app on this toolchain reports:

```
main     identifier=main
aux      identifier=aux                              (Window(id: "aux"))
settings identifier=com_apple_SwiftUI_Settings_window
sheet    identifier=<nil>  isSheet=true
```

Sheets carry no identifier and auxiliary scenes carry their own, so one positive check covers all three cases the denylist enumerated — and a window scene added later is excluded without anyone remembering to add it.

## Deliberate loss

`.fileImporter` cannot set the open panel's `message` or `prompt`, so "Choose a folder to scan for music" / "Add" are gone. The panel is still folder-only and the button beside it says "Add Folder…". Worth it to stop `runModal()` spinning a nested run loop under the main actor mid-update.

(If you open it on this machine you may still see the old message — the system open-panel service caches per-app panel configuration. The string is not in the binary: `strings … | grep -c "Choose a folder to scan for music"` → 0.)

## How to confirm it works

Built and run, not just compiled:

- **⌘Z on a cover** — full-size square viewer, sized to the window as before; Escape dismisses. This exercises both the hotkey window check and the new sheet sizing.
- **Settings → Library → Add Folder…** — opens a folder-restricted panel; Cancel is clean.
- Hover an artist or album name anywhere — hand cursor, underline, and no stuck cursor after the row scrolls off.
- Organize is still its own window and still keeps the bare keys out of it.

`swift build -c release` clean. No Rust touched. `just macos-test` reports no test targets, which is pre-existing.