### PR TITLE
release: v0.30.0 — liquid glass, and the colour of the record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.30.0 (2026-08-24)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Changed
 
+- **The queue takes its colour from the record playing.** A queue is a list of names, and the only thing in it with a colour is the record that is on. Its cover, blurred out, washes the top of the queue and fades across the first few rows — the same treatment an album page gives its header, applied to what is playing rather than to what you opened. It follows the *record*, not the track: artwork is fetched per track, so re-deriving it every few minutes would ask the server for another copy of the same sleeve.
+
+  It drifts while something is playing — a slow wander of scale, rotation and offset on three periods that never line up, so it never reads as a loop — and settles where it is when you stop. One record dissolves into the next over five seconds, long enough that you notice the room has changed colour without catching it changing. The old cover stays up until the new one is in hand rather than wiping through a placeholder, and a record with no art is no wash rather than a grey one.
+
+  Not tied to scroll position. The wash says what is playing, and following the scroll would have it announce whichever record you happened to be looking at instead.
+
 - **The macOS app is built out of Liquid Glass.** Not a coat of blur over the old chrome — the real macOS 26 material, and the layout changes it asks for. The transport is a slab of glass floating over the stage rather than a bar welded to the window's bottom edge behind a divider: the queue scrolls *under* it, fading out at the soft scroll edge as it goes, because glass with nothing moving behind it is just a grey rectangle. It stops short of the sidebar, which is glass in its own right on 26, and stacking the two reads as neither.
 
   It hangs off the window rather than the detail column. A `NavigationStack` drops decoration applied around it the moment it pushes, which took the transport off every album and artist page; each screen now makes its own room for it instead. Play/pause is bigger than the two beside it and no longer goes dead when nothing is queued — it is the control you reach for without looking.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Changed
 
+- **The queue takes its colour from the record playing.** A queue is a list of names, and the only thing in it with a colour is the record that is on. Its cover, blurred out, washes the top of the queue and fades across the first few rows — the same treatment an album page gives its header, applied to what is playing rather than to what you opened. It follows the *record*, not the track: artwork is fetched per track, so re-deriving it every few minutes would ask the server for another copy of the same sleeve.
+
+  Not tied to scroll position. The wash says what is playing, and following the scroll would have it announce whichever record you happened to be looking at instead.
+
 - **The macOS app is built out of Liquid Glass.** Not a coat of blur over the old chrome — the real macOS 26 material, and the layout changes it asks for. The transport is a slab of glass floating over the stage rather than a bar welded to the window's bottom edge behind a divider: the queue scrolls *under* it, fading out at the soft scroll edge as it goes, because glass with nothing moving behind it is just a grey rectangle. It stops short of the sidebar, which is glass in its own right on 26, and stacking the two reads as neither.
 
   It hangs off the window rather than the detail column. A `NavigationStack` drops decoration applied around it the moment it pushes, which took the transport off every album and artist page; each screen now makes its own room for it instead. Play/pause is bigger than the two beside it and no longer goes dead when nothing is queued — it is the control you reach for without looking.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- **The macOS app is built out of Liquid Glass.** Not a coat of blur over the old chrome — the real macOS 26 material, and the layout changes it asks for. The transport is a slab of glass floating over the stage rather than a bar welded to the window's bottom edge behind a divider: the queue scrolls *under* it, fading out at the soft scroll edge as it goes, because glass with nothing moving behind it is just a grey rectangle. It stops short of the sidebar, which is glass in its own right on 26, and stacking the two reads as neither.
+
+  It hangs off the window rather than the detail column. A `NavigationStack` drops decoration applied around it the moment it pushes, which took the transport off every album and artist page; each screen now makes its own room for it instead. Play/pause is bigger than the two beside it and no longer goes dead when nothing is queued — it is the control you reach for without looking.
+
+- **The toolbar says what belongs together.** `ToolbarSpacer` replaces a `Spacer` smuggled inside a `ToolbarItem`, so filtering and sorting sit on separate panes of glass instead of sharing one joined capsule with the lyrics toggle.
+
+- **An album page carries the colour of the record.** The cover, blurred out behind the header, mirrors outwards under the sidebar and the toolbar via `backgroundExtensionEffect` — the art bleeds into the chrome rather than stopping at a hard edge where the pane begins.
+
+- **Everything laid over artwork is glass now.** The codec badge on a sleeve is clear glass rather than a black scrim hiding the corner it sits on; the favourite heart gets a ground of its own instead of a drop shadow fighting whatever is behind it, and grows in on hover. Artist chips, the shortcut sheet's key caps, the picker's commit bar and the error toast follow — the toast tinted rather than bordered, since glass already has an edge.
+
 ## v0.29.0 (2026-08-24)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@
 
 - **The sidebar said no remote tracks were cached, however many were.** The count asked for tracks whose `source` is `'cached'` — a value the schema allows and nothing writes, because downloading a track does not change where it came from. What a download writes is `cached_path`, which is what `set_cached_path` sets and clearing the cache nulls. Counted from there it agrees with the files on disk.
 
+## v0.29.1 (2026-08-24)
+
+### Changed
+
+- **The playing row is marked by bars rather than a speaker.** A speaker glyph says "sound comes out of here", which is true of the whole application; what a row needs to say is *this one, and it is still moving*. Three bars ride a pair of sine waves whose frequencies sit at an irrational ratio, so the pattern never settles into a loop the eye can catch, and they freeze where they stand when the transport pauses — paused is the absence of motion, so it costs no second glyph. Reduce Motion gets the bars at rest.
+
 ## v0.29.0 (2026-08-24)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - **The queue takes its colour from the record playing.** A queue is a list of names, and the only thing in it with a colour is the record that is on. Its cover, blurred out, washes the top of the queue and fades across the first few rows — the same treatment an album page gives its header, applied to what is playing rather than to what you opened. It follows the *record*, not the track: artwork is fetched per track, so re-deriving it every few minutes would ask the server for another copy of the same sleeve.
 
+  It drifts while something is playing — a slow wander of scale, rotation and offset on three periods that never line up, so it never reads as a loop — and settles where it is when you stop. One record dissolves into the next over five seconds, long enough that you notice the room has changed colour without catching it changing. The old cover stays up until the new one is in hand rather than wiping through a placeholder, and a record with no art is no wash rather than a grey one.
+
   Not tied to scroll position. The wash says what is playing, and following the scroll would have it announce whichever record you happened to be looking at instead.
 
 - **The macOS app is built out of Liquid Glass.** Not a coat of blur over the old chrome — the real macOS 26 material, and the layout changes it asks for. The transport is a slab of glass floating over the stage rather than a bar welded to the window's bottom edge behind a divider: the queue scrolls *under* it, fading out at the soft scroll edge as it goes, because glass with nothing moving behind it is just a grey rectangle. It stops short of the sidebar, which is glass in its own right on 26, and stacking the two reads as neither.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2744,7 +2744,7 @@ dependencies = [
 
 [[package]]
 name = "koan-cli"
-version = "0.29.1"
+version = "0.30.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "koan-core"
-version = "0.29.1"
+version = "0.30.0"
 dependencies = [
  "argon2",
  "bliss-audio",
@@ -2810,7 +2810,7 @@ dependencies = [
 
 [[package]]
 name = "koan-ffi"
-version = "0.29.1"
+version = "0.30.0"
 dependencies = [
  "chrono",
  "crossbeam-channel",
@@ -2830,7 +2830,7 @@ dependencies = [
 
 [[package]]
 name = "koan-server"
-version = "0.29.1"
+version = "0.30.0"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",
@@ -2863,7 +2863,7 @@ dependencies = [
 
 [[package]]
 name = "koan-tui"
-version = "0.29.1"
+version = "0.30.0"
 dependencies = [
  "core-foundation 0.10.1",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/koan-core", "crates/koan-ffi", "crates/koan-server", "crates/koan-tui", "crates/koan-cli"]
 
 [workspace.package]
-version = "0.29.1"
+version = "0.30.0"
 edition = "2024"
 rust-version = "1.89"
 homepage = "https://github.com/radiosilence/koan"
@@ -13,9 +13,9 @@ license = "MIT"
 [workspace.dependencies]
 # Internal crates. Keep the version in step with [workspace.package] above —
 # a stale pin here publishes members that resolve against the wrong sibling.
-koan-core = { path = "crates/koan-core", version = "0.29.1" }
-koan-server = { path = "crates/koan-server", version = "0.29.1" }
-koan-tui = { path = "crates/koan-tui", version = "0.29.1" }
+koan-core = { path = "crates/koan-core", version = "0.30.0" }
+koan-server = { path = "crates/koan-server", version = "0.30.0" }
+koan-tui = { path = "crates/koan-tui", version = "0.30.0" }
 # Feature set is the union every member needs; `default-tls` is an alias for
 # `rustls`, so there is exactly one TLS stack.
 reqwest = { version = "0.13", default-features = false, features = [

--- a/apps/macos/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/apps/macos/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -4,7 +4,7 @@
       "idiom" : "universal",
       "color" : {
         "color-space" : "srgb",
-        "components" : { "red" : "0.560", "green" : "0.560", "blue" : "0.560", "alpha" : "1.000" }
+        "components" : { "red" : "0.180", "green" : "0.180", "blue" : "0.180", "alpha" : "1.000" }
       }
     },
     {
@@ -12,7 +12,7 @@
       "appearances" : [ { "appearance" : "luminosity", "value" : "dark" } ],
       "color" : {
         "color-space" : "srgb",
-        "components" : { "red" : "0.660", "green" : "0.660", "blue" : "0.660", "alpha" : "1.000" }
+        "components" : { "red" : "0.220", "green" : "0.220", "blue" : "0.220", "alpha" : "1.000" }
       }
     }
   ],

--- a/apps/macos/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/apps/macos/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -4,7 +4,7 @@
       "idiom" : "universal",
       "color" : {
         "color-space" : "srgb",
-        "components" : { "red" : "0.850", "green" : "0.090", "blue" : "0.450", "alpha" : "1.000" }
+        "components" : { "red" : "0.560", "green" : "0.560", "blue" : "0.560", "alpha" : "1.000" }
       }
     },
     {
@@ -12,7 +12,7 @@
       "appearances" : [ { "appearance" : "luminosity", "value" : "dark" } ],
       "color" : {
         "color-space" : "srgb",
-        "components" : { "red" : "1.000", "green" : "0.180", "blue" : "0.580", "alpha" : "1.000" }
+        "components" : { "red" : "0.660", "green" : "0.660", "blue" : "0.660", "alpha" : "1.000" }
       }
     }
   ],

--- a/apps/macos/Sources/Koan/Support/Palette.swift
+++ b/apps/macos/Sources/Koan/Support/Palette.swift
@@ -21,3 +21,79 @@ import SwiftUI
 extension Color {
     static let koanAccent = NSColor(named: "AccentColor").map(Color.init) ?? .accentColor
 }
+
+
+extension Color {
+    /// The colour a record reads as, for tinting the app while it plays.
+    ///
+    /// Not the average of the sleeve: averaging every pixel of a busy cover
+    /// gives the same brown-grey every time, because opposite hues cancel. This
+    /// is a circular mean of *hue* weighted by how colourful each sample is, so
+    /// the one strong colour on a mostly black cover wins rather than being
+    /// drowned by the black.
+    ///
+    /// The result is forced into a band that stays legible as a tint on dark
+    /// chrome. A navy sleeve would otherwise give an accent invisible against
+    /// the window and a neon one would flare.
+    static func dominant(of image: NSImage) -> Color? {
+        let side = 12
+        var pixels = [UInt8](repeating: 0, count: side * side * 4)
+        var rect = NSRect(origin: .zero, size: image.size)
+        guard let cgImage = image.cgImage(forProposedRect: &rect, context: nil, hints: nil),
+              let context = CGContext(
+                  data: &pixels,
+                  width: side,
+                  height: side,
+                  bitsPerComponent: 8,
+                  bytesPerRow: side * 4,
+                  space: CGColorSpaceCreateDeviceRGB(),
+                  bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+              )
+        else { return nil }
+        context.draw(cgImage, in: CGRect(x: 0, y: 0, width: side, height: side))
+
+        var x = 0.0, y = 0.0, saturation = 0.0, total = 0.0
+        for i in stride(from: 0, to: pixels.count, by: 4) {
+            let (hue, sat, value) = hsb(
+                Double(pixels[i]) / 255,
+                Double(pixels[i + 1]) / 255,
+                Double(pixels[i + 2]) / 255
+            )
+            // Near-grey, near-black and blown-out samples say nothing about
+            // what colour the record is.
+            guard sat > 0.15, value > 0.15, value < 0.98 else { continue }
+            let weight = sat * value
+            let angle = hue * 2 * .pi
+            x += cos(angle) * weight
+            y += sin(angle) * weight
+            saturation += sat * weight
+            total += weight
+        }
+        guard total > 0 else { return nil }
+
+        let mean = atan2(y / total, x / total) / (2 * .pi)
+        return Color(
+            hue: mean < 0 ? mean + 1 : mean,
+            saturation: min(0.85, max(0.55, saturation / total)),
+            brightness: 0.80
+        )
+    }
+
+    /// Written out rather than going through `NSColor`, whose HSB components
+    /// are only valid in colour spaces it will happily hand you a colour
+    /// outside of.
+    private static func hsb(_ r: Double, _ g: Double, _ b: Double) -> (Double, Double, Double) {
+        let high = max(r, g, b), low = min(r, g, b), delta = high - low
+        guard delta > 0 else { return (0, 0, high) }
+        var hue: Double
+        if high == r {
+            hue = ((g - b) / delta).truncatingRemainder(dividingBy: 6)
+        } else if high == g {
+            hue = (b - r) / delta + 2
+        } else {
+            hue = (r - g) / delta + 4
+        }
+        hue /= 6
+        return (hue < 0 ? hue + 1 : hue, high == 0 ? 0 : delta / high, high)
+    }
+}

--- a/apps/macos/Sources/Koan/Support/UIState.swift
+++ b/apps/macos/Sources/Koan/Support/UIState.swift
@@ -21,6 +21,10 @@ final class UIState {
     /// that is — a `GeometryReader` inside one only ever sees the sheet's own
     /// proposal. The window measures itself and leaves the answer here.
     var windowSize: CGSize = .zero
+    /// How far in the stage starts. The transport floats over the window — the
+    /// only place a `NavigationStack` push cannot drop it — so it needs to know
+    /// where the sidebar ends in order not to sit on it.
+    var sidebarWidth: CGFloat = 0
 
     enum Edge { case top, bottom }
 

--- a/apps/macos/Sources/Koan/Views/AlbumGridCell.swift
+++ b/apps/macos/Sources/Koan/Views/AlbumGridCell.swift
@@ -28,24 +28,33 @@ struct AlbumGridCell: View {
                         Text(codec.uppercased())
                             .font(.system(size: 9, weight: .semibold).monospaced())
                             .foregroundStyle(.white)
-                            .padding(.horizontal, 5)
-                            .padding(.vertical, 2)
-                            .background(.black.opacity(0.55), in: Capsule())
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 3)
+                            // Clear glass, not a black scrim: over artwork the
+                            // point is to stay readable without hiding the
+                            // corner of the cover it sits on.
+                            .glassEffect(.clear, in: .capsule)
                             .padding(6)
                     }
                 }
                 .overlay(alignment: .bottomTrailing) {
-                    FavouriteButton(
-                        isOn: library.isFavourite(album: album.id),
-                        showing: hovering,
-                        size: .callout
-                    ) {
-                        library.toggleFavourite(album: album.id)
-                    }
                     // Over artwork, which can be any colour — the plain
-                    // tertiary heart disappears against half of them.
-                    .shadow(color: .black.opacity(0.6), radius: 3)
-                    .padding(7)
+                    // tertiary heart disappears against half of them. Glass
+                    // gives it a ground of its own, so the shape is legible
+                    // whatever is behind it, and it grows in on hover rather
+                    // than fading a shadowed glyph up.
+                    if hovering || library.isFavourite(album: album.id) {
+                        FavouriteButton(
+                            isOn: library.isFavourite(album: album.id),
+                            size: .callout
+                        ) {
+                            library.toggleFavourite(album: album.id)
+                        }
+                        .padding(7)
+                        .glassEffect(.clear.interactive(), in: .circle)
+                        .glassEffectTransition(.materialize)
+                        .padding(7)
+                    }
                 }
 
             Text(album.title)
@@ -68,6 +77,7 @@ struct AlbumGridCell: View {
             }
         }
         .onHover { hovering = $0 }
+        .animation(.smooth(duration: 0.18), value: hovering)
         .contextMenu { PlayableMenu(playable: .album(album)) }
         .draggablePlayable(.album(album))
     }

--- a/apps/macos/Sources/Koan/Views/ArtistPill.swift
+++ b/apps/macos/Sources/Koan/Views/ArtistPill.swift
@@ -11,7 +11,6 @@ struct ArtistPill: View {
 
     @Environment(LibraryModel.self) private var library
     @Environment(Navigator.self) private var nav
-    @State private var hovering = false
 
     var body: some View {
         HStack(spacing: 5) {
@@ -36,9 +35,8 @@ struct ArtistPill: View {
         .padding(.horizontal, 11)
         .padding(.vertical, 6)
         .fixedSize(horizontal: true, vertical: false)
-        .background(hovering ? AnyShapeStyle(.tertiary) : AnyShapeStyle(.quaternary), in: Capsule())
+        .glassEffect(.regular.interactive(), in: .capsule)
         .contentShape(Capsule())
-        .onHover { hovering = $0 }
         .onTapGesture { nav.open(artist: artistId) }
         .help("Go to \(name)")
         .contextMenu { PlayableMenu(playable: .artist(id: artistId, name: name)) }

--- a/apps/macos/Sources/Koan/Views/ArtworkBleed.swift
+++ b/apps/macos/Sources/Koan/Views/ArtworkBleed.swift
@@ -1,0 +1,107 @@
+import AppKit
+import SwiftUI
+
+/// The cover, blurred out to a wash of the record's colour behind a header.
+///
+/// `backgroundExtensionEffect` is what makes it worth doing: it mirrors the
+/// blur outwards into the insets around the detail column, so the colour
+/// carries under the glass sidebar and toolbar instead of stopping at a hard
+/// edge where the pane begins. The gradient goes on first, so the mirrored copy
+/// fades out the same way the real one does.
+///
+/// Fills whatever it is given — a `.background` on a header takes the header's
+/// height; anywhere else, say how far down the page the wash should reach.
+struct ArtworkBleed: View {
+    /// Nothing playing, or a record with no art, means no wash rather than a
+    /// grey one.
+    let source: AlbumArtwork.Source?
+    /// Whether the wash drifts. The room breathes while something is playing
+    /// and settles when it stops.
+    var drifts = false
+
+    @Environment(CoverArtCache.self) private var cache
+    /// Held rather than drawn through `AlbumArtwork`, which shows a placeholder
+    /// while it loads. Over a five second dissolve that placeholder is a long
+    /// grey wipe between two records, so the old cover stays up until the new
+    /// one is actually in hand.
+    @State private var image: NSImage?
+    /// Bumped when the cover changes, which is what the dissolve keys on. The
+    /// image itself cannot: `NSImage` is a reference and identity is not enough
+    /// to drive a transition.
+    @State private var generation = 0
+
+    /// The cover is blurred to mush, so it is rendered small and scaled up
+    /// afterwards. Blurring a 360pt layer and magnifying the result costs a
+    /// fraction of blurring one the width of the window, which matters when it
+    /// is redrawn twenty times a second.
+    private static let side: CGFloat = 360
+
+    var body: some View {
+        GeometryReader { geo in
+            // Paused rather than switched off, so stopping playback leaves the
+            // drift where it is instead of snapping it back.
+            TimelineView(.animation(minimumInterval: 1 / 20, paused: !drifts)) { context in
+                ZStack {
+                    if let image {
+                        // Three incommensurate periods, so the drift never
+                        // arrives back where it started and never reads as a
+                        // loop.
+                        let t = context.date.timeIntervalSinceReferenceDate
+                        Image(nsImage: image)
+                            .resizable()
+                            .aspectRatio(contentMode: .fill)
+                            .frame(width: Self.side, height: Self.side)
+                            .blur(radius: 14)
+                            .scaleEffect(geo.size.width / Self.side * (1.25 + 0.06 * sin(t / 13)))
+                            .rotationEffect(.degrees(3 * sin(t / 19)))
+                            .offset(
+                                x: geo.size.width * 0.04 * sin(t / 23),
+                                y: geo.size.height * 0.06 * cos(t / 17)
+                            )
+                            .saturation(1.6)
+                            .id(generation)
+                            .transition(.opacity)
+                    }
+                }
+                .frame(width: geo.size.width, height: geo.size.height)
+            }
+        }
+        .clipped()
+        .opacity(0.5)
+        .mask(
+            LinearGradient(
+                colors: [.black, .black, .clear],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+        )
+        .backgroundExtensionEffect()
+        .allowsHitTesting(false)
+        // One record dissolving into the next over long enough that you notice
+        // the room has changed colour without ever catching it changing.
+        .animation(.easeInOut(duration: 5), value: generation)
+        .task(id: source) { await load() }
+    }
+
+    private func load() async {
+        guard let source else {
+            show(nil)
+            return
+        }
+        if let cached = cache.cached(source) {
+            show(cached)
+            return
+        }
+        let loaded = await cache.image(for: source)
+        // A cancelled load means the record moved on again; whatever came back
+        // is for the wrong one.
+        guard !Task.isCancelled else { return }
+        show(loaded)
+    }
+
+    private func show(_ new: NSImage?) {
+        guard new !== image else { return }
+        image = new
+        generation += 1
+    }
+}

--- a/apps/macos/Sources/Koan/Views/ArtworkBleed.swift
+++ b/apps/macos/Sources/Koan/Views/ArtworkBleed.swift
@@ -79,7 +79,7 @@ struct ArtworkBleed: View {
         .allowsHitTesting(false)
         // One record dissolving into the next over long enough that you notice
         // the room has changed colour without ever catching it changing.
-        .animation(.easeInOut(duration: 3), value: generation)
+        .animation(.easeInOut(duration: 2), value: generation)
         .task(id: source) { await load() }
     }
 

--- a/apps/macos/Sources/Koan/Views/ArtworkBleed.swift
+++ b/apps/macos/Sources/Koan/Views/ArtworkBleed.swift
@@ -79,7 +79,7 @@ struct ArtworkBleed: View {
         .allowsHitTesting(false)
         // One record dissolving into the next over long enough that you notice
         // the room has changed colour without ever catching it changing.
-        .animation(.easeInOut(duration: 5), value: generation)
+        .animation(.easeInOut(duration: 3), value: generation)
         .task(id: source) { await load() }
     }
 

--- a/apps/macos/Sources/Koan/Views/ArtworkBleed.swift
+++ b/apps/macos/Sources/Koan/Views/ArtworkBleed.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 /// The cover, blurred out to a wash of the record's colour behind a header.
@@ -14,20 +15,55 @@ struct ArtworkBleed: View {
     /// Nothing playing, or a record with no art, means no wash rather than a
     /// grey one.
     let source: AlbumArtwork.Source?
+    /// Whether the wash drifts. The room breathes while something is playing
+    /// and settles when it stops.
+    var drifts = false
+
+    @Environment(CoverArtCache.self) private var cache
+    /// Held rather than drawn through `AlbumArtwork`, which shows a placeholder
+    /// while it loads. Over a five second dissolve that placeholder is a long
+    /// grey wipe between two records, so the old cover stays up until the new
+    /// one is actually in hand.
+    @State private var image: NSImage?
+    /// Bumped when the cover changes, which is what the dissolve keys on. The
+    /// image itself cannot: `NSImage` is a reference and identity is not enough
+    /// to drive a transition.
+    @State private var generation = 0
+
+    /// The cover is blurred to mush, so it is rendered small and scaled up
+    /// afterwards. Blurring a 360pt layer and magnifying the result costs a
+    /// fraction of blurring one the width of the window, which matters when it
+    /// is redrawn twenty times a second.
+    private static let side: CGFloat = 360
 
     var body: some View {
         GeometryReader { geo in
-            if let source {
-                // Square art drawn at the full width and centred vertically:
-                // the wash wants the middle of the cover, not a letterboxed
-                // copy of the whole thing.
-                AlbumArtwork(source: source, cornerRadius: 0)
-                    .frame(width: geo.size.width, height: geo.size.width)
-                    .offset(y: (geo.size.height - geo.size.width) / 2)
-                    .blur(radius: 64)
-                    .saturation(1.6)
-                    .id(source)
-                    .transition(.opacity)
+            // Paused rather than switched off, so stopping playback leaves the
+            // drift where it is instead of snapping it back.
+            TimelineView(.animation(minimumInterval: 1 / 20, paused: !drifts)) { context in
+                ZStack {
+                    if let image {
+                        // Three incommensurate periods, so the drift never
+                        // arrives back where it started and never reads as a
+                        // loop.
+                        let t = context.date.timeIntervalSinceReferenceDate
+                        Image(nsImage: image)
+                            .resizable()
+                            .aspectRatio(contentMode: .fill)
+                            .frame(width: Self.side, height: Self.side)
+                            .blur(radius: 14)
+                            .scaleEffect(geo.size.width / Self.side * (1.25 + 0.06 * sin(t / 13)))
+                            .rotationEffect(.degrees(3 * sin(t / 19)))
+                            .offset(
+                                x: geo.size.width * 0.04 * sin(t / 23),
+                                y: geo.size.height * 0.06 * cos(t / 17)
+                            )
+                            .saturation(1.6)
+                            .id(generation)
+                            .transition(.opacity)
+                    }
+                }
+                .frame(width: geo.size.width, height: geo.size.height)
             }
         }
         .clipped()
@@ -41,8 +77,31 @@ struct ArtworkBleed: View {
         )
         .backgroundExtensionEffect()
         .allowsHitTesting(false)
-        // One record dissolving into the next. Long enough to read as the room
-        // changing colour rather than as a redraw.
-        .animation(.smooth(duration: 0.55), value: source)
+        // One record dissolving into the next over long enough that you notice
+        // the room has changed colour without ever catching it changing.
+        .animation(.easeInOut(duration: 5), value: generation)
+        .task(id: source) { await load() }
+    }
+
+    private func load() async {
+        guard let source else {
+            show(nil)
+            return
+        }
+        if let cached = cache.cached(source) {
+            show(cached)
+            return
+        }
+        let loaded = await cache.image(for: source)
+        // A cancelled load means the record moved on again; whatever came back
+        // is for the wrong one.
+        guard !Task.isCancelled else { return }
+        show(loaded)
+    }
+
+    private func show(_ new: NSImage?) {
+        guard new !== image else { return }
+        image = new
+        generation += 1
     }
 }

--- a/apps/macos/Sources/Koan/Views/ArtworkBleed.swift
+++ b/apps/macos/Sources/Koan/Views/ArtworkBleed.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+
+/// The cover, blurred out to a wash of the record's colour behind a header.
+///
+/// `backgroundExtensionEffect` is what makes it worth doing: it mirrors the
+/// blur outwards into the insets around the detail column, so the colour
+/// carries under the glass sidebar and toolbar instead of stopping at a hard
+/// edge where the pane begins. The gradient goes on first, so the mirrored copy
+/// fades out the same way the real one does.
+///
+/// Fills whatever it is given — a `.background` on a header takes the header's
+/// height; anywhere else, say how far down the page the wash should reach.
+struct ArtworkBleed: View {
+    /// Nothing playing, or a record with no art, means no wash rather than a
+    /// grey one.
+    let source: AlbumArtwork.Source?
+
+    var body: some View {
+        GeometryReader { geo in
+            if let source {
+                // Square art drawn at the full width and centred vertically:
+                // the wash wants the middle of the cover, not a letterboxed
+                // copy of the whole thing.
+                AlbumArtwork(source: source, cornerRadius: 0)
+                    .frame(width: geo.size.width, height: geo.size.width)
+                    .offset(y: (geo.size.height - geo.size.width) / 2)
+                    .blur(radius: 64)
+                    .saturation(1.6)
+                    .id(source)
+                    .transition(.opacity)
+            }
+        }
+        .clipped()
+        .opacity(0.5)
+        .mask(
+            LinearGradient(
+                colors: [.black, .black, .clear],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+        )
+        .backgroundExtensionEffect()
+        .allowsHitTesting(false)
+        // One record dissolving into the next. Long enough to read as the room
+        // changing colour rather than as a redraw.
+        .animation(.smooth(duration: 0.55), value: source)
+    }
+}

--- a/apps/macos/Sources/Koan/Views/PickerSheet.swift
+++ b/apps/macos/Sources/Koan/Views/PickerSheet.swift
@@ -31,8 +31,10 @@ struct PickerSheet: View {
             kindPicker
             Divider()
             resultList
-            Divider()
-            commitBar
+                // The commit bar floats over the results rather than being
+                // fenced off below them, so the list keeps the full height and
+                // you can see what is still under the bar as you scroll.
+                .safeAreaInset(edge: .bottom, spacing: 0) { commitBar }
         }
         .frame(width: 660, height: 500)
         .onAppear { fieldFocused = true }
@@ -114,6 +116,7 @@ struct PickerSheet: View {
                 }
             }
             .listStyle(.inset)
+            .scrollEdgeEffectStyle(.soft, for: .bottom)
         }
     }
 
@@ -155,9 +158,11 @@ struct PickerSheet: View {
                 .buttonStyle(.borderedProminent)
         }
         .disabled(resolving || (picked.isEmpty && highlighted == nil))
-        .padding(.horizontal, 16)
-        .padding(.vertical, 11)
-        .background(.bar)
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .glassEffect(.regular, in: .rect(cornerRadius: 20))
+        .padding(.horizontal, 12)
+        .padding(.bottom, 12)
     }
 
     private func toggle(_ row: PickerRow) {

--- a/apps/macos/Sources/Koan/Views/QueueView.swift
+++ b/apps/macos/Sources/Koan/Views/QueueView.swift
@@ -540,21 +540,27 @@ private struct QueueRow: View {
 
     var body: some View {
         HStack(spacing: 10) {
-            statusIcon
-                .font(.caption)
-                .frame(width: 16)
+            // The status and the number are one thing — where this track is and
+            // what it is doing — so they sit together. Apart, a mark narrower
+            // than its column and a number aligned to the right of its own left
+            // most of twenty points of air between them.
+            HStack(spacing: 6) {
+                statusIcon
+                    .font(.caption)
+                    .frame(width: 16, alignment: .trailing)
 
-            if artwork, let trackId = item.trackId {
-                AlbumArtwork(source: .track(trackId), cornerRadius: 3)
-                    .frame(width: 28, height: 28)
-            } else {
-                // Always occupies its column, number or not: a missing track
-                // number would otherwise shift the title left and break the
-                // alignment down the list.
-                Text(item.trackNumber.map(String.init) ?? "")
-                    .font(.caption.monospacedDigit())
-                    .foregroundStyle(.tertiary)
-                    .frame(width: artwork ? 28 : 20, alignment: .trailing)
+                if artwork, let trackId = item.trackId {
+                    AlbumArtwork(source: .track(trackId), cornerRadius: 3)
+                        .frame(width: 28, height: 28)
+                } else {
+                    // Always occupies its column, number or not: a missing track
+                    // number would otherwise shift the title left and break the
+                    // alignment down the list.
+                    Text(item.trackNumber.map(String.init) ?? "")
+                        .font(.caption.monospacedDigit())
+                        .foregroundStyle(.tertiary)
+                        .frame(width: artwork ? 28 : 20, alignment: .trailing)
+                }
             }
 
             VStack(alignment: .leading, spacing: 1) {

--- a/apps/macos/Sources/Koan/Views/QueueView.swift
+++ b/apps/macos/Sources/Koan/Views/QueueView.swift
@@ -18,6 +18,14 @@ struct QueueView: View {
     @State private var savingSnapshot = false
     @State private var snapshotName = ""
 
+    /// The record the wash behind the header is showing.
+    ///
+    /// Held rather than derived from `currentTrackId` on every frame: artwork
+    /// is fetched per *track*, so re-deriving it would ask the server for a new
+    /// copy of the same sleeve at every track change within a record. It only
+    /// moves when the record does.
+    @State private var bleed: AlbumArtwork.Source?
+
     /// Grouped or one row per track. Persisted because it is a preference about
     /// how you listen rather than about the queue in front of you: an album
     /// listen wants the headings, a long shuffled queue wants every row to say
@@ -44,7 +52,6 @@ struct QueueView: View {
     var body: some View {
         VStack(spacing: 0) {
             header
-            Divider()
 
             if player.queue.isEmpty {
                 EmptyState(
@@ -62,6 +69,10 @@ struct QueueView: View {
                         .onMove(perform: move)
                     }
                     .listStyle(.inset)
+                    // Otherwise the List paints over the wash and it stops at
+                    // the header in a hard line, rather than fading out across
+                    // the first few rows.
+                    .scrollContentBackground(.hidden)
                     // `g` / `G`. Watches the token rather than the edge: jumping
                     // to where you already are still has to scroll, because the
                     // list may have been moved since.
@@ -94,6 +105,16 @@ struct QueueView: View {
                 }
             }
         }
+        // The queue is a list of names; the record playing is the one thing in
+        // it with a colour. An album page washes its header in the cover, and
+        // this is the same treatment applied to what is on rather than to what
+        // you opened.
+        .background(alignment: .top) {
+            ArtworkBleed(source: bleed).frame(height: 320)
+        }
+        .onChange(of: playingRecord, initial: true) { _, _ in
+            bleed = player.currentTrackId.map { .track($0) }
+        }
         // On the whole stage, not the List: an empty queue is exactly when you
         // want to drop a folder on it, and it has no rows to land on.
         .dropDestination(for: URL.self) { urls, _ in
@@ -114,6 +135,12 @@ struct QueueView: View {
     }
 
     // MARK: - Header
+
+    /// Which record is playing — artist as well as title, because "Greatest
+    /// Hits" is not one record.
+    private var playingRecord: String? {
+        player.currentEntry.map { "\($0.albumArtist)\u{1}\($0.album)" }
+    }
 
     private var header: some View {
         HStack(spacing: 12) {

--- a/apps/macos/Sources/Koan/Views/QueueView.swift
+++ b/apps/macos/Sources/Koan/Views/QueueView.swift
@@ -110,7 +110,8 @@ struct QueueView: View {
         // this is the same treatment applied to what is on rather than to what
         // you opened.
         .background(alignment: .top) {
-            ArtworkBleed(source: bleed).frame(height: 320)
+            ArtworkBleed(source: bleed, drifts: player.isPlaying)
+                .frame(height: 320)
         }
         .onChange(of: playingRecord, initial: true) { _, _ in
             bleed = player.currentTrackId.map { .track($0) }

--- a/apps/macos/Sources/Koan/Views/QueueView.swift
+++ b/apps/macos/Sources/Koan/Views/QueueView.swift
@@ -18,13 +18,6 @@ struct QueueView: View {
     @State private var savingSnapshot = false
     @State private var snapshotName = ""
 
-    /// The record the wash behind the header is showing.
-    ///
-    /// Held rather than derived from `currentTrackId` on every frame: artwork
-    /// is fetched per *track*, so re-deriving it would ask the server for a new
-    /// copy of the same sleeve at every track change within a record. It only
-    /// moves when the record does.
-    @State private var bleed: AlbumArtwork.Source?
 
     /// Grouped or one row per track. Persisted because it is a preference about
     /// how you listen rather than about the queue in front of you: an album
@@ -105,17 +98,6 @@ struct QueueView: View {
                 }
             }
         }
-        // The queue is a list of names; the record playing is the one thing in
-        // it with a colour. An album page washes its header in the cover, and
-        // this is the same treatment applied to what is on rather than to what
-        // you opened.
-        .background(alignment: .top) {
-            ArtworkBleed(source: bleed, drifts: player.isPlaying)
-                .frame(height: 320)
-        }
-        .onChange(of: playingRecord, initial: true) { _, _ in
-            bleed = player.currentTrackId.map { .track($0) }
-        }
         // On the whole stage, not the List: an empty queue is exactly when you
         // want to drop a folder on it, and it has no rows to land on.
         .dropDestination(for: URL.self) { urls, _ in
@@ -136,12 +118,6 @@ struct QueueView: View {
     }
 
     // MARK: - Header
-
-    /// Which record is playing — artist as well as title, because "Greatest
-    /// Hits" is not one record.
-    private var playingRecord: String? {
-        player.currentEntry.map { "\($0.albumArtist)\u{1}\($0.album)" }
-    }
 
     private var header: some View {
         HStack(spacing: 12) {

--- a/apps/macos/Sources/Koan/Views/QueueView.swift
+++ b/apps/macos/Sources/Koan/Views/QueueView.swift
@@ -18,6 +18,14 @@ struct QueueView: View {
     @State private var savingSnapshot = false
     @State private var snapshotName = ""
 
+    /// The record the wash behind the header is showing.
+    ///
+    /// Held rather than derived from `currentTrackId` on every frame: artwork
+    /// is fetched per *track*, so re-deriving it would ask the server for a new
+    /// copy of the same sleeve at every track change within a record. It only
+    /// moves when the record does.
+    @State private var bleed: AlbumArtwork.Source?
+
     /// Grouped or one row per track. Persisted because it is a preference about
     /// how you listen rather than about the queue in front of you: an album
     /// listen wants the headings, a long shuffled queue wants every row to say
@@ -44,7 +52,6 @@ struct QueueView: View {
     var body: some View {
         VStack(spacing: 0) {
             header
-            Divider()
 
             if player.queue.isEmpty {
                 EmptyState(
@@ -62,6 +69,10 @@ struct QueueView: View {
                         .onMove(perform: move)
                     }
                     .listStyle(.inset)
+                    // Otherwise the List paints over the wash and it stops at
+                    // the header in a hard line, rather than fading out across
+                    // the first few rows.
+                    .scrollContentBackground(.hidden)
                     // `g` / `G`. Watches the token rather than the edge: jumping
                     // to where you already are still has to scroll, because the
                     // list may have been moved since.
@@ -94,6 +105,17 @@ struct QueueView: View {
                 }
             }
         }
+        // The queue is a list of names; the record playing is the one thing in
+        // it with a colour. An album page washes its header in the cover, and
+        // this is the same treatment applied to what is on rather than to what
+        // you opened.
+        .background(alignment: .top) {
+            ArtworkBleed(source: bleed, drifts: player.isPlaying)
+                .frame(height: 320)
+        }
+        .onChange(of: playingRecord, initial: true) { _, _ in
+            bleed = player.currentTrackId.map { .track($0) }
+        }
         // On the whole stage, not the List: an empty queue is exactly when you
         // want to drop a folder on it, and it has no rows to land on.
         .dropDestination(for: URL.self) { urls, _ in
@@ -114,6 +136,12 @@ struct QueueView: View {
     }
 
     // MARK: - Header
+
+    /// Which record is playing — artist as well as title, because "Greatest
+    /// Hits" is not one record.
+    private var playingRecord: String? {
+        player.currentEntry.map { "\($0.albumArtist)\u{1}\($0.album)" }
+    }
 
     private var header: some View {
         HStack(spacing: 12) {

--- a/apps/macos/Sources/Koan/Views/RootView.swift
+++ b/apps/macos/Sources/Koan/Views/RootView.swift
@@ -26,14 +26,37 @@ struct RootView: View {
     @Environment(Navigator.self) private var nav
     @Environment(SearchModel.self) private var search
     @Environment(PlayerModel.self) private var player
+    /// Read here only to hand back to the window background — see below.
+    @Environment(CoverArtCache.self) private var art
 
     @AppStorage("showLyrics") private var showLyrics = false
     @State private var transportHeight: CGFloat = 0
+    /// The record the window is washed in.
+    ///
+    /// Held rather than derived from `currentTrackId` on every frame: artwork
+    /// is fetched per *track*, so re-deriving it would ask the server for a new
+    /// copy of the same sleeve at every track change within a record. It only
+    /// moves when the record does.
+    @State private var bleed: AlbumArtwork.Source?
+
+    /// Which record is playing — artist as well as title, because "Greatest
+    /// Hits" is not one record.
+    private var playingRecord: String? {
+        player.currentEntry.map { "\($0.albumArtist)\u{1}\($0.album)" }
+    }
 
     var body: some View {
         @Bindable var library = library
         @Bindable var search = search
         @Bindable var ui = ui
+
+        // The window background is evaluated by the *scene*, outside every
+        // environment `RootView` was handed, so anything it needs is captured
+        // here. Reading an `@Environment` inside that closure — including to
+        // put one back — traps, and the app dies on launch.
+        let wash = nav.section == .queue ? bleed : nil
+        let washDrifts = player.isPlaying
+        let artCache = art
 
         NavigationSplitView {
             SidebarView()
@@ -79,6 +102,31 @@ struct RootView: View {
                     }
                 }
         }
+        // The queue is a list of names, and the record playing is the only
+        // thing in it with a colour. On the *window* rather than behind the
+        // queue: nothing inside a split view column reaches past the toolbar's
+        // inset, and a wash that stops in a line under the toolbar is worse
+        // than none. An album page washes its own header, so the window stays
+        // out of its way.
+        .containerBackground(for: .window) {
+            // Over an opaque ground, because this *replaces* the window's own
+            // background rather than sitting on it — a half-transparent wash on
+            // its own leaves you looking through the app at the desktop.
+            ZStack {
+                Rectangle().fill(.background)
+                ArtworkBleed(source: wash, drifts: washDrifts)
+                    .environment(artCache)
+            }
+        }
+        .onChange(of: playingRecord, initial: true) { _, _ in
+            bleed = player.currentTrackId.map { .track($0) }
+        }
+        // The toolbar paints its own ground over whatever is behind it, which
+        // put a hard grey strip across the top of a queue washed in the colour
+        // of the record. Hidden, the glass controls sit in that colour — which
+        // is the whole point of them being glass — and the scroll edge effect
+        // keeps rows legible as they pass under.
+        .toolbarBackgroundVisibility(.hidden, for: .windowToolbar)
         .onChange(of: search.query) { _, _ in search.schedule() }
         .onSubmit(of: .search) { handleSubmit() }
         // On the window rather than inside the detail column: a

--- a/apps/macos/Sources/Koan/Views/RootView.swift
+++ b/apps/macos/Sources/Koan/Views/RootView.swift
@@ -38,6 +38,13 @@ struct RootView: View {
     /// copy of the same sleeve at every track change within a record. It only
     /// moves when the record does.
     @State private var bleed: AlbumArtwork.Source?
+    /// The colour of the record playing. The app's own accent is a neutral, so
+    /// the only colour in the chrome is the one the music brought.
+    @State private var recordTint: Color?
+    /// Watched rather than inferred from the measured width: a collapsed
+    /// sidebar still reports its last width, so the transport kept a gap where
+    /// it used to be.
+    @State private var columns: NavigationSplitViewVisibility = .automatic
 
     /// Which record is playing — artist as well as title, because "Greatest
     /// Hits" is not one record.
@@ -54,11 +61,19 @@ struct RootView: View {
         // environment `RootView` was handed, so anything it needs is captured
         // here. Reading an `@Environment` inside that closure — including to
         // put one back — traps, and the app dies on launch.
-        let wash = nav.section == .queue ? bleed : nil
+        // An album page washes the window in the record you opened; everywhere
+        // else it is the record playing, and only where that means something.
+        let wash: AlbumArtwork.Source? = if case .album(let id) = nav.stack.wrappedValue.last {
+            .album(id)
+        } else if nav.section == .queue {
+            bleed
+        } else {
+            nil
+        }
         let washDrifts = player.isPlaying
         let artCache = art
 
-        NavigationSplitView {
+        NavigationSplitView(columnVisibility: $columns) {
             SidebarView()
                 .navigationSplitViewColumnWidth(min: 190, ideal: 215, max: 290)
         } detail: {
@@ -121,6 +136,19 @@ struct RootView: View {
         .onChange(of: playingRecord, initial: true) { _, _ in
             bleed = player.currentTrackId.map { .track($0) }
         }
+        .task(id: bleed) {
+            guard let bleed, let cover = await art.image(for: bleed) else {
+                recordTint = nil
+                return
+            }
+            recordTint = .dominant(of: cover)
+        }
+        // Overrides the app-wide tint for everything below, which is every
+        // control koan draws itself. What AppKit draws — list selection, focus
+        // rings — keeps the declared accent, and that is deliberately a neutral
+        // so the two never argue.
+        .tint(recordTint ?? .koanAccent)
+        .animation(.easeInOut(duration: 3), value: recordTint)
         // The toolbar paints its own ground over whatever is behind it, which
         // put a hard grey strip across the top of a queue washed in the colour
         // of the record. Hidden, the glass controls sit in that colour — which
@@ -137,7 +165,7 @@ struct RootView: View {
         // `clearsTransport`.
         .overlay(alignment: .bottom) {
             TransportBar()
-                .padding(.leading, ui.sidebarWidth)
+                .padding(.leading, columns == .detailOnly ? 0 : ui.sidebarWidth)
                 .background(
                     GeometryReader { proxy in
                         Color.clear.preference(

--- a/apps/macos/Sources/Koan/Views/RootView.swift
+++ b/apps/macos/Sources/Koan/Views/RootView.swift
@@ -36,21 +36,12 @@ struct RootView: View {
         @Bindable var ui = ui
 
         NavigationSplitView {
-            SidebarView(bottomInset: transportHeight)
+            SidebarView()
                 .navigationSplitViewColumnWidth(min: 190, ideal: 215, max: 290)
         } detail: {
             NavigationStack(path: nav.stack) {
                 StageView()
-                    // The transport is a safeAreaInset on the split view, which
-                    // reserves space in the *window* but not inside the detail
-                    // column's own scroll views — a List draws its last rows
-                    // under the bar, where they cannot be read or clicked.
-                    //
-                    // Measured rather than a constant. The bar's height is a
-                    // stack of paddings and a control size, so any number
-                    // written here would be right until one of them changed and
-                    // then be a gap or a clipped row with nothing to say why.
-                    .safeAreaPadding(.bottom, transportHeight)
+                    .clearsTransport(transportHeight)
                     // The stack draws its own back button for pushed
                     // destinations, next to the pair we already have — three
                     // chevrons in a row. Ours can cross sections and search
@@ -60,9 +51,11 @@ struct RootView: View {
                         case .album(let id):
                             AlbumDetailView(albumId: id)
                                 .navigationBarBackButtonHidden(true)
+                                .clearsTransport(transportHeight)
                         case .artist(let id):
                             ArtistDetailView(artistId: id)
                                 .navigationBarBackButtonHidden(true)
+                                .clearsTransport(transportHeight)
                         }
                     }
             }
@@ -88,19 +81,23 @@ struct RootView: View {
         }
         .onChange(of: search.query) { _, _ in search.schedule() }
         .onSubmit(of: .search) { handleSubmit() }
-        .safeAreaInset(edge: .bottom, spacing: 0) {
-            VStack(spacing: 0) {
-                Divider()
-                TransportBar()
-            }
-            .background(
-                GeometryReader { proxy in
-                    Color.clear.preference(
-                        key: TransportHeightKey.self,
-                        value: proxy.size.height
-                    )
-                }
-            )
+        // On the window rather than inside the detail column: a
+        // `NavigationStack` drops decoration applied around it the moment it
+        // pushes, and the transport vanished on every album and artist page.
+        // Padded clear of the sidebar instead, because glass floating on glass
+        // reads as neither. Each screen makes its own room with
+        // `clearsTransport`.
+        .overlay(alignment: .bottom) {
+            TransportBar()
+                .padding(.leading, ui.sidebarWidth)
+                .background(
+                    GeometryReader { proxy in
+                        Color.clear.preference(
+                            key: TransportHeightKey.self,
+                            value: proxy.size.height
+                        )
+                    }
+                )
         }
         .onPreferenceChange(TransportHeightKey.self) { transportHeight = $0 }
         .onGeometryChange(for: CGSize.self) { $0.size } action: { ui.windowSize = $0 }
@@ -121,12 +118,10 @@ struct RootView: View {
                 .help("Forward (⌘])")
             }
 
-            // Separate items, not one ToolbarItemGroup: a group is drawn as a
-            // single joined control, which put the filter field and the lyrics
-            // toggle inside the same capsule.
-            ToolbarItem(placement: .primaryAction) {
-                Spacer()
-            }
+            // Separate items with `ToolbarSpacer` between them, not one
+            // `ToolbarItemGroup`: a group shares a single pane of glass, which
+            // put the filter field and the lyrics toggle in the same capsule.
+            ToolbarSpacer(.flexible, placement: .primaryAction)
 
             // Filtering what is on screen belongs with it, not in the sidebar
             // search, which navigates away instead of narrowing.
@@ -144,6 +139,10 @@ struct RootView: View {
 
             // Sort belongs next to what it sorts, so it only appears there.
             if nav.section == .albums {
+                // Filtering and sorting are different questions, so they get
+                // different panes of glass rather than one joined control.
+                ToolbarSpacer(.fixed, placement: .primaryAction)
+
                 // A pull-down with the current choice ticked, the way Finder's
                 // arrange control works — rather than a picker forced to a
                 // fixed width, which reads as a control that did not fit.
@@ -206,7 +205,8 @@ struct RootView: View {
         .overlay(alignment: .bottom) {
             if let error = player.lastError {
                 ErrorToast(message: error) { player.lastError = nil }
-                    .padding(.bottom, 24)
+                    // Above the transport, not behind it.
+                    .padding(.bottom, transportHeight + 10)
             }
         }
     }
@@ -285,11 +285,11 @@ private struct ErrorToast: View {
             .buttonStyle(.plain)
             .foregroundStyle(.secondary)
         }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 10)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 10))
-        .overlay(RoundedRectangle(cornerRadius: 10).strokeBorder(.separator))
-        .shadow(radius: 12, y: 4)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 11)
+        // Tinted glass rather than a material and a border: the tint carries
+        // the warning without a second colour, and glass already has an edge.
+        .glassEffect(.regular.tint(.orange.opacity(0.22)), in: .capsule)
         .task {
             try? await Task.sleep(for: .seconds(6))
             dismiss()
@@ -304,5 +304,21 @@ private struct TransportHeightKey: PreferenceKey {
     static let defaultValue: CGFloat = 0
     static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
         value = max(value, nextValue())
+    }
+}
+
+private extension View {
+    /// Room for the transport, which floats over every screen in the stack.
+    ///
+    /// Measured rather than a constant. The bar's height is a stack of paddings
+    /// and a control size, so any number written here would be right until one
+    /// of them changed and then be a gap, or a row clipped by a bar with
+    /// nothing to say why.
+    func clearsTransport(_ height: CGFloat) -> some View {
+        // Content passing under the glass is what makes it glass. The soft edge
+        // fades a row out as it goes, so one half under the bar reads as behind
+        // it rather than cut off.
+        safeAreaPadding(.bottom, height)
+            .scrollEdgeEffectStyle(.soft, for: .bottom)
     }
 }

--- a/apps/macos/Sources/Koan/Views/RootView.swift
+++ b/apps/macos/Sources/Koan/Views/RootView.swift
@@ -95,6 +95,11 @@ struct RootView: View {
             NavigationStack(path: nav.stack) {
                 StageView()
                     .clearsTransport(transportHeight)
+                    // A page with no wash needs a ground of its own. The
+                    // window's is the wash now, so anything transparent
+                    // composites onto it — and onto the page you came from,
+                    // which is what a library grid was doing.
+                    .background(washSource == nil ? AnyShapeStyle(.background) : AnyShapeStyle(.clear))
                     // The stack draws its own back button for pushed
                     // destinations, next to the pair we already have — three
                     // chevrons in a row. Ours can cross sections and search
@@ -109,6 +114,9 @@ struct RootView: View {
                             ArtistDetailView(artistId: id)
                                 .navigationBarBackButtonHidden(true)
                                 .clearsTransport(transportHeight)
+                                // An artist is a shelf of records rather than
+                                // one, so there is no wash to show through.
+                                .background(.background)
                         }
                     }
             }

--- a/apps/macos/Sources/Koan/Views/RootView.swift
+++ b/apps/macos/Sources/Koan/Views/RootView.swift
@@ -110,6 +110,20 @@ struct RootView: View {
                             AlbumDetailView(albumId: id)
                                 .navigationBarBackButtonHidden(true)
                                 .clearsTransport(transportHeight)
+                                // Its own ground and its own wash, rather than
+                                // borrowing the window's. A pushed view lingers
+                                // in the hierarchy after you pop it, and a
+                                // transparent one goes on drawing itself over
+                                // the grid you came back to.
+                                .background {
+                                    ZStack {
+                                        Rectangle().fill(.background)
+                                        ArtworkBleed(
+                                            source: .album(id),
+                                            drifts: player.isPlaying
+                                        )
+                                    }
+                                }
                         case .artist(let id):
                             ArtistDetailView(artistId: id)
                                 .navigationBarBackButtonHidden(true)

--- a/apps/macos/Sources/Koan/Views/RootView.swift
+++ b/apps/macos/Sources/Koan/Views/RootView.swift
@@ -46,6 +46,29 @@ struct RootView: View {
     /// it used to be.
     @State private var columns: NavigationSplitViewVisibility = .automatic
 
+    /// What the window is washed in: the record you opened, or the one playing,
+    /// and only where either means something. A library grid is its own colour.
+    private var washSource: AlbumArtwork.Source? {
+        if case .album(let id) = nav.stack.wrappedValue.last {
+            .album(id)
+        } else if nav.section == .queue {
+            bleed
+        } else {
+            nil
+        }
+    }
+
+    /// What the *controls* take their colour from. The page you are on first —
+    /// an album's own record — and what is playing everywhere else, so a
+    /// favourites list is still coloured by the music rather than by nothing.
+    private var tintSource: AlbumArtwork.Source? {
+        if case .album(let id) = nav.stack.wrappedValue.last {
+            .album(id)
+        } else {
+            bleed
+        }
+    }
+
     /// Which record is playing — artist as well as title, because "Greatest
     /// Hits" is not one record.
     private var playingRecord: String? {
@@ -61,15 +84,7 @@ struct RootView: View {
         // environment `RootView` was handed, so anything it needs is captured
         // here. Reading an `@Environment` inside that closure — including to
         // put one back — traps, and the app dies on launch.
-        // An album page washes the window in the record you opened; everywhere
-        // else it is the record playing, and only where that means something.
-        let wash: AlbumArtwork.Source? = if case .album(let id) = nav.stack.wrappedValue.last {
-            .album(id)
-        } else if nav.section == .queue {
-            bleed
-        } else {
-            nil
-        }
+        let wash = washSource
         let washDrifts = player.isPlaying
         let artCache = art
 
@@ -136,8 +151,8 @@ struct RootView: View {
         .onChange(of: playingRecord, initial: true) { _, _ in
             bleed = player.currentTrackId.map { .track($0) }
         }
-        .task(id: bleed) {
-            guard let bleed, let cover = await art.image(for: bleed) else {
+        .task(id: tintSource) {
+            guard let tintSource, let cover = await art.image(for: tintSource) else {
                 recordTint = nil
                 return
             }
@@ -148,7 +163,7 @@ struct RootView: View {
         // rings — keeps the declared accent, and that is deliberately a neutral
         // so the two never argue.
         .tint(recordTint ?? .koanAccent)
-        .animation(.easeInOut(duration: 3), value: recordTint)
+        .animation(.easeInOut(duration: 2), value: recordTint)
         // The toolbar paints its own ground over whatever is behind it, which
         // put a hard grey strip across the top of a queue washed in the colour
         // of the record. Hidden, the glass controls sit in that colour — which

--- a/apps/macos/Sources/Koan/Views/ShortcutsSheet.swift
+++ b/apps/macos/Sources/Koan/Views/ShortcutsSheet.swift
@@ -51,9 +51,9 @@ struct ShortcutsSheet: View {
                 ForEach(hotkey.keys, id: \.self) { key in
                     Text(key == " " ? "space" : key)
                         .font(.caption.monospaced())
-                        .padding(.horizontal, 5)
-                        .padding(.vertical, 2)
-                        .background(.quaternary, in: RoundedRectangle(cornerRadius: 4))
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 3)
+                        .glassEffect(.regular, in: .rect(cornerRadius: 6))
                 }
             }
             Text(hotkey.label)

--- a/apps/macos/Sources/Koan/Views/SidebarView.swift
+++ b/apps/macos/Sources/Koan/Views/SidebarView.swift
@@ -2,13 +2,6 @@ import KoanFFI
 import SwiftUI
 
 struct SidebarView: View {
-    /// The transport bar's height. The bar is a `safeAreaInset` on the split
-    /// view, which reserves space in the window but not inside this List — so
-    /// the footer drew underneath it and everything below the first activity
-    /// row was cut off. Measured in `RootView` and passed down rather than
-    /// guessed at, for the same reason the detail column measures it.
-    let bottomInset: CGFloat
-
     @Environment(LibraryModel.self) private var library
     @Environment(Navigator.self) private var nav
     @Environment(PlayerModel.self) private var player
@@ -75,6 +68,9 @@ struct SidebarView: View {
             }
         }
         .listStyle(.sidebar)
+        // The footer floats over the rows rather than being fenced off by a
+        // divider; the soft edge fades a row out as it passes underneath.
+        .scrollEdgeEffectStyle(.soft, for: .bottom)
         // The field belongs to the sidebar, not the window: in the toolbar it
         // sat on top of the lyrics inspector.
         .searchable(text: $search.query, placement: .sidebar, prompt: "Search")
@@ -85,10 +81,9 @@ struct SidebarView: View {
         .onChange(of: ui.searchFocusToken) { _, _ in
             searchFocused = true
         }
-        .safeAreaInset(edge: .bottom) {
-            footer
-                .padding(.bottom, bottomInset)
-        }
+        .safeAreaInset(edge: .bottom) { footer }
+        .onGeometryChange(for: CGFloat.self) { $0.size.width } action: { ui.sidebarWidth = $0 }
+        .onDisappear { ui.sidebarWidth = 0 }
     }
 
     /// What radio is about to do, rather than that it is switched on.
@@ -109,8 +104,6 @@ struct SidebarView: View {
     @ViewBuilder
     private var footer: some View {
         VStack(alignment: .leading, spacing: 6) {
-            Divider()
-
             // Every long task, one row each. Replaces a "Scanning…" line that
             // said the same thing whatever was actually running.
             ActivityList()

--- a/apps/macos/Sources/Koan/Views/TrackListView.swift
+++ b/apps/macos/Sources/Koan/Views/TrackListView.swift
@@ -47,9 +47,13 @@ struct TrackListView: View {
                         }
                     }
                     .listStyle(.inset)
-                    // Otherwise the List paints over the window's wash and the
-                    // record's colour stops in a line under the header.
-                    .scrollContentBackground(.hidden)
+                    // Gives up its ground only where there is a wash to show:
+                    // otherwise the List paints over it and the record's colour
+                    // stops in a line under the header. Without a cover — a
+                    // favourites list — it keeps its ground, or it composites
+                    // onto whatever the window is drawing, which is the page
+                    // you came from.
+                    .scrollContentBackground(artwork == nil ? .visible : .hidden)
 
                     // The List's own double-click hook. Wired into selection
                     // rather than the gesture system, so it doesn't steal the

--- a/apps/macos/Sources/Koan/Views/TrackListView.swift
+++ b/apps/macos/Sources/Koan/Views/TrackListView.swift
@@ -47,6 +47,10 @@ struct TrackListView: View {
                         }
                     }
                     .listStyle(.inset)
+                    // Otherwise the List paints over the window's wash and the
+                    // record's colour stops in a line under the header.
+                    .scrollContentBackground(.hidden)
+
                     // The List's own double-click hook. Wired into selection
                     // rather than the gesture system, so it doesn't steal the
                     // first click.

--- a/apps/macos/Sources/Koan/Views/TrackListView.swift
+++ b/apps/macos/Sources/Koan/Views/TrackListView.swift
@@ -24,7 +24,6 @@ struct TrackListView: View {
                 .padding(.horizontal, 24)
                 .padding(.top, 18)
                 .padding(.bottom, 16)
-                .background(alignment: .top) { ArtworkBleed(source: artwork) }
 
             if tracks.isEmpty {
                 EmptyState(icon: "music.note.list", title: "No tracks")

--- a/apps/macos/Sources/Koan/Views/TrackListView.swift
+++ b/apps/macos/Sources/Koan/Views/TrackListView.swift
@@ -24,7 +24,7 @@ struct TrackListView: View {
                 .padding(.horizontal, 24)
                 .padding(.top, 18)
                 .padding(.bottom, 16)
-                .background(alignment: .top) { artworkBackdrop }
+                .background(alignment: .top) { ArtworkBleed(source: artwork) }
 
             if tracks.isEmpty {
                 EmptyState(icon: "music.note.list", title: "No tracks")
@@ -110,37 +110,6 @@ struct TrackListView: View {
     private var subtitleRest: String {
         let parts = subtitle.components(separatedBy: " · ").dropFirst()
         return parts.isEmpty ? "" : "· " + parts.joined(separator: " · ")
-    }
-
-    /// The cover, blurred out to fill the space behind the header.
-    ///
-    /// `backgroundExtensionEffect` is what makes it worth doing: it mirrors the
-    /// blur outwards into the insets around the detail column, so the colour of
-    /// the record carries under the glass sidebar and toolbar instead of
-    /// stopping at a hard edge where the pane begins. The gradient goes on
-    /// first so the mirrored copy fades out the same way the real one does.
-    @ViewBuilder
-    private var artworkBackdrop: some View {
-        if let artwork {
-            GeometryReader { geo in
-                AlbumArtwork(source: artwork, cornerRadius: 0)
-                    .frame(width: geo.size.width, height: geo.size.width)
-                    .offset(y: (geo.size.height - geo.size.width) / 2)
-                    .blur(radius: 64)
-                    .saturation(1.6)
-            }
-            .clipped()
-            .opacity(0.5)
-            .mask(
-                LinearGradient(
-                    colors: [.black, .black, .clear],
-                    startPoint: .top,
-                    endPoint: .bottom
-                )
-            )
-            .backgroundExtensionEffect()
-            .allowsHitTesting(false)
-        }
     }
 
     private var header: some View {

--- a/apps/macos/Sources/Koan/Views/TrackListView.swift
+++ b/apps/macos/Sources/Koan/Views/TrackListView.swift
@@ -24,6 +24,7 @@ struct TrackListView: View {
                 .padding(.horizontal, 24)
                 .padding(.top, 18)
                 .padding(.bottom, 16)
+                .background(alignment: .top) { artworkBackdrop }
 
             if tracks.isEmpty {
                 EmptyState(icon: "music.note.list", title: "No tracks")
@@ -109,6 +110,37 @@ struct TrackListView: View {
     private var subtitleRest: String {
         let parts = subtitle.components(separatedBy: " · ").dropFirst()
         return parts.isEmpty ? "" : "· " + parts.joined(separator: " · ")
+    }
+
+    /// The cover, blurred out to fill the space behind the header.
+    ///
+    /// `backgroundExtensionEffect` is what makes it worth doing: it mirrors the
+    /// blur outwards into the insets around the detail column, so the colour of
+    /// the record carries under the glass sidebar and toolbar instead of
+    /// stopping at a hard edge where the pane begins. The gradient goes on
+    /// first so the mirrored copy fades out the same way the real one does.
+    @ViewBuilder
+    private var artworkBackdrop: some View {
+        if let artwork {
+            GeometryReader { geo in
+                AlbumArtwork(source: artwork, cornerRadius: 0)
+                    .frame(width: geo.size.width, height: geo.size.width)
+                    .offset(y: (geo.size.height - geo.size.width) / 2)
+                    .blur(radius: 64)
+                    .saturation(1.6)
+            }
+            .clipped()
+            .opacity(0.5)
+            .mask(
+                LinearGradient(
+                    colors: [.black, .black, .clear],
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+            )
+            .backgroundExtensionEffect()
+            .allowsHitTesting(false)
+        }
     }
 
     private var header: some View {

--- a/apps/macos/Sources/Koan/Views/TransportBar.swift
+++ b/apps/macos/Sources/Koan/Views/TransportBar.swift
@@ -173,8 +173,12 @@ private struct SeekBar: View {
                     Capsule()
                         .fill(.quaternary)
                         .frame(height: 4)
+                    // Not the tint. The tint is the colour of the record now,
+                    // and a muted sleeve puts the played portion at the same
+                    // value as the track behind it — this is a bar you read a
+                    // position off, not a thing that needs to say whose it is.
                     Capsule()
-                        .fill(.tint)
+                        .fill(.primary)
                         .frame(width: geo.size.width * player.progress, height: 4)
                 }
                 .frame(maxHeight: .infinity, alignment: .center)

--- a/apps/macos/Sources/Koan/Views/TransportBar.swift
+++ b/apps/macos/Sources/Koan/Views/TransportBar.swift
@@ -1,15 +1,31 @@
 import KoanFFI
 import SwiftUI
 
+/// The transport, as a slab of glass floating over the stage.
+///
+/// Inset from the window rather than welded to its bottom edge: the material
+/// only reads as glass when there is something moving underneath it and an edge
+/// for the light to catch. `RootView` insets the stage by the bar's measured
+/// height so the queue keeps scrolling under it instead of stopping short.
+///
+/// It stops short of the sidebar, which is glass in its own right on macOS 26 —
+/// glass floating on glass reads as neither.
 struct TransportBar: View {
     @Environment(PlayerModel.self) private var player
+
+    /// Wide enough to read as a slab rather than a pill at this height.
+    private static let radius: CGFloat = 26
+    /// One height for all three zones, so the bar is a bar and not a stack of
+    /// controls that happen to be near each other.
+    private static let zoneHeight: CGFloat = 46
 
     var body: some View {
         // Three equal-weight columns so the transport stays centred as the
         // window grows, rather than the centre pinning at a fixed width and
         // everything bunching to the left.
-        HStack(spacing: 16) {
+        HStack(spacing: 18) {
             nowPlaying
+                .frame(height: Self.zoneHeight)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .layoutPriority(1)
 
@@ -17,16 +33,20 @@ struct TransportBar: View {
                 controls
                 SeekBar()
             }
+            .frame(height: Self.zoneHeight)
             .frame(maxWidth: 560)
             .layoutPriority(2)
 
             trailing
+                .frame(height: Self.zoneHeight)
                 .frame(maxWidth: .infinity, alignment: .trailing)
                 .layoutPriority(1)
         }
-        .padding(.horizontal, 18)
-        .padding(.vertical, 11)
-        .background(.bar)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 9)
+        .glassEffect(.regular, in: .rect(cornerRadius: Self.radius))
+        .padding(.horizontal, 16)
+        .padding(.bottom, 14)
     }
 
     // MARK: - Left: what's on
@@ -35,8 +55,8 @@ struct TransportBar: View {
     private var nowPlaying: some View {
         HStack(spacing: 11) {
             if let trackId = player.currentTrackId {
-                AlbumArtwork(source: .track(trackId), cornerRadius: 5)
-                    .frame(width: 46, height: 46)
+                AlbumArtwork(source: .track(trackId), cornerRadius: 8)
+                    .frame(width: 44, height: 44)
                     .showsArtworkFullSize(
                         source: .track(trackId),
                         title: player.nowPlaying.entry?.title ?? "",
@@ -45,9 +65,9 @@ struct TransportBar: View {
                         }
                     )
             } else {
-                RoundedRectangle(cornerRadius: 5)
+                RoundedRectangle(cornerRadius: 8)
                     .fill(.quaternary)
-                    .frame(width: 46, height: 46)
+                    .frame(width: 44, height: 44)
                     .overlay {
                         Image(systemName: "music.note")
                             .foregroundStyle(.tertiary)
@@ -76,17 +96,20 @@ struct TransportBar: View {
     // MARK: - Centre: transport
 
     private var controls: some View {
-        HStack(spacing: 20) {
+        HStack(spacing: 22) {
             Button(action: player.previous) {
                 Image(systemName: "backward.fill")
             }
             .keyboardShortcut(.leftArrow, modifiers: .command)
             .help("Previous track (⌘←)")
 
+            // Bigger than the pair either side of it: it is the one you reach
+            // for without looking.
             Button(action: player.togglePlayPause) {
                 Image(systemName: player.isPlaying ? "pause.fill" : "play.fill")
-                    .font(.system(size: 19))
-                    .frame(width: 26)
+                    .font(.system(size: 25))
+                    .contentTransition(.symbolEffect(.replace))
+                    .frame(width: 30)
             }
             .help(player.isPlaying ? "Pause (Space)" : "Play (Space)")
 
@@ -97,15 +120,14 @@ struct TransportBar: View {
             .help("Next track (⌘→)")
         }
         .buttonStyle(.plain)
-        .font(.system(size: 14))
-        .disabled(player.currentEntry == nil)
+        .font(.system(size: 13))
     }
 
     // MARK: - Right: format and output
 
     @ViewBuilder
     private var trailing: some View {
-        HStack(spacing: 14) {
+        HStack(spacing: 12) {
             // The whole point of the player: what the DAC is being handed.
             if let format = player.currentFormat {
                 Text(Format.quality(format))
@@ -113,7 +135,7 @@ struct TransportBar: View {
                     .foregroundStyle(.secondary)
                     .padding(.horizontal, 8)
                     .padding(.vertical, 3)
-                    .background(.quaternary, in: RoundedRectangle(cornerRadius: 5))
+                    .background(.quaternary, in: Capsule())
                     .help("Source format — koan matches the device rate rather than resampling")
             }
 
@@ -126,6 +148,7 @@ struct TransportBar: View {
                     .font(.caption)
             }
             .toggleStyle(.button)
+            .buttonStyle(.glass)
             .help("Radio (⌥⌘R) — when the queue runs low, keep it topped up with similar tracks")
 
             DeviceMenu()


### PR DESCRIPTION
Closes #278

Two halves that turned out to be one thing. macOS 26's Liquid Glass adopted with the real APIs — `glassEffect`, `ToolbarSpacer`, `backgroundExtensionEffect`, `scrollEdgeEffectStyle`, `containerBackground(for: .window)` — and then, because glass only means anything when there is something behind it, the record playing became the thing behind it.

#286 was squashed into this branch partway through; everything after it is here too.

## The glass

**The transport floats.** It was a bar welded to the window's bottom edge behind a divider, with the stage stopping short of it. It is now a glass slab inset from the edges with content scrolling underneath, fading at the soft scroll edge. Glass with nothing moving behind it is a grey rectangle, so the content passing under it is the point.

**It hangs off the window, not the detail column.** A `NavigationStack` drops decoration applied *around* it the moment it pushes, so a `safeAreaInset` or `overlay` on the detail column vanished on every album and artist page. It is an overlay on the split view, padded clear of the sidebar by the width the sidebar reports, and full width when the sidebar is closed. Each screen reserves its own room with `clearsTransport`.

**Toolbar groups are declared, not faked.** `ToolbarSpacer(.flexible/.fixed)` replaces a `Spacer` smuggled inside a `ToolbarItem`; filter and sort get their own panes rather than sharing a capsule with the lyrics toggle. Its background is hidden so the wash runs behind it.

**Glass wherever something sits over content** — codec badges on sleeves are `.clear` glass instead of black scrims, the favourite heart gets a ground of its own and materializes on hover, plus artist chips, shortcut key caps, the picker's commit bar and the error toast.

## The colour

**The wash is on the window.** Nothing inside a split-view column reaches past the toolbar's inset, so a wash owned by the queue stopped in a grey line under it. `containerBackground(for: .window)` runs it full height under the toolbar, the sidebar and the transport. Two traps came with that: it *replaces* the window's own ground rather than sitting on it (hence the opaque base, or you see straight through the app to the desktop), and the scene evaluates its content outside every environment `RootView` was handed — reading an `@Environment` in there traps on launch, so what it needs is captured outside.

**Pages without a wash need a ground of their own.** Once the window's background is the wash, anything transparent composites onto it *and onto the page you came from*. The album page goes further and carries its own wash over its own opaque base, because a popped `NavigationStack` destination lingers in the hierarchy and kept drawing itself across the library grid.

**It follows the record, not the track** — artwork is fetched per track id, so deriving it from `currentTrackId` would refetch the same sleeve every few minutes. And **not scroll position**: the transport floats in that colour, and following the scroll would have it announce whichever record you scrolled past.

**The tint is the dominant colour of the sleeve, not its average.** Averaging every pixel of a busy cover gives the same brown-grey every time as opposite hues cancel; this is a circular mean of hue weighted by how colourful each sample is, clamped to stay legible on dark chrome. It follows the page — an album's own record, the playing one everywhere else.

**The accent goes near-black.** All it still drives is what AppKit draws, since a root `.tint()` overrides everything koan draws itself. At that weight the selection reads as a recess with a crisp white label; a light accent does not work, because macOS lifts the label off a light fill only as far as a mid grey. (It is only honoured at all when the user's system accent is Multicolor — an explicit system accent wins, and nothing can be done about that.)

**Dissolves are 2s**, holding a resolved `NSImage` rather than drawing through `AlbumArtwork`, whose placeholder would be a long grey wipe between records. A record with no art is no wash rather than a grey one. The blur happens at 360pt and is magnified afterwards, so the drift costs nothing; it pauses rather than stops, on periods of 13/19/23s so it never lands back where it started.

## How to check it

`just macos-run`:

- **Queue** — rows pass under the transport and fade; the wash is the playing record's colour, under the toolbar and behind the sidebar. It should wander visibly over ten seconds and hold still when you press space.
- **Skip between records** — a 2s cross-dissolve, never a grey flash. Within a record, nothing changes and no artwork request fires.
- **Open an album, then go back** — the album page has its own wash and tint, and nothing of it survives onto the grid.
- **Favourites / Artists / library grids** — opaque, no wash, tint still from what is playing.
- **Sidebar** — nothing of the transport touches it, collapsed or expanded.
- **A record with no cover** — the wash fades out rather than washing grey.

Measured rather than eyeballed: mean pixel delta over the header strip across 6s is 30.7 while playing and 0.45 while paused.

Verified by looking at it rather than by tests. The bits worth re-checking after a squash are the transparency rules: popping back from an album to the grid, and Favourites, which shares `TrackListView` but has no cover and so keeps its own list background.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017HbjSSsL2MTmazfJFPdAst