### PR TITLE
release: v0.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.29.0 (2026-08-24)
 
 ### Added
 
@@ -19,6 +19,10 @@
 - **The queue's album headings carry the record, not a label.** The cover was 22pt — too small to recognise a sleeve by — and the heading read as one run-on line of artist, album and year. Art is 52pt, and the text is the album, its artist, then year · track count · running time · codec, so a run in the queue says what it is without counting rows. The codec only shows when the whole run shares one.
 
 ### Fixed
+
+- **Everything but the TUI downloaded one track at a time.** `remote.download_workers` defaults to 5 and the macOS settings pane offers it, but the code path behind it ignored the value: the download queue — a worker pool, a permit-limited priority lane, and a watcher that reorders around the playback cursor — lived in the TUI crate, and `koan-ffi` cannot import `koan-tui`. What everything else got instead was a stand-in that spawned one thread per batch and walked it with a `for` loop. Queue an album from the macOS app and it fetched track after track, in submission order, ignoring where you actually were in the queue.
+
+  The queue moves to `koan-core`, where it should have been — it imported nothing but `koan-core` already. The macOS app, the GraphQL server and radio's auto-extend all reach it through the same helper they already called, so all three now download in parallel and promote what you jump to, and several tracks report progress at once instead of one.
 
 - **A track that can never load no longer parks the queue on itself forever.** `play()` leaves the cursor on an item that is not yet Ready and waits for `TrackReady` — and a download that fails never sends one. With the library folder offline and the remote unreadable, every item failed and the player sat stopped on the first one, which is the same picture as a queue still fetching. Failures raise `TrackFailed` now, and the cursor walks on to the next item that can still load, or stops cleanly when there is none.
 
@@ -89,10 +93,6 @@
   The lit row is now the section being browsed and nothing else. Opening an album from search results keeps Results lit, and Back returns you to them.
 
 - **Picking from the search dropdown landed on an empty results page instead of what you picked.** Choosing a suggestion pushes its album or artist and then empties the field, and both happened in one update: the results page is the stack's root at that moment, so clearing the query changed what that root drew while the destination was still landing, and it was discarded against the root it had been pushed onto. Emptying the field is its own update now, so the push settles first.
-
-- **Everything but the TUI downloaded one track at a time.** `remote.download_workers` defaults to 5 and the macOS settings pane offers it, but the code path behind it ignored the value: the download queue — a worker pool, a permit-limited priority lane, and a watcher that reorders around the playback cursor — lived in the TUI crate, and `koan-ffi` cannot import `koan-tui`. What everything else got instead was a stand-in that spawned one thread per batch and walked it with a `for` loop. Queue an album from the macOS app and it fetched track after track, in submission order, ignoring where you actually were in the queue.
-
-  The queue moves to `koan-core`, where it should have been — it imported nothing but `koan-core` already. The macOS app, the GraphQL server and radio's auto-extend all reach it through the same helper they already called, so all three now download in parallel and promote what you jump to, and several tracks report progress at once instead of one.
 
 ## v0.27.0 (2026-08-24)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2744,7 +2744,7 @@ dependencies = [
 
 [[package]]
 name = "koan-cli"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "koan-core"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "argon2",
  "bliss-audio",
@@ -2810,7 +2810,7 @@ dependencies = [
 
 [[package]]
 name = "koan-ffi"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "chrono",
  "crossbeam-channel",
@@ -2830,7 +2830,7 @@ dependencies = [
 
 [[package]]
 name = "koan-server"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",
@@ -2863,7 +2863,7 @@ dependencies = [
 
 [[package]]
 name = "koan-tui"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "core-foundation 0.10.1",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/koan-core", "crates/koan-ffi", "crates/koan-server", "crates/koan-tui", "crates/koan-cli"]
 
 [workspace.package]
-version = "0.28.0"
+version = "0.29.0"
 edition = "2024"
 rust-version = "1.89"
 homepage = "https://github.com/radiosilence/koan"
@@ -13,9 +13,9 @@ license = "MIT"
 [workspace.dependencies]
 # Internal crates. Keep the version in step with [workspace.package] above —
 # a stale pin here publishes members that resolve against the wrong sibling.
-koan-core = { path = "crates/koan-core", version = "0.28.0" }
-koan-server = { path = "crates/koan-server", version = "0.28.0" }
-koan-tui = { path = "crates/koan-tui", version = "0.28.0" }
+koan-core = { path = "crates/koan-core", version = "0.29.0" }
+koan-server = { path = "crates/koan-server", version = "0.29.0" }
+koan-tui = { path = "crates/koan-tui", version = "0.29.0" }
 # Feature set is the union every member needs; `default-tls` is an alias for
 # `rustls`, so there is exactly one TLS stack.
 reqwest = { version = "0.13", default-features = false, features = [


### PR DESCRIPTION
Eight PRs since v0.28.0. Minor rather than patch — the queue gained a grouping mode.

| | |
|---|---|
| #265 | queue album headings show the record |
| #266 | download queue moved to core — parallel and cursor-prioritised for every front end |
| #268 | grouped / individual queue toggle |
| #269 | correcting a file's tags re-merges it with its remote copy |
| #270 | the detail stack's navigation path gets an owner |
| #271 | AppKit workarounds dropped now the floor is macOS 26 |
| #272 | scanning stops reading cover art it throws away |
| #273 | a track that can never load no longer parks the queue on itself |

## Checks

- `cargo test --workspace` — **876 passing**, 2 ignored, 0 failing
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- Version pins: `[workspace.package]` and all three internal `koan-*` pins moved together; CI's own drift check passes locally
- Every commit since the tag has a changelog entry (traced commit-by-commit, not eyeballed)

## One correction folded in

The download queue entry had been written into **v0.28.0's** section rather than Unreleased — I anchored the insert on `v0.27.x` while `main` had already cut 0.28.0, so it sat in the released notes describing work that shipped a release later than it claims. Moved into v0.29.0 where it belongs.

## Merging publishes

`Check Version` compares `Cargo.toml` against the latest GitHub release, so merging cuts the release: crates.io, GitHub release, homebrew tap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L2QYGXTN6dYC7MX5KNY8a5