### PR TITLE
fix(core): count cached tracks by what a download actually writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- **The sidebar said no remote tracks were cached, however many were.** The count asked for tracks whose `source` is `'cached'` — a value the schema allows and nothing writes, because downloading a track does not change where it came from. What a download writes is `cached_path`, which is what `set_cached_path` sets and clearing the cache nulls. Counted from there it agrees with the files on disk.
+
 ## v0.29.1 (2026-08-24)
 
 ### Changed

--- a/crates/koan-core/src/db/queries/stats.rs
+++ b/crates/koan-core/src/db/queries/stats.rs
@@ -17,8 +17,12 @@ pub fn library_stats(conn: &Connection) -> Result<LibraryStats, DbError> {
         [],
         |r| r.get(0),
     )?;
+    // A downloaded track keeps `source = 'remote'` — where it came from does
+    // not change because a copy landed on disk. What changes is `cached_path`,
+    // which is what `set_cached_path` writes and `clear_download_cache` nulls.
+    // 'cached' is a source the CHECK constraint allows and nothing writes.
     let cached_tracks: i64 = conn.query_row(
-        "SELECT COUNT(*) FROM tracks WHERE source = 'cached'",
+        "SELECT COUNT(*) FROM tracks WHERE cached_path IS NOT NULL",
         [],
         |r| r.get(0),
     )?;
@@ -64,5 +68,37 @@ mod tests {
         assert_eq!(stats.local_tracks, 2);
         assert_eq!(stats.total_albums, 2);
         assert_eq!(stats.total_artists, 2);
+    }
+
+    /// Downloading does not change where a track came from, so counting
+    /// `source = 'cached'` counted nothing — a library with a full cache
+    /// reported "0 of 47,944 cached" and always would have.
+    #[test]
+    fn a_downloaded_track_counts_as_cached_and_stays_remote() {
+        let db = test_db();
+        let mut meta = sample_meta("Song", "Artist", "Album");
+        meta.source = "remote".into();
+        meta.path = None;
+        meta.remote_id = Some("r1".into());
+        let id = upsert_track(&db.conn, &meta).unwrap();
+
+        let stats = library_stats(&db.conn).unwrap();
+        assert_eq!(stats.remote_tracks, 1);
+        assert_eq!(stats.cached_tracks, 0, "nothing downloaded yet");
+
+        let file = std::env::temp_dir().join("koan-stats-cached.mp3");
+        std::fs::write(&file, b"not really audio").unwrap();
+        super::super::set_cached_path(&db.conn, id, &file.to_string_lossy()).unwrap();
+
+        let stats = library_stats(&db.conn).unwrap();
+        assert_eq!(stats.cached_tracks, 1);
+        assert_eq!(
+            stats.remote_tracks, 1,
+            "a cached copy does not change where the track came from"
+        );
+
+        super::super::clear_cached_paths(&db.conn).unwrap();
+        assert_eq!(library_stats(&db.conn).unwrap().cached_tracks, 0);
+        let _ = std::fs::remove_file(&file);
     }
 }


### PR DESCRIPTION
The sidebar reports "0 of 47,944 remote cached" on a library with a full cache, and always would have.

```sql
SELECT COUNT(*) FROM tracks WHERE source = 'cached'
```

`'cached'` is a source the schema's CHECK constraint allows and **nothing in the workspace writes**. Downloading a track does not change where it came from — it stays `'remote'`, which is correct, and is also why the "X of Y remote" framing only makes sense this way round.

What a download actually writes is `cached_path` (with `cache_size_bytes` and `cache_download_date`), via `set_cached_path`, and `clear_download_cache` nulls all three. The write side was never broken — on the library this was found on, **206 tracks carry a `cached_path` and there are exactly 206 files in the cache directory.** Only the question being asked was wrong.

Counted from `cached_path`, that library now reports `206 of 47,944 remote cached`.

## Test

`a_downloaded_track_counts_as_cached_and_stays_remote` — a remote track, then `set_cached_path`, then `clear_cached_paths`, asserting the count moves 0 → 1 → 0 **and that `remote_tracks` never moves**. That second assertion is the one that would have caught this: a cached copy does not change a track's origin, and any implementation that makes those two counts exclusive breaks the sentence the sidebar prints.

`'cached'` is left in the CHECK constraint — removing it wants a migration, and it is inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L2QYGXTN6dYC7MX5KNY8a5