### PR TITLE
fix(core): a track that can never load no longer parks the queue on itself

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -189,6 +189,8 @@ struct Playlist {
 
 Advancing parks on the next item that is not `Failed`, including one still downloading — playback stops until its `TrackReady`/`TrackStreamReady` arrives, which only reaches the player because the cursor is sitting on it. Skipping ahead to the next `Ready` item instead would drop the track from the queue permanently. Both advance and peek treat a reference item that is no longer in the playlist as "nothing follows": restarting from index 0 would silently replay the queue from the top.
 
+A download that gives up sends `TrackFailed` instead, and the parked cursor advances past the item rather than waiting for a `TrackReady` that cannot come. The reason rides on the item as `LoadState::Failed(reason)` and out through `QueueEntry::error`, because a queue of unplayable tracks and a queue still fetching look identical without it.
+
 ## koan-core modules
 
 ### `audio/`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Fixed
+
+- **A track that can never load no longer parks the queue on itself forever.** `play()` leaves the cursor on an item that is not yet Ready and waits for `TrackReady` — and a download that fails never sends one. With the library folder offline and the remote unreadable, every item failed and the player sat stopped on the first one, which is the same picture as a queue still fetching. Failures raise `TrackFailed` now, and the cursor walks on to the next item that can still load, or stops cleanly when there is none.
+
+- **The reason a track cannot play reaches the front ends.** It was a string inside `LoadState::Failed` that nothing read: the TUI drew `!`, the macOS app drew a triangle captioned "Couldn't be fetched", and the actual sentence — a locked keychain, a server that would not answer — lived in the log file. `QueueEntry` carries it, so the TUI raises it once per distinct reason rather than once per track, the triangle's tooltip says it, and GraphQL clients can read `QueueEntry.failureReason`.
+
+- **Sharing a track asked the config file whether there was a password.** The same mistake `koan remote status` had in v0.27: `remote.password` is empty for every keychain-backed sign-in, so "Remote not configured" was the answer on a perfectly good setup. It goes through `subsonic_client` and reports `remote_unavailable()` like everything else.
+
 ### Changed
 
 - **The queue's album headings carry the record, not a label.** The cover was 22pt — too small to recognise a sleeve by — and the heading read as one run-on line of artist, album and year. Art is 52pt, and the text is the album, its artist, then year · track count · running time · codec, so a run in the queue says what it is without counting rows. The codec only shows when the whole run shares one.

--- a/apps/macos/Sources/Koan/Views/QueueView.swift
+++ b/apps/macos/Sources/Koan/Views/QueueView.swift
@@ -599,7 +599,9 @@ private struct QueueRow: View {
         case .priorityPending:
             Image(systemName: "arrow.down.circle.fill").foregroundStyle(.tint)
         case .failed:
-            Image(systemName: "exclamationmark.triangle.fill").foregroundStyle(.orange)
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.orange)
+                .help(item.failureReason ?? "Couldn't be fetched")
         case .played:
             Image(systemName: "checkmark").foregroundStyle(.tertiary)
         case .queued:

--- a/apps/macos/Sources/Koan/Views/TrackListView.swift
+++ b/apps/macos/Sources/Koan/Views/TrackListView.swift
@@ -292,7 +292,7 @@ private struct TrackAvailability: View {
         case .failed:
             Image(systemName: "exclamationmark.triangle.fill")
                 .foregroundStyle(.orange)
-                .help("Couldn't be fetched")
+                .help(item.failureReason ?? "Couldn't be fetched")
         default:
             EmptyView()
         }

--- a/crates/koan-core/src/helpers.rs
+++ b/crates/koan-core/src/helpers.rs
@@ -1055,14 +1055,14 @@ pub fn download_track(
     let db = match Database::open_default() {
         Ok(db) => db,
         Err(e) => {
-            state.update_load_state(queue_id, LoadState::Failed(format!("db error: {}", e)));
+            fail_track(state, tx, queue_id, format!("db error: {}", e));
             return;
         }
     };
     let track = match queries::get_track_row(&db.conn, db_id) {
         Ok(Some(t)) => t,
         _ => {
-            state.update_load_state(queue_id, LoadState::Failed("track not found".into()));
+            fail_track(state, tx, queue_id, "track not found".into());
             return;
         }
     };
@@ -1082,7 +1082,12 @@ pub fn download_track(
                     return;
                 }
             }
-            state.update_load_state(queue_id, LoadState::Failed("no remote_id".into()));
+            fail_track(
+                state,
+                tx,
+                queue_id,
+                "not in the library folder, and no remote copy to fetch".into(),
+            );
             return;
         }
     };
@@ -1161,7 +1166,7 @@ pub fn download_track(
     });
 
     if let Err(e) = result {
-        state.update_load_state(queue_id, LoadState::Failed(e.to_string()));
+        fail_track(state, tx, queue_id, e.to_string());
         push_log(log_buf, format!("x {} — {}", track.title, e));
         return;
     }
@@ -1185,6 +1190,23 @@ pub fn download_track(
 
     if state.is_cursor(queue_id) {
         tx.send(PlayerCommand::TrackReady(queue_id)).ok();
+    }
+}
+
+/// Mark a queue item unplayable and tell the player, if it is waiting on it.
+///
+/// Setting `LoadState::Failed` alone is not enough: the player only wakes for
+/// `TrackReady`, so a cursor parked on the item would wait for a download that
+/// has already given up.
+pub(crate) fn fail_track(
+    state: &Arc<SharedPlayerState>,
+    tx: &crossbeam_channel::Sender<PlayerCommand>,
+    queue_id: QueueItemId,
+    reason: String,
+) {
+    state.update_load_state(queue_id, LoadState::Failed(reason));
+    if state.is_cursor(queue_id) {
+        tx.send(PlayerCommand::TrackFailed(queue_id)).ok();
     }
 }
 

--- a/crates/koan-core/src/player/commands.rs
+++ b/crates/koan-core/src/player/commands.rs
@@ -57,6 +57,12 @@ pub enum PlayerCommand {
     TrackReady(QueueItemId),
     /// Enough data buffered for streaming playback — check if cursor is waiting.
     TrackStreamReady(QueueItemId),
+    /// Download failed — a cursor parked on this item must stop waiting.
+    ///
+    /// Without it the player sits on a `Pending` item forever: `Ready` is the
+    /// only thing it listens for, and a track that cannot be fetched never
+    /// becomes Ready. That is the offline-library stall.
+    TrackFailed(QueueItemId),
     /// Decode thread exhausted the playlist — auto-advance or stop.
     DecodeFinished,
     /// Undo the last reversible playlist operation.

--- a/crates/koan-core/src/player/mod.rs
+++ b/crates/koan-core/src/player/mod.rs
@@ -1020,6 +1020,26 @@ impl Player {
         }
     }
 
+    /// A download the cursor is parked on will never land.
+    ///
+    /// `play()` leaves the cursor on an item that is not yet Ready and stops,
+    /// waiting for `TrackReady`. When the download fails instead, that wait has
+    /// no end — so walk on to the next item that can still load, or stop
+    /// cleanly if there is none.
+    pub fn track_failed(&mut self, id: QueueItemId) {
+        if !self.shared_state.is_cursor(id) {
+            return;
+        }
+        // Only a parked cursor is waiting on this. Playing means it is being
+        // streamed from the partial file — the pump sees the failure and ends
+        // the decode, which advances the queue — and paused is the user's.
+        if self.shared_state.playback_state() != PlaybackState::Stopped {
+            return;
+        }
+        log::info!("track {:?} cannot load, moving on", id);
+        self.next_track();
+    }
+
     /// Decode thread naturally finished (playlist exhausted or error).
     /// Advance to the next playable track; otherwise stop cleanly.
     ///
@@ -1180,6 +1200,7 @@ impl Player {
             PlayerCommand::TrackReady(id) => self.track_ready(id),
             PlayerCommand::DecodeFinished => self.on_decode_finished(),
             PlayerCommand::TrackStreamReady(id) => self.track_stream_ready(id),
+            PlayerCommand::TrackFailed(id) => self.track_failed(id),
             PlayerCommand::Undo => self.execute_undo(),
             PlayerCommand::Redo => self.execute_redo(),
             PlayerCommand::BeginUndoBatch => {
@@ -1547,6 +1568,76 @@ mod tests {
 
         assert_eq!(player.playback_starts, 1);
         assert_eq!(player.shared_state.cursor(), Some(waiting_id));
+    }
+
+    #[test]
+    fn a_download_that_cannot_land_moves_the_cursor_on() {
+        let mut player = Player::new();
+        let waiting = pending_item("waiting");
+        let later = make_item("later");
+        let (waiting_id, later_id) = (waiting.id, later.id);
+        player.process_command(PlayerCommand::AddToPlaylist(vec![waiting, later]));
+
+        player.process_command(PlayerCommand::Play(waiting_id));
+        assert_eq!(player.playback_starts, 0, "nothing to play yet");
+
+        // The download gives up. Ready will never come.
+        player
+            .shared_state
+            .update_load_state(waiting_id, LoadState::Failed("remote unavailable".into()));
+        player.process_command(PlayerCommand::TrackFailed(waiting_id));
+
+        assert_eq!(
+            player.shared_state.cursor(),
+            Some(later_id),
+            "the queue moves past a track that can never load"
+        );
+        assert_eq!(player.playback_starts, 1);
+    }
+
+    #[test]
+    fn a_queue_that_can_never_load_stops_rather_than_waiting() {
+        let mut player = Player::new();
+        let first = pending_item("first");
+        let second = pending_item("second");
+        let (first_id, second_id) = (first.id, second.id);
+        player.process_command(PlayerCommand::AddToPlaylist(vec![first, second]));
+
+        player.process_command(PlayerCommand::Play(first_id));
+        for id in [first_id, second_id] {
+            player
+                .shared_state
+                .update_load_state(id, LoadState::Failed("remote unavailable".into()));
+            player.process_command(PlayerCommand::TrackFailed(id));
+        }
+
+        assert_eq!(player.playback_starts, 0);
+        assert_eq!(
+            player.shared_state.playback_state(),
+            PlaybackState::Stopped,
+            "a stop the UI can see, not an indefinite wait for TrackReady"
+        );
+    }
+
+    #[test]
+    fn a_failure_elsewhere_in_the_queue_leaves_the_cursor_alone() {
+        let mut player = Player::new();
+        let waiting = pending_item("waiting");
+        let other = pending_item("other");
+        let (waiting_id, other_id) = (waiting.id, other.id);
+        player.process_command(PlayerCommand::AddToPlaylist(vec![waiting, other]));
+        player.process_command(PlayerCommand::Play(waiting_id));
+
+        player
+            .shared_state
+            .update_load_state(other_id, LoadState::Failed("remote unavailable".into()));
+        player.process_command(PlayerCommand::TrackFailed(other_id));
+
+        assert_eq!(
+            player.shared_state.cursor(),
+            Some(waiting_id),
+            "a track still downloading keeps the cursor"
+        );
     }
 
     #[test]

--- a/crates/koan-core/src/player/state.rs
+++ b/crates/koan-core/src/player/state.rs
@@ -150,6 +150,8 @@ pub struct QueueEntry {
     pub duration_ms: Option<u64>,
     pub status: QueueEntryStatus,
     pub download_progress: Option<(u64, u64)>,
+    /// Why this entry cannot play, when `status` is `Failed`.
+    pub error: Option<String>,
 }
 
 /// Pre-built visible queue — single atomic snapshot for the UI.
@@ -855,6 +857,10 @@ impl SharedPlayerState {
                 duration_ms,
                 status,
                 download_progress: dl_progress,
+                error: match &item.load_state {
+                    LoadState::Failed(reason) => Some(reason.clone()),
+                    _ => None,
+                },
             });
         }
 

--- a/crates/koan-core/src/remote/queue.rs
+++ b/crates/koan-core/src/remote/queue.rs
@@ -216,9 +216,11 @@ fn run_download(inner: &Arc<Inner>, (db_id, queue_id): (i64, QueueItemId)) {
     let Some(client) = inner.client.as_ref() else {
         // Failed, not left Pending: the player waits for Ready, so a queue of
         // tracks that can never arrive would otherwise sit saying nothing.
-        inner.state.update_load_state(
+        crate::helpers::fail_track(
+            &inner.state,
+            &inner.cmd_tx,
             queue_id,
-            LoadState::Failed(crate::helpers::remote_unavailable(&inner.cfg)),
+            crate::helpers::remote_unavailable(&inner.cfg),
         );
         return;
     };
@@ -237,9 +239,12 @@ fn run_download(inner: &Arc<Inner>, (db_id, queue_id): (i64, QueueItemId)) {
 
     if outcome.is_err() {
         log::error!("download panicked for {:?}", queue_id);
-        inner
-            .state
-            .update_load_state(queue_id, LoadState::Failed("download panicked".into()));
+        crate::helpers::fail_track(
+            &inner.state,
+            &inner.cmd_tx,
+            queue_id,
+            "download panicked".into(),
+        );
     }
 }
 

--- a/crates/koan-ffi/src/types.rs
+++ b/crates/koan-ffi/src/types.rs
@@ -232,6 +232,8 @@ pub struct QueueItem {
     pub status: EntryStatus,
     /// 0.0–1.0 while downloading, `None` otherwise.
     pub download_progress: Option<f64>,
+    /// Why this item cannot play, when `status` is `Failed`.
+    pub failure_reason: Option<String>,
 }
 
 impl QueueItem {
@@ -271,6 +273,10 @@ impl QueueItem {
             duration_ms: item.duration_ms,
             status,
             download_progress,
+            failure_reason: match &item.load_state {
+                LoadState::Failed(reason) => Some(reason.clone()),
+                _ => None,
+            },
         }
     }
 }
@@ -294,6 +300,7 @@ impl From<&QueueEntry> for QueueItem {
             duration_ms: e.duration_ms,
             status: e.status.into(),
             download_progress,
+            failure_reason: e.error.clone(),
         }
     }
 }

--- a/crates/koan-server/src/graphql/types.rs
+++ b/crates/koan-server/src/graphql/types.rs
@@ -438,6 +438,7 @@ pub(super) struct GqlQueueEntry {
     pub is_current: bool,
     pub status: GqlQueueEntryStatus,
     pub download_progress: Option<GqlDownloadProgress>,
+    pub failure_reason: Option<String>,
 }
 
 #[Object(name = "QueueEntry")]
@@ -491,6 +492,11 @@ impl GqlQueueEntry {
     /// Download progress — present only when the track is being downloaded.
     async fn download_progress(&self) -> Option<&GqlDownloadProgress> {
         self.download_progress.as_ref()
+    }
+
+    /// Why the entry cannot play — present only when `status` is `FAILED`.
+    async fn failure_reason(&self) -> Option<&str> {
+        self.failure_reason.as_deref()
     }
 }
 
@@ -810,6 +816,7 @@ impl GqlQueueSnapshot {
                     download_progress: entry
                         .download_progress
                         .map(|(downloaded, total)| GqlDownloadProgress { downloaded, total }),
+                    failure_reason: entry.error.clone(),
                 }
             })
             .collect();

--- a/crates/koan-tui/src/app.rs
+++ b/crates/koan-tui/src/app.rs
@@ -282,6 +282,10 @@ pub struct App {
     /// Transient status message shown in the hint bar. Cleared after a timeout.
     pub status_message: Option<StatusMessage>,
 
+    /// Failure reasons already reported, so one dead remote raises one message
+    /// rather than one per track it took down. Reset once nothing is failed.
+    noted_failures: std::collections::HashSet<String>,
+
     /// Pending share result from background thread.
     pending_share_status: Option<Arc<Mutex<Option<StatusMessage>>>>,
 
@@ -370,6 +374,7 @@ impl App {
             frame_count: 0,
             favourites: std::collections::HashSet::new(),
             status_message: None,
+            noted_failures: std::collections::HashSet::new(),
             pending_share_status: None,
             show_fps: cfg.playback.show_fps,
             viz_fullscreen: false,
@@ -1378,8 +1383,11 @@ impl App {
 
     fn create_and_copy_share_link(&mut self) {
         let cfg = koan_core::config::Config::load().unwrap_or_default();
-        if !cfg.remote.enabled || cfg.remote.password.is_empty() {
-            self.status_message = Some(("Remote not configured".into(), std::time::Instant::now()));
+        if koan_core::helpers::subsonic_client(&cfg).is_none() {
+            self.status_message = Some((
+                koan_core::helpers::remote_unavailable(&cfg),
+                std::time::Instant::now(),
+            ));
             return;
         }
 
@@ -2859,7 +2867,32 @@ impl App {
             // Clamp cursor after every external playlist change.
             self.clamp_queue_cursor();
             self.close_stale_track_info();
+            self.note_new_failures();
         }
+    }
+
+    /// Say why a track cannot play. The reason used to reach only the log file,
+    /// so a queue nothing could fetch looked exactly like a queue still loading.
+    fn note_new_failures(&mut self) {
+        let mut reasons = self
+            .queue
+            .vq_cache
+            .entries
+            .iter()
+            .filter_map(|e| e.error.as_deref())
+            .peekable();
+        if reasons.peek().is_none() {
+            self.noted_failures.clear();
+            return;
+        }
+        let Some(fresh) = reasons
+            .find(|r| !self.noted_failures.contains(*r))
+            .map(str::to_owned)
+        else {
+            return;
+        };
+        self.status_message = Some((format!("can't play — {fresh}"), std::time::Instant::now()));
+        self.noted_failures.insert(fresh);
     }
 
     /// The track info modal renders nothing once its track leaves the queue,

--- a/crates/koan-tui/src/queue.rs
+++ b/crates/koan-tui/src/queue.rs
@@ -571,6 +571,7 @@ mod tests {
             duration_ms: Some(200_000),
             status: QueueEntryStatus::Queued,
             download_progress: None,
+            error: None,
         }
     }
 

--- a/crates/koan-tui/src/remote_bridge.rs
+++ b/crates/koan-tui/src/remote_bridge.rs
@@ -490,6 +490,7 @@ fn command_loop(
             // catches new variants.
             PlayerCommand::TrackReady(_)
             | PlayerCommand::TrackStreamReady(_)
+            | PlayerCommand::TrackFailed(_)
             | PlayerCommand::BeginUndoBatch
             | PlayerCommand::EndUndoBatch
             | PlayerCommand::UpdatePaths(_)

--- a/crates/koan-tui/src/ui.rs
+++ b/crates/koan-tui/src/ui.rs
@@ -497,6 +497,7 @@ mod tests {
             duration_ms: Some(200_000),
             status: QueueEntryStatus::Queued,
             download_progress: None,
+            error: None,
         }
     }
 

--- a/crates/koan-tui/tests/render.rs
+++ b/crates/koan-tui/tests/render.rs
@@ -105,6 +105,7 @@ fn entry(title: &str, status: QueueEntryStatus) -> QueueEntry {
         duration_ms: Some(215_000),
         status,
         download_progress: Some((3, 10)),
+        error: None,
     }
 }
 


### PR DESCRIPTION
The library folder was offline and the remote's password could not be read, so nothing was downloadable. Every queue item failed, and the player sat stopped on the first one — the same picture as a queue that is merely slow. v0.27 marked those items `Failed` instead of leaving them `Pending`, which made the queue *look* right, but nothing ever told the player, and `TrackReady` is the only thing it wakes for.

## The stall

`play()` parks the cursor on an item that is not yet Ready and waits. That wait had no end when the download gave up. `PlayerCommand::TrackFailed` closes it: every path that sets `LoadState::Failed` now goes through `helpers::fail_track`, which sends the command when the failed item is the one the cursor is on. The player advances to the next item that can still load, or stops cleanly when there is none.

A parked cursor is the only thing that reacts — playing means the item is being streamed from its partial file and the decode ending will advance the queue anyway, and paused is the user's.

## Saying why

The reason has been a `String` inside `LoadState::Failed` that nothing read. The TUI drew `!`, the macOS app drew a triangle captioned "Couldn't be fetched", and the sentence that would have explained it — a keychain koan cannot read, a server that would not answer — was in the log file.

`QueueEntry::error` carries it, and out from there: `QueueItem.failureReason` over FFI, `QueueEntry.failureReason` over GraphQL. The TUI raises it in the status line once per distinct reason rather than once per track, since one dead remote takes the whole queue down at once. The macOS triangle says it in its tooltip.

`"no remote_id"` became "not in the library folder, and no remote copy to fetch" — it is a sentence a user reads now, not a field name.

## Also

`create_and_copy_share_link` gated on `cfg.remote.password.is_empty()`, which is exactly the bug #247 reported in `koan remote status`: that field is empty for every keychain-backed sign-in, so sharing answered "Remote not configured" on a perfectly good setup. It asks `subsonic_client` and reports `remote_unavailable()` like everything else.

## Verifying

`just check` — 884 tests pass, clippy clean under `-D warnings`. `just macos-build` links.

Three new tests in `player/mod.rs` pin the behaviour: a failed cursor item advances the queue, a queue where everything fails stops rather than waiting, and a failure elsewhere leaves a downloading cursor alone.

## Not in this PR

**Nothing retries.** A download that failed stays failed; granting keychain access afterwards means re-queueing. The queue now says so instead of looking like a stall, which was the actual complaint, but a retry path is its own change.

Closes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDmxsnfgsPdojXFCUL7ZWK