### PR TITLE
release: v0.29.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.29.1 (2026-08-24)
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2744,7 +2744,7 @@ dependencies = [
 
 [[package]]
 name = "koan-cli"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "chrono",
  "clap",
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "koan-core"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "argon2",
  "bliss-audio",
@@ -2810,7 +2810,7 @@ dependencies = [
 
 [[package]]
 name = "koan-ffi"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "chrono",
  "crossbeam-channel",
@@ -2830,7 +2830,7 @@ dependencies = [
 
 [[package]]
 name = "koan-server"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",
@@ -2863,7 +2863,7 @@ dependencies = [
 
 [[package]]
 name = "koan-tui"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "core-foundation 0.10.1",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/koan-core", "crates/koan-ffi", "crates/koan-server", "crates/koan-tui", "crates/koan-cli"]
 
 [workspace.package]
-version = "0.29.0"
+version = "0.29.1"
 edition = "2024"
 rust-version = "1.89"
 homepage = "https://github.com/radiosilence/koan"
@@ -13,9 +13,9 @@ license = "MIT"
 [workspace.dependencies]
 # Internal crates. Keep the version in step with [workspace.package] above —
 # a stale pin here publishes members that resolve against the wrong sibling.
-koan-core = { path = "crates/koan-core", version = "0.29.0" }
-koan-server = { path = "crates/koan-server", version = "0.29.0" }
-koan-tui = { path = "crates/koan-tui", version = "0.29.0" }
+koan-core = { path = "crates/koan-core", version = "0.29.1" }
+koan-server = { path = "crates/koan-server", version = "0.29.1" }
+koan-tui = { path = "crates/koan-tui", version = "0.29.1" }
 # Feature set is the union every member needs; `default-tls` is an alias for
 # `rustls`, so there is exactly one TLS stack.
 reqwest = { version = "0.13", default-features = false, features = [


### PR DESCRIPTION
Patch release. One change since v0.29.0 — #280, the playing indicator. No behaviour, API or schema changes, so nothing to migrate and nothing to re-scan.

### Changed

- **The playing row is marked by bars rather than a speaker.** A speaker glyph says "sound comes out of here", which is true of the whole application; what a row needs to say is *this one, and it is still moving*. Three bars ride a pair of sine waves whose frequencies sit at an irrational ratio, so the pattern never settles into a loop the eye can catch, and they freeze where they stand when the transport pauses — paused is the absence of motion, so it costs no second glyph. Reduce Motion gets the bars at rest.

Version bumped in `Cargo.toml` (workspace + the three internal pins) and `Cargo.lock`. Tag is yours to push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L2XEkoE45iGuLYHQ7CNXiu