### PR TITLE
feat(macos): the playing row gets bars, not a speaker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- **The playing row is marked by bars rather than a speaker.** A speaker glyph says "sound comes out of here", which is true of the whole application; what a row needs to say is *this one, and it is still moving*. Three bars ride a pair of sine waves whose frequencies sit at an irrational ratio, so the pattern never settles into a loop the eye can catch, and they freeze where they stand when the transport pauses — paused is the absence of motion, so it costs no second glyph. Reduce Motion gets the bars at rest.
+
 ## v0.29.0 (2026-08-24)
 
 ### Added

--- a/apps/macos/Sources/Koan/Views/PlayingIndicator.swift
+++ b/apps/macos/Sources/Koan/Views/PlayingIndicator.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+
+/// The bars that mark whatever is playing. They dance while the transport
+/// runs and freeze where they stand when it pauses, so the row says both
+/// "this one" and "still going" without a second glyph.
+struct PlayingIndicator: View {
+    let isPlaying: Bool
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    private struct Bar {
+        let speed: Double
+        let phase: Double
+        /// Where a still bar sits, so a frozen indicator still reads as bars.
+        let rest: Double
+    }
+
+    private static let bars = [
+        Bar(speed: 5.1, phase: 0.0, rest: 0.75),
+        Bar(speed: 7.3, phase: 1.7, rest: 0.35),
+        Bar(speed: 6.2, phase: 3.4, rest: 0.6),
+    ]
+
+    private static let minHeight = 3.0
+    private static let maxHeight = 11.0
+
+    var body: some View {
+        TimelineView(.animation(minimumInterval: 1 / 30, paused: !isPlaying || reduceMotion)) { timeline in
+            let now = timeline.date.timeIntervalSinceReferenceDate
+            HStack(alignment: .bottom, spacing: 2) {
+                ForEach(Array(Self.bars.enumerated()), id: \.offset) { _, bar in
+                    Capsule(style: .continuous)
+                        .frame(width: 2, height: height(of: bar, at: now))
+                }
+            }
+        }
+        .frame(height: Self.maxHeight, alignment: .bottom)
+        .foregroundStyle(.tint)
+        .accessibilityLabel(isPlaying ? "Playing" : "Paused")
+    }
+
+    private func height(of bar: Bar, at now: Double) -> Double {
+        guard !reduceMotion else {
+            return Self.minHeight + bar.rest * (Self.maxHeight - Self.minHeight)
+        }
+        // Two frequencies with an irrational ratio: the bars never fall back
+        // into a loop the eye can catch.
+        let wave = sin(now * bar.speed + bar.phase) * 0.6
+            + sin(now * bar.speed * 1.618 + bar.phase * 2) * 0.4
+        let level = (wave + 1) / 2
+        return Self.minHeight + level * (Self.maxHeight - Self.minHeight)
+    }
+}

--- a/apps/macos/Sources/Koan/Views/QueueView.swift
+++ b/apps/macos/Sources/Koan/Views/QueueView.swift
@@ -626,8 +626,7 @@ private struct QueueRow: View {
     private var statusIcon: some View {
         switch item.status {
         case .playing:
-            Image(systemName: player.isPlaying ? "speaker.wave.2.fill" : "speaker.fill")
-                .foregroundStyle(.tint)
+            PlayingIndicator(isPlaying: player.isPlaying)
         case .downloading:
             Image(systemName: "arrow.down.circle").foregroundStyle(.secondary)
         case .priorityPending:

--- a/apps/macos/Sources/Koan/Views/TrackListView.swift
+++ b/apps/macos/Sources/Koan/Views/TrackListView.swift
@@ -176,7 +176,7 @@ private struct TrackRow: View {
 
     var body: some View {
         HStack(spacing: 12) {
-            // The row number becomes a speaker for whatever is playing —
+            // The row number becomes bars for whatever is playing —
             // same width either way so the column doesn't twitch.
             Group {
                 if hovering {
@@ -186,8 +186,7 @@ private struct TrackRow: View {
                         inContext: (trackIds: allTrackIds, startAt: position - 1)
                     )
                 } else if isCurrent {
-                    Image(systemName: player.isPlaying ? "speaker.wave.2.fill" : "speaker.fill")
-                        .foregroundStyle(.tint)
+                    PlayingIndicator(isPlaying: player.isPlaying)
                 } else {
                     Text("\(position)")
                         .foregroundStyle(.tertiary)


### PR DESCRIPTION
The playing indicator in the queue and in a track list is three bars that move while the transport does and freeze where they stand when it pauses, replacing `speaker.wave.2.fill` / `speaker.fill`.

## Decisions

- **`TimelineView(.animation(paused:))` rather than a `repeatForever` animation.** Heights are a function of the timeline's clock, so pausing is `paused: true` — no animation to cancel, no state to unwind, and the bars stop where they are instead of snapping to a rest pose. That freeze is what carries "paused", so no second glyph is needed.
- **Two sine waves per bar at an irrational frequency ratio.** One sine reads as a metronome; the pair never settles into a loop the eye can catch.
- **Reduce Motion draws the bars at fixed, uneven heights** — still legibly bars, no movement.

## Verifying

`just macos-build` compiles clean. Play something and look at the queue and at an album's track list: bars while playing, frozen on pause, row number back when nothing on that row is current. The column width is unchanged (22pt in the track list, 16pt in the queue), so nothing should twitch as playback moves between rows.

Closes #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L2XEkoE45iGuLYHQ7CNXiu