### PR TITLE
perf(core): stop reading the cover art a scan throws away

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -241,6 +241,7 @@ Advancing parks on the next item that is not `Failed`, including one still downl
 |---|---|
 | `scanner.rs` | Parallel library scan: walkdir → rayon metadata extraction → sequential DB upsert, one transaction per 1000-file chunk |
 | `metadata.rs` | Tag reading via lofty (ID3, Vorbis, MP4, etc.), codec detection from extension |
+| `id3v2_pictures.rs` | MP3 tag reads with the embedded art held back — walks the ID3v2 frame headers and serves lofty zeros over the picture frames it would only discard |
 
 ### `format/`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- **Scanning stops reading the cover art it throws away.** `ParseOptions::read_cover_art(false)` tells lofty not to *decode* a picture frame, not to skip it: holding nothing but a `Read`, it streams the frame into `io::sink()`. Embedded art is around 95% of the average ID3v2 tag, so a 48,000-file library spent 4.1 GiB of every scan pulling JPEGs off the disk to drop them on the floor. koan now walks the frame headers itself and hands lofty a reader that answers with zeros over the picture frames and the trailing padding — both of which lofty is contractually discarding — so those bytes never leave the disk. Over 4,000 real MP3s that is 865 MB unread, 216 KiB a file, with every tag and audio property parsing byte-for-byte as before. There is a per-file floor that bytes don't touch, so expect a scan to shorten by something nearer a fifth than a third. A tag the walk cannot mirror lofty over — unsynchronised v2.2/v2.3, an extended header, a frame ID that isn't one — is read the old way.
+
 - **The queue's album headings carry the record, not a label.** The cover was 22pt — too small to recognise a sleeve by — and the heading read as one run-on line of artist, album and year. Art is 52pt, and the text is the album, its artist, then year · track count · running time · codec, so a run in the queue says what it is without counting rows. The codec only shows when the whole run shares one.
 
 ## v0.28.0 (2026-08-24)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,7 @@ Pre-push hook (`.claude/settings.json`) runs `cargo fmt --all` + `cargo clippy -
 | `db/queries/` | Row types, upsert (3-strategy dedup), FTS5 search, scan cache, stats, snapshots, `batch` (SQL-side track filtering, batched parent→child reads) |
 | `index/scanner.rs` | Streaming library scan: walkdir → rayon tag reads → bounded channel → batched DB transactions. `ScanOptions` carries a cancel flag and an optional progress sink. `import_paths` indexes named files where they lie (Finder drops), removing nothing |
 | `index/metadata.rs` | Tag reading via lofty (ID3, Vorbis, MP4, APE), codec detection |
+| `index/id3v2_pictures.rs` | MP3 tag reads with the embedded art held back — walks the ID3v2 frame headers and serves lofty zeros over the picture frames it would only discard |
 | `format/` | fb2k-compatible template engine: parser (recursive descent), evaluator, 59 built-in functions |
 | `remote/client.rs` | Subsonic/Navidrome HTTP client (reqwest blocking, MD5+salt auth) |
 | `remote/download.rs` | Streaming downloads: `.part` → verify → atomic rename, progress, retries. All disk-bound remote bytes go through here |

--- a/crates/koan-core/src/index/id3v2_pictures.rs
+++ b/crates/koan-core/src/index/id3v2_pictures.rs
@@ -1,0 +1,357 @@
+//! Reading an MP3's tags without paying for the pictures in it.
+//!
+//! `ParseOptions::read_cover_art(false)` stops lofty *decoding* an APIC frame,
+//! not reading it: `id3::v2::frame::read::skip_frame` streams the frame into
+//! `io::sink()`, because at that point it holds nothing but a `Read`. Embedded
+//! art is 95% of the average ID3v2 tag, so a scan pulls it all off the disk and
+//! drops it on the floor — 4.1 GiB of it over a 48,000-file library.
+//!
+//! So we walk the frame headers ourselves first and hand lofty a reader that
+//! answers with zeros over each picture, never going to the disk for those
+//! bytes. lofty is contractually discarding them, so what it finds there cannot
+//! change what it parses — but only while our frame arithmetic matches its own
+//! exactly. Anything the walk cannot account for (an unsynchronised v2.2/v2.3
+//! tag, whose byte stuffing moves lofty's stream off the file's own offsets; an
+//! extended header; a frame ID that is not a frame ID) ends the walk, and the
+//! rest of the tag is read the ordinary way.
+
+use std::fs::File;
+use std::io::{self, BufReader, Read, Seek, SeekFrom};
+use std::path::Path;
+
+/// Open `path` with its ID3v2 pictures blanked out, ready to hand to lofty.
+///
+/// `None` if the file cannot be opened, leaving the caller to read it the
+/// ordinary way.
+pub(super) fn open(path: &Path) -> Option<BufReader<PictureFreeFile>> {
+    let mut file = File::open(path).ok()?;
+    let holes = discardable_ranges(&mut file);
+    file.seek(SeekFrom::Start(0)).ok()?;
+    Some(BufReader::new(PictureFreeFile {
+        file,
+        pos: 0,
+        file_pos: 0,
+        holes,
+    }))
+}
+
+/// A file with holes in it: reads inside one are answered with zeros and never
+/// reach the disk.
+pub(super) struct PictureFreeFile {
+    file: File,
+    /// Where the consumer is reading from.
+    pos: u64,
+    /// Where the file's own cursor is, so that reading straight through costs
+    /// no more seeks than reading the file directly would.
+    file_pos: u64,
+    /// Sorted, disjoint `[start, end)` byte ranges, in file offsets.
+    holes: Vec<(u64, u64)>,
+}
+
+impl PictureFreeFile {
+    /// The end of the hole `pos` falls inside, if it falls inside one.
+    fn hole_end(&self, pos: u64) -> Option<u64> {
+        self.holes
+            .iter()
+            .find(|(start, end)| pos >= *start && pos < *end)
+            .map(|(_, end)| *end)
+    }
+
+    /// The start of the first hole after `pos`, which is as far as a read from
+    /// `pos` may go.
+    fn next_hole(&self, pos: u64) -> u64 {
+        self.holes
+            .iter()
+            .map(|(start, _)| *start)
+            .find(|start| *start > pos)
+            .unwrap_or(u64::MAX)
+    }
+}
+
+impl Read for PictureFreeFile {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+
+        if let Some(end) = self.hole_end(self.pos) {
+            let n = buf.len().min((end - self.pos) as usize);
+            buf[..n].fill(0);
+            self.pos += n as u64;
+            return Ok(n);
+        }
+
+        let limit = self.next_hole(self.pos) - self.pos;
+        let n = buf.len().min(limit.min(usize::MAX as u64) as usize);
+
+        if self.file_pos != self.pos {
+            self.file.seek(SeekFrom::Start(self.pos))?;
+            self.file_pos = self.pos;
+        }
+        let read = self.file.read(&mut buf[..n])?;
+        self.pos += read as u64;
+        self.file_pos += read as u64;
+        Ok(read)
+    }
+}
+
+impl Seek for PictureFreeFile {
+    fn seek(&mut self, from: SeekFrom) -> io::Result<u64> {
+        let pos = match from {
+            SeekFrom::Start(n) => n,
+            // The only seek whose answer we don't already hold. Take the real
+            // file's word for the length rather than caching one.
+            SeekFrom::End(n) => {
+                let pos = self.file.seek(SeekFrom::End(n))?;
+                self.file_pos = pos;
+                pos
+            }
+            SeekFrom::Current(n) => self.pos.checked_add_signed(n).ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidInput, "seek before start of file")
+            })?,
+        };
+        self.pos = pos;
+        Ok(pos)
+    }
+
+    fn stream_position(&mut self) -> io::Result<u64> {
+        Ok(self.pos)
+    }
+}
+
+/// Frame ID for an attached picture, in ID3v2.3/v2.4 and in v2.2.
+const PICTURE_IDS: [&[u8]; 2] = [b"APIC", b"PIC"];
+
+/// The byte ranges of `file`'s ID3v2 tag that lofty reads only to throw away:
+/// every picture frame's payload, plus the tag's trailing padding.
+///
+/// Empty when there is nothing to skip, and short when the walk meets something
+/// it cannot mirror lofty with — the ranges it has by then are still exact, so
+/// there is no need to abandon them too.
+fn discardable_ranges(file: &mut File) -> Vec<(u64, u64)> {
+    let mut ranges = Vec::new();
+
+    let mut header = [0u8; 10];
+    if file.seek(SeekFrom::Start(0)).is_err()
+        || file.read_exact(&mut header).is_err()
+        || &header[..3] != b"ID3"
+    {
+        return ranges;
+    }
+
+    let version = header[3];
+    let flags = header[5];
+
+    if !matches!(version, 2..=4) {
+        return ranges;
+    }
+    // 0x40 is an extended header in v2.3/v2.4 and an unspecified compression
+    // scheme in v2.2. Either way the frames are not where they appear to be.
+    if flags & 0x40 != 0 {
+        return ranges;
+    }
+    // v2.4 unsynchronises per frame, inside the frame's own byte count, so
+    // frame boundaries stay on file offsets. Before that the stuffing applied
+    // to the whole tag, which moves every offset after the first 0xFF.
+    if flags & 0x80 != 0 && version < 4 {
+        return ranges;
+    }
+
+    let header_len: u64 = if version == 2 { 6 } else { 10 };
+    let tag_end = 10
+        + u64::from(unsynch(u32::from_be_bytes([
+            header[6], header[7], header[8], header[9],
+        ])));
+
+    let mut cursor = 10u64;
+    let mut frame = [0u8; 10];
+    loop {
+        if cursor + header_len > tag_end {
+            break;
+        }
+        let frame = &mut frame[..header_len as usize];
+        if file.seek(SeekFrom::Start(cursor)).is_err() || file.read_exact(frame).is_err() {
+            return ranges;
+        }
+
+        // A zero where a frame ID should be is the start of the padding, which
+        // is where lofty stops reading frames too.
+        if frame[0] == 0 {
+            break;
+        }
+
+        let (id, size) = if version == 2 {
+            (
+                &frame[..3],
+                u32::from_be_bytes([0, frame[3], frame[4], frame[5]]),
+            )
+        } else {
+            let size = u32::from_be_bytes([frame[4], frame[5], frame[6], frame[7]]);
+            // Only v2.4 stores frame sizes synchsafe. Some v2.3 writers put a
+            // v2.2 frame ID in a v2.3 header, which lofty upgrades in place.
+            let size = if version == 4 { unsynch(size) } else { size };
+            let id_end = if version == 3 && frame[3] == 0 { 3 } else { 4 };
+            (&frame[..id_end], size)
+        };
+
+        // Past a frame ID we can't read, we can no longer say where lofty is.
+        if !id
+            .iter()
+            .all(|b| b.is_ascii_uppercase() || b.is_ascii_digit())
+        {
+            return ranges;
+        }
+
+        let content = cursor + header_len;
+        let Some(end) = content
+            .checked_add(u64::from(size))
+            .filter(|end| *end <= tag_end)
+        else {
+            return ranges;
+        };
+
+        if PICTURE_IDS.contains(&id) && size > 0 {
+            ranges.push((content, end));
+        }
+        cursor = end;
+    }
+
+    // Whatever is left of the tag is padding, which lofty copies into a sink.
+    if cursor < tag_end {
+        ranges.push((cursor, tag_end));
+    }
+    ranges
+}
+
+/// Decode a synchsafe integer — seven bits to the byte.
+fn unsynch(n: u32) -> u32 {
+    ((n & 0x7F00_0000) >> 3) | ((n & 0x7F_0000) >> 2) | ((n & 0x7F00) >> 1) | (n & 0x7F)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::generate_mp3_with_picture;
+
+    const TITLE: &str = "Golden Skans";
+    const ARTIST: &str = "Klaxons";
+
+    /// Recognisably not zero, so a hole in the wrong place shows up as zeros
+    /// where real bytes should be.
+    fn picture() -> Vec<u8> {
+        (0..40_000u32).map(|i| (i % 251) as u8 + 1).collect()
+    }
+
+    fn write(dir: &Path, version: u8) -> (std::path::PathBuf, std::ops::Range<u64>) {
+        let path = dir.join(format!("v2{version}.mp3"));
+        let range = generate_mp3_with_picture(&path, version, TITLE, ARTIST, &picture());
+        (path, range)
+    }
+
+    /// The whole file as lofty sees it through the wrapper.
+    fn read_through(path: &Path) -> Vec<u8> {
+        let mut out = Vec::new();
+        open(path).unwrap().read_to_end(&mut out).unwrap();
+        out
+    }
+
+    #[test]
+    fn the_walk_finds_the_picture_and_the_padding() {
+        let dir = tempfile::tempdir().unwrap();
+        for version in [2, 3, 4] {
+            let (path, range) = write(dir.path(), version);
+            let ranges = discardable_ranges(&mut File::open(&path).unwrap());
+
+            assert_eq!(
+                ranges.first().copied(),
+                Some((range.start, range.end)),
+                "v2.{version}: picture payload not found"
+            );
+            assert_eq!(ranges.len(), 2, "v2.{version}: expected picture + padding");
+            let (start, end) = ranges[1];
+            assert_eq!(end - start, 64, "v2.{version}: padding");
+        }
+    }
+
+    /// The point of the exercise: those bytes never come off the disk.
+    #[test]
+    fn the_picture_reads_back_as_zeros_and_nothing_else_moves() {
+        let dir = tempfile::tempdir().unwrap();
+        for version in [2, 3, 4] {
+            let (path, range) = write(dir.path(), version);
+
+            let mut expected = std::fs::read(&path).unwrap();
+            for (start, end) in discardable_ranges(&mut File::open(&path).unwrap()) {
+                expected[start as usize..end as usize].fill(0);
+            }
+
+            let got = read_through(&path);
+            assert_eq!(got.len(), expected.len(), "v2.{version}: length");
+            assert_eq!(got, expected, "v2.{version}: contents");
+            assert!(
+                got[range.start as usize..range.end as usize]
+                    .iter()
+                    .all(|b| *b == 0),
+                "v2.{version}: picture should have read back as zeros"
+            );
+        }
+    }
+
+    /// Seeks land where they would on the real file, including from the end,
+    /// which is where lofty goes looking for ID3v1 and APE tags.
+    #[test]
+    fn seeking_matches_the_file_underneath() {
+        let dir = tempfile::tempdir().unwrap();
+        let (path, range) = write(dir.path(), 3);
+        let real = std::fs::read(&path).unwrap();
+
+        let mut reader = open(&path).unwrap();
+        assert_eq!(
+            reader.seek(SeekFrom::End(-128)).unwrap(),
+            real.len() as u64 - 128
+        );
+        let mut tail = [0u8; 128];
+        reader.read_exact(&mut tail).unwrap();
+        assert_eq!(&tail[..], &real[real.len() - 128..]);
+
+        // Back into the middle of the picture, which still answers with zeros.
+        reader.seek(SeekFrom::Start(range.start + 100)).unwrap();
+        let mut buf = [0xFFu8; 16];
+        reader.read_exact(&mut buf).unwrap();
+        assert_eq!(buf, [0u8; 16]);
+
+        assert_eq!(
+            reader.seek(SeekFrom::Current(-16)).unwrap(),
+            range.start + 100
+        );
+    }
+
+    /// A tag whose bytes are not where they look like they are gets no holes at
+    /// all — reading it wrong is far worse than reading it slowly.
+    #[test]
+    fn shapes_the_walk_cannot_mirror_are_left_alone() {
+        let dir = tempfile::tempdir().unwrap();
+
+        for (name, flags, version) in [
+            ("unsynchronised-v3", 0x80, 3),
+            ("extended-v4", 0x40, 4),
+            ("compressed-v2", 0x40, 2),
+        ] {
+            let (path, _) = write(dir.path(), version);
+            let mut bytes = std::fs::read(&path).unwrap();
+            bytes[5] = flags;
+            let path = dir.path().join(format!("{name}.mp3"));
+            std::fs::write(&path, &bytes).unwrap();
+
+            assert!(
+                discardable_ranges(&mut File::open(&path).unwrap()).is_empty(),
+                "{name}: should have been left alone"
+            );
+        }
+
+        // Not an ID3v2 tag at all.
+        let path = dir.path().join("no-tag.mp3");
+        std::fs::write(&path, b"\xFF\xFB\x90\x00not a tag at all").unwrap();
+        assert!(discardable_ranges(&mut File::open(&path).unwrap()).is_empty());
+    }
+}

--- a/crates/koan-core/src/index/metadata.rs
+++ b/crates/koan-core/src/index/metadata.rs
@@ -89,9 +89,23 @@ fn raise_allocation_limit() {
 /// single track actually needs artwork.
 fn read_tagged_file(path: &Path) -> Result<lofty::file::TaggedFile, Box<dyn std::error::Error>> {
     raise_allocation_limit();
-    Ok(lofty::probe::Probe::open(path)?
-        .options(ParseOptions::new().read_cover_art(false))
-        .read()?)
+    let options = ParseOptions::new().read_cover_art(false);
+
+    // An MP3's embedded art is read and discarded even under
+    // `read_cover_art(false)`, so it gets a reader that holds the pictures back
+    // rather than a plain file. See `id3v2_pictures`.
+    let file_type = lofty::file::FileType::from_path(path);
+    if file_type == Some(lofty::file::FileType::Mpeg)
+        && let Some(reader) = super::id3v2_pictures::open(path)
+    {
+        return Ok(
+            lofty::probe::Probe::with_file_type(reader, lofty::file::FileType::Mpeg)
+                .options(options)
+                .read()?,
+        );
+    }
+
+    Ok(lofty::probe::Probe::open(path)?.options(options).read()?)
 }
 
 /// Full metadata read via lofty (happy path).
@@ -805,5 +819,54 @@ mod tests {
             "ALAC",
             "real ALAC .m4a should be identified as ALAC, not AAC"
         );
+    }
+
+    /// The scan reads MP3 tags through a reader that blanks out the embedded
+    /// art (see `id3v2_pictures`). That is only sound if what comes back is
+    /// byte-for-byte what lofty would have parsed off the plain file.
+    #[test]
+    fn holding_the_pictures_back_changes_nothing_lofty_parses() {
+        let dir = tempfile::tempdir().unwrap();
+        let art: Vec<u8> = (0..40_000u32).map(|i| (i % 251) as u8 + 1).collect();
+
+        for version in [2, 3, 4] {
+            let path = dir.path().join(format!("v2{version}.mp3"));
+            crate::test_utils::generate_mp3_with_picture(
+                &path,
+                version,
+                "Golden Skans",
+                "Klaxons",
+                &art,
+            );
+
+            let held_back = read_tagged_file(&path).unwrap();
+            let plain = lofty::probe::Probe::open(&path)
+                .unwrap()
+                .options(ParseOptions::new().read_cover_art(false))
+                .read()
+                .unwrap();
+
+            let tags = |f: &lofty::file::TaggedFile| {
+                let tag = f.primary_tag().or_else(|| f.first_tag()).unwrap();
+                (
+                    tag.title().map(|s| s.to_string()),
+                    tag.artist().map(|s| s.to_string()),
+                )
+            };
+            assert_eq!(tags(&held_back), tags(&plain), "v2.{version}");
+            assert_eq!(
+                tags(&held_back),
+                (Some("Golden Skans".into()), Some("Klaxons".into())),
+                "v2.{version}: the frame after the picture must survive intact"
+            );
+            assert_eq!(
+                held_back.properties().duration(),
+                plain.properties().duration(),
+                "v2.{version}"
+            );
+
+            // And the art is still there for whoever actually wants it.
+            assert_eq!(extract_cover_art(&path), Some(art.clone()), "v2.{version}");
+        }
     }
 }

--- a/crates/koan-core/src/index/mod.rs
+++ b/crates/koan-core/src/index/mod.rs
@@ -1,3 +1,4 @@
 pub mod features;
+mod id3v2_pictures;
 pub mod metadata;
 pub mod scanner;

--- a/crates/koan-core/src/test_utils.rs
+++ b/crates/koan-core/src/test_utils.rs
@@ -165,3 +165,84 @@ pub fn generate_mp3_with_both_tags(path: &Path, id3v2_title: &str, id3v1_title: 
 
     std::fs::write(path, out).expect("failed to write MP3 file");
 }
+
+/// Generate an MP3 whose ID3v2 tag carries an embedded picture, at ID3v2 major
+/// version `version` (2, 3 or 4).
+///
+/// The artist frame is written *after* the picture on purpose: anything that
+/// miscounts the picture's length reads the artist out of the middle of a JPEG.
+/// Returns the picture frame's payload range in the file — the whole of what
+/// a tag reader skips, prefix included, not just the image bytes.
+pub fn generate_mp3_with_picture(
+    path: &Path,
+    version: u8,
+    title: &str,
+    artist: &str,
+    picture: &[u8],
+) -> std::ops::Range<u64> {
+    /// Encode a synchsafe integer — seven bits to the byte.
+    fn synch(n: u32) -> u32 {
+        (n & 0x7F)
+            | ((n & (0x7F << 7)) << 1)
+            | ((n & (0x7F << 14)) << 2)
+            | ((n & (0x7F << 21)) << 3)
+    }
+
+    let frame = |out: &mut Vec<u8>, id_v2: &str, id_v3: &str, body: &[u8]| {
+        let len = body.len() as u32;
+        if version == 2 {
+            out.extend_from_slice(id_v2.as_bytes());
+            out.extend_from_slice(&len.to_be_bytes()[1..]);
+        } else {
+            out.extend_from_slice(id_v3.as_bytes());
+            let len = if version == 4 { synch(len) } else { len };
+            out.extend_from_slice(&len.to_be_bytes());
+            out.extend_from_slice(&[0, 0]); // flags
+        }
+        out.extend_from_slice(body);
+    };
+
+    let mut frames: Vec<u8> = Vec::new();
+
+    let mut text = vec![0u8]; // ISO-8859-1
+    text.extend_from_slice(title.as_bytes());
+    frame(&mut frames, "TT2", "TIT2", &text);
+
+    let mut art = vec![0u8]; // ISO-8859-1
+    if version == 2 {
+        art.extend_from_slice(b"JPG");
+    } else {
+        art.extend_from_slice(b"image/jpeg\0");
+    }
+    art.push(3); // cover (front)
+    art.push(0); // empty description
+    art.extend_from_slice(picture);
+    let picture_start = frames.len() + if version == 2 { 6 } else { 10 };
+    let picture_len = art.len();
+    frame(&mut frames, "PIC", "APIC", &art);
+
+    let mut text = vec![0u8];
+    text.extend_from_slice(artist.as_bytes());
+    frame(&mut frames, "TP1", "TPE1", &text);
+
+    // Padding, which lofty reads and drops just as it does the picture.
+    let tag_len = frames.len() + 64;
+
+    let mut out: Vec<u8> = Vec::new();
+    out.extend_from_slice(b"ID3");
+    out.extend_from_slice(&[version, 0, 0]);
+    out.extend_from_slice(&synch(tag_len as u32).to_be_bytes());
+    out.extend_from_slice(&frames);
+    out.resize(10 + tag_len, 0);
+
+    // MPEG-1 Layer III, 128 kbps, 44.1 kHz, stereo — 417 bytes a frame.
+    for _ in 0..40 {
+        out.extend_from_slice(&[0xFF, 0xFB, 0x90, 0x00]);
+        out.extend_from_slice(&[0u8; 413]);
+    }
+
+    std::fs::write(path, out).expect("failed to write MP3 file");
+
+    let start = (10 + picture_start) as u64;
+    start..start + picture_len as u64
+}


### PR DESCRIPTION
Closes #232

`ParseOptions::read_cover_art(false)` tells lofty not to *decode* an APIC frame, not to skip it: `id3::v2::frame::read::skip_frame` holds nothing but a `Read`, so it streams the frame into `io::sink()`. Embedded art is around 95% of the average ID3v2 tag — a 48,000-file library spent 4.1 GiB of every scan pulling JPEGs off the disk to drop them on the floor.

## What it does

`index/id3v2_pictures.rs` walks the ID3v2 frame headers itself and wraps the file in a reader that answers with zeros over two kinds of byte range, never issuing a read for them:

- every picture frame's payload — `skip_frame` consumes exactly `size` bytes and discards them;
- the tag's trailing padding — `parse_id3v2` ends with `io::copy(rest, &mut sink())`.

`read_tagged_file` uses it for MP3s only; every other format goes through `Probe::open` exactly as before, as does `extract_cover_art`, which still reads the art with lofty's defaults for whichever single track wants it.

## The load-bearing decision

Serving zeros is only sound while our frame arithmetic matches lofty's *exactly* — a range off by one frame means text frames read back as zeros and the library gets silently wrong tags. So the walk mirrors `ParsedFrame::read` (v2.2 6-byte headers, v2.3 plain sizes, v2.4 synchsafe, the v2-frame-ID-in-a-v3-tag quirk) and gives up the moment it meets something it cannot account for: an unsynchronised v2.2/v2.3 tag, whose whole-tag byte stuffing moves lofty's stream off the file's own offsets; an extended header; a frame ID that is not a frame ID. Ranges found before the bail are still exact, so they are kept; the rest of the tag is read the ordinary way.

## What it buys

Measured to the issue's own rules — both arms inside one run, alternating file by file so each file is read exactly once and cold, over contiguous blocks of a real 23,700-MP3 library on the external QLC drive the issue profiled. Single-threaded, tag read only.

| block | arms | old | new | |
|---|---|---|---|---|
| 12,000 | as-is | 4.28 ms/file | 1.11 ms/file | 3.9x |
| 12,000 | as-is | 16.04 ms/file | 5.16 ms/file | 3.1x |
| 16,000 | as-is | 22.68 ms/file | 6.97 ms/file | 3.3x |
| 16,000 | swapped | 19.64 ms/file | 6.15 ms/file | 3.2x |
| 19,000 | swapped | 21.81 ms/file | 7.01 ms/file | 3.1x |
| 19,000 | as-is | 19.82 ms/file | 6.38 ms/file | 3.1x |

Read the ratios, not the absolutes: the old arm swung 4.3 → 22.7 ms/file between runs, which is the drive variance the issue warns invents or hides any effect. Swapping which arm gets the even-numbered files changes nothing, so the interleave is not just feeding one arm the other's readahead on adjacent files.

161–259 KiB a file stops being read, depending on the block. This is the tag read alone — a whole scan also walks directories and writes to SQLite, so it will not shorten by the same factor, though the issue's profile put `read()` at 132,537 of ~147,000 samples across all threads.

The issue predicted ~18% from a per-file floor. At this byte saving that floor does not dominate.

## Verifying correctness

- `holding_the_pictures_back_changes_nothing_lofty_parses` builds an MP3 with an ID3v2.2, v2.3 and v2.4 tag, each with a text frame *after* the picture — anything that miscounts the picture's length reads the artist out of the middle of a JPEG — and asserts the tags and audio properties match a plain `Probe::open`, and that `extract_cover_art` still returns the art.
- `the_walk_finds_the_picture_and_the_padding`, `the_picture_reads_back_as_zeros_and_nothing_else_moves` and `seeking_matches_the_file_underneath` cover the walk and the reader directly, including `SeekFrom::End`, which is where lofty goes looking for ID3v1 and APE tags.
- `shapes_the_walk_cannot_mirror_are_left_alone` asserts the bail-outs produce no holes at all.
- Ad hoc, off the tree: 4,000 real MP3s read both ways, comparing every tag item and audio property as strings — all identical, 865 MB not read.

## Not in scope

The other two thirds of the issue's read budget — Ogg's `find_last_page` reverse-searching with a 4 MB buffer, and m4a at 1.4 MiB a file — are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jneiv9RdeiVX1m7MqkWk1p