### PR TITLE
feat(macos): the app takes its colour from the record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Changed
 
+- **The queue takes its colour from the record playing.** A queue is a list of names, and the only thing in it with a colour is the record that is on. Its cover, blurred out, washes the top of the queue and fades across the first few rows — the same treatment an album page gives its header, applied to what is playing rather than to what you opened. It follows the *record*, not the track: artwork is fetched per track, so re-deriving it every few minutes would ask the server for another copy of the same sleeve.
+
+  Not tied to scroll position. The wash says what is playing, and following the scroll would have it announce whichever record you happened to be looking at instead.
+
 - **The macOS app is built out of Liquid Glass.** Not a coat of blur over the old chrome — the real macOS 26 material, and the layout changes it asks for. The transport is a slab of glass floating over the stage rather than a bar welded to the window's bottom edge behind a divider: the queue scrolls *under* it, fading out at the soft scroll edge as it goes, because glass with nothing moving behind it is just a grey rectangle. It stops short of the sidebar, which is glass in its own right on 26, and stacking the two reads as neither.
 
   It hangs off the window rather than the detail column. A `NavigationStack` drops decoration applied around it the moment it pushes, which took the transport off every album and artist page; each screen now makes its own room for it instead. Play/pause is bigger than the two beside it and no longer goes dead when nothing is queued — it is the control you reach for without looking.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - **The queue takes its colour from the record playing.** A queue is a list of names, and the only thing in it with a colour is the record that is on. Its cover, blurred out, washes the top of the queue and fades across the first few rows — the same treatment an album page gives its header, applied to what is playing rather than to what you opened. It follows the *record*, not the track: artwork is fetched per track, so re-deriving it every few minutes would ask the server for another copy of the same sleeve.
 
+  It drifts while something is playing — a slow wander of scale, rotation and offset on three periods that never line up, so it never reads as a loop — and settles where it is when you stop. One record dissolves into the next over five seconds, long enough that you notice the room has changed colour without catching it changing. The old cover stays up until the new one is in hand rather than wiping through a placeholder, and a record with no art is no wash rather than a grey one.
+
   Not tied to scroll position. The wash says what is playing, and following the scroll would have it announce whichever record you happened to be looking at instead.
 
 - **The macOS app is built out of Liquid Glass.** Not a coat of blur over the old chrome — the real macOS 26 material, and the layout changes it asks for. The transport is a slab of glass floating over the stage rather than a bar welded to the window's bottom edge behind a divider: the queue scrolls *under* it, fading out at the soft scroll edge as it goes, because glass with nothing moving behind it is just a grey rectangle. It stops short of the sidebar, which is glass in its own right on 26, and stacking the two reads as neither.

--- a/apps/macos/Sources/Koan/Views/ArtworkBleed.swift
+++ b/apps/macos/Sources/Koan/Views/ArtworkBleed.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 /// The cover, blurred out to a wash of the record's colour behind a header.
@@ -14,20 +15,55 @@ struct ArtworkBleed: View {
     /// Nothing playing, or a record with no art, means no wash rather than a
     /// grey one.
     let source: AlbumArtwork.Source?
+    /// Whether the wash drifts. The room breathes while something is playing
+    /// and settles when it stops.
+    var drifts = false
+
+    @Environment(CoverArtCache.self) private var cache
+    /// Held rather than drawn through `AlbumArtwork`, which shows a placeholder
+    /// while it loads. Over a five second dissolve that placeholder is a long
+    /// grey wipe between two records, so the old cover stays up until the new
+    /// one is actually in hand.
+    @State private var image: NSImage?
+    /// Bumped when the cover changes, which is what the dissolve keys on. The
+    /// image itself cannot: `NSImage` is a reference and identity is not enough
+    /// to drive a transition.
+    @State private var generation = 0
+
+    /// The cover is blurred to mush, so it is rendered small and scaled up
+    /// afterwards. Blurring a 360pt layer and magnifying the result costs a
+    /// fraction of blurring one the width of the window, which matters when it
+    /// is redrawn twenty times a second.
+    private static let side: CGFloat = 360
 
     var body: some View {
         GeometryReader { geo in
-            if let source {
-                // Square art drawn at the full width and centred vertically:
-                // the wash wants the middle of the cover, not a letterboxed
-                // copy of the whole thing.
-                AlbumArtwork(source: source, cornerRadius: 0)
-                    .frame(width: geo.size.width, height: geo.size.width)
-                    .offset(y: (geo.size.height - geo.size.width) / 2)
-                    .blur(radius: 64)
-                    .saturation(1.6)
-                    .id(source)
-                    .transition(.opacity)
+            // Paused rather than switched off, so stopping playback leaves the
+            // drift where it is instead of snapping it back.
+            TimelineView(.animation(minimumInterval: 1 / 20, paused: !drifts)) { context in
+                ZStack {
+                    if let image {
+                        // Three incommensurate periods, so the drift never
+                        // arrives back where it started and never reads as a
+                        // loop.
+                        let t = context.date.timeIntervalSinceReferenceDate
+                        Image(nsImage: image)
+                            .resizable()
+                            .aspectRatio(contentMode: .fill)
+                            .frame(width: Self.side, height: Self.side)
+                            .blur(radius: 14)
+                            .scaleEffect(geo.size.width / Self.side * (1.25 + 0.06 * sin(t / 13)))
+                            .rotationEffect(.degrees(3 * sin(t / 19)))
+                            .offset(
+                                x: geo.size.width * 0.04 * sin(t / 23),
+                                y: geo.size.height * 0.06 * cos(t / 17)
+                            )
+                            .saturation(1.6)
+                            .id(generation)
+                            .transition(.opacity)
+                    }
+                }
+                .frame(width: geo.size.width, height: geo.size.height)
             }
         }
         .clipped()
@@ -41,8 +77,31 @@ struct ArtworkBleed: View {
         )
         .backgroundExtensionEffect()
         .allowsHitTesting(false)
-        // One record dissolving into the next. Long enough to read as the room
-        // changing colour rather than as a redraw.
-        .animation(.smooth(duration: 0.55), value: source)
+        // One record dissolving into the next over long enough that you notice
+        // the room has changed colour without ever catching it changing.
+        .animation(.easeInOut(duration: 5), value: generation)
+        .task(id: source) { await load() }
+    }
+
+    private func load() async {
+        guard let source else {
+            show(nil)
+            return
+        }
+        if let cached = cache.cached(source) {
+            show(cached)
+            return
+        }
+        let loaded = await cache.image(for: source)
+        // A cancelled load means the record moved on again; whatever came back
+        // is for the wrong one.
+        guard !Task.isCancelled else { return }
+        show(loaded)
+    }
+
+    private func show(_ new: NSImage?) {
+        guard new !== image else { return }
+        image = new
+        generation += 1
     }
 }

--- a/apps/macos/Sources/Koan/Views/ArtworkBleed.swift
+++ b/apps/macos/Sources/Koan/Views/ArtworkBleed.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+
+/// The cover, blurred out to a wash of the record's colour behind a header.
+///
+/// `backgroundExtensionEffect` is what makes it worth doing: it mirrors the
+/// blur outwards into the insets around the detail column, so the colour
+/// carries under the glass sidebar and toolbar instead of stopping at a hard
+/// edge where the pane begins. The gradient goes on first, so the mirrored copy
+/// fades out the same way the real one does.
+///
+/// Fills whatever it is given — a `.background` on a header takes the header's
+/// height; anywhere else, say how far down the page the wash should reach.
+struct ArtworkBleed: View {
+    /// Nothing playing, or a record with no art, means no wash rather than a
+    /// grey one.
+    let source: AlbumArtwork.Source?
+
+    var body: some View {
+        GeometryReader { geo in
+            if let source {
+                // Square art drawn at the full width and centred vertically:
+                // the wash wants the middle of the cover, not a letterboxed
+                // copy of the whole thing.
+                AlbumArtwork(source: source, cornerRadius: 0)
+                    .frame(width: geo.size.width, height: geo.size.width)
+                    .offset(y: (geo.size.height - geo.size.width) / 2)
+                    .blur(radius: 64)
+                    .saturation(1.6)
+                    .id(source)
+                    .transition(.opacity)
+            }
+        }
+        .clipped()
+        .opacity(0.5)
+        .mask(
+            LinearGradient(
+                colors: [.black, .black, .clear],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+        )
+        .backgroundExtensionEffect()
+        .allowsHitTesting(false)
+        // One record dissolving into the next. Long enough to read as the room
+        // changing colour rather than as a redraw.
+        .animation(.smooth(duration: 0.55), value: source)
+    }
+}

--- a/apps/macos/Sources/Koan/Views/QueueView.swift
+++ b/apps/macos/Sources/Koan/Views/QueueView.swift
@@ -18,6 +18,14 @@ struct QueueView: View {
     @State private var savingSnapshot = false
     @State private var snapshotName = ""
 
+    /// The record the wash behind the header is showing.
+    ///
+    /// Held rather than derived from `currentTrackId` on every frame: artwork
+    /// is fetched per *track*, so re-deriving it would ask the server for a new
+    /// copy of the same sleeve at every track change within a record. It only
+    /// moves when the record does.
+    @State private var bleed: AlbumArtwork.Source?
+
     /// Grouped or one row per track. Persisted because it is a preference about
     /// how you listen rather than about the queue in front of you: an album
     /// listen wants the headings, a long shuffled queue wants every row to say
@@ -44,7 +52,6 @@ struct QueueView: View {
     var body: some View {
         VStack(spacing: 0) {
             header
-            Divider()
 
             if player.queue.isEmpty {
                 EmptyState(
@@ -62,6 +69,10 @@ struct QueueView: View {
                         .onMove(perform: move)
                     }
                     .listStyle(.inset)
+                    // Otherwise the List paints over the wash and it stops at
+                    // the header in a hard line, rather than fading out across
+                    // the first few rows.
+                    .scrollContentBackground(.hidden)
                     // `g` / `G`. Watches the token rather than the edge: jumping
                     // to where you already are still has to scroll, because the
                     // list may have been moved since.
@@ -94,6 +105,16 @@ struct QueueView: View {
                 }
             }
         }
+        // The queue is a list of names; the record playing is the one thing in
+        // it with a colour. An album page washes its header in the cover, and
+        // this is the same treatment applied to what is on rather than to what
+        // you opened.
+        .background(alignment: .top) {
+            ArtworkBleed(source: bleed).frame(height: 320)
+        }
+        .onChange(of: playingRecord, initial: true) { _, _ in
+            bleed = player.currentTrackId.map { .track($0) }
+        }
         // On the whole stage, not the List: an empty queue is exactly when you
         // want to drop a folder on it, and it has no rows to land on.
         .dropDestination(for: URL.self) { urls, _ in
@@ -114,6 +135,12 @@ struct QueueView: View {
     }
 
     // MARK: - Header
+
+    /// Which record is playing — artist as well as title, because "Greatest
+    /// Hits" is not one record.
+    private var playingRecord: String? {
+        player.currentEntry.map { "\($0.albumArtist)\u{1}\($0.album)" }
+    }
 
     private var header: some View {
         HStack(spacing: 12) {

--- a/apps/macos/Sources/Koan/Views/QueueView.swift
+++ b/apps/macos/Sources/Koan/Views/QueueView.swift
@@ -110,7 +110,8 @@ struct QueueView: View {
         // this is the same treatment applied to what is on rather than to what
         // you opened.
         .background(alignment: .top) {
-            ArtworkBleed(source: bleed).frame(height: 320)
+            ArtworkBleed(source: bleed, drifts: player.isPlaying)
+                .frame(height: 320)
         }
         .onChange(of: playingRecord, initial: true) { _, _ in
             bleed = player.currentTrackId.map { .track($0) }

--- a/apps/macos/Sources/Koan/Views/TrackListView.swift
+++ b/apps/macos/Sources/Koan/Views/TrackListView.swift
@@ -24,7 +24,7 @@ struct TrackListView: View {
                 .padding(.horizontal, 24)
                 .padding(.top, 18)
                 .padding(.bottom, 16)
-                .background(alignment: .top) { artworkBackdrop }
+                .background(alignment: .top) { ArtworkBleed(source: artwork) }
 
             if tracks.isEmpty {
                 EmptyState(icon: "music.note.list", title: "No tracks")
@@ -110,37 +110,6 @@ struct TrackListView: View {
     private var subtitleRest: String {
         let parts = subtitle.components(separatedBy: " · ").dropFirst()
         return parts.isEmpty ? "" : "· " + parts.joined(separator: " · ")
-    }
-
-    /// The cover, blurred out to fill the space behind the header.
-    ///
-    /// `backgroundExtensionEffect` is what makes it worth doing: it mirrors the
-    /// blur outwards into the insets around the detail column, so the colour of
-    /// the record carries under the glass sidebar and toolbar instead of
-    /// stopping at a hard edge where the pane begins. The gradient goes on
-    /// first so the mirrored copy fades out the same way the real one does.
-    @ViewBuilder
-    private var artworkBackdrop: some View {
-        if let artwork {
-            GeometryReader { geo in
-                AlbumArtwork(source: artwork, cornerRadius: 0)
-                    .frame(width: geo.size.width, height: geo.size.width)
-                    .offset(y: (geo.size.height - geo.size.width) / 2)
-                    .blur(radius: 64)
-                    .saturation(1.6)
-            }
-            .clipped()
-            .opacity(0.5)
-            .mask(
-                LinearGradient(
-                    colors: [.black, .black, .clear],
-                    startPoint: .top,
-                    endPoint: .bottom
-                )
-            )
-            .backgroundExtensionEffect()
-            .allowsHitTesting(false)
-        }
     }
 
     private var header: some View {


### PR DESCRIPTION
Stacked on #284 — review that first; this branches off it, and main is merged in.

koan's chrome was pink whatever was playing. Now the cover of the record on — or of the album page you opened — is blurred into a wash across the whole window, and the controls take their colour from the same sleeve. The declared accent becomes a near-black neutral so nothing competes with it.

## Load-bearing decisions

**The wash is on the window, not behind a view.** Nothing inside a split-view column reaches past the toolbar's inset, so a wash owned by the queue stopped in a grey line under the toolbar. `containerBackground(for: .window)` runs it full height under the toolbar, the sidebar and the transport — every piece of glass in the app sits in it. Two traps came with that: it *replaces* the window's own ground rather than sitting on it (hence the opaque base, or you see straight through the app), and the scene evaluates its content outside every environment `RootView` was handed, so what it needs is captured rather than read inside it — reading an `@Environment` there traps on launch.

**A page with no wash needs a ground of its own.** Once the window's background is the wash, anything transparent composites onto it — and onto the page you came from. Library grids were drawing over the album page behind them. The album page goes further and carries its own wash over its own opaque base, because a popped `NavigationStack` destination lingers in the hierarchy and a transparent one keeps drawing itself over the grid you returned to.

**It follows the record, not the track.** Artwork is fetched per track id, so deriving the wash from `currentTrackId` would ask the server for another copy of the same sleeve every few minutes. It moves only when the album *and* album artist change — "Greatest Hits" is not one record.

**Not tied to scroll position.** The obvious alternative was a wash following the topmost visible album run. It reads well for ten seconds and then lies: the transport floats in that colour, and the transport is about what is playing, not what you scrolled past.

**The tint is the dominant colour of the sleeve, not its average.** Averaging every pixel of a busy cover gives the same brown-grey every time, because opposite hues cancel. It is a circular mean of hue weighted by how colourful each sample is, clamped into a band that stays legible on dark chrome — a navy sleeve would otherwise give an accent invisible against the window and a neon one would flare.

**Near-black accent.** All the declared accent still drives is what AppKit draws — list selection and focus rings — since a root `.tint()` overrides it everywhere else. At that weight the selection reads as a recess with a crisp white label. A light accent does not work: macOS lifts the label off a light fill only as far as a mid grey. (It is also only honoured at all when the user's system accent is Multicolor; an explicit system accent wins, and nothing can be done about that.)

**It holds a resolved `NSImage` rather than drawing through `AlbumArtwork`,** which shows a placeholder while it loads — over a two second dissolve that is a long grey wipe between records. The old cover stays up until the new one is in hand, and a record with no art is no wash rather than a grey one. The blur happens at 360pt and is magnified afterwards, so redrawing it twenty times a second costs nothing.

**The drift pauses rather than stops** (`TimelineView(.animation(paused:))`), on periods of 13/19/23s so it never lands back where it started.

## How to check it

`just macos-run`:

- **Queue** — the wash is the playing record's colour, running under the toolbar and behind the sidebar. It should visibly wander over ten seconds and hold still when you press space.
- **Skip between records** — a two second cross-dissolve, never a grey flash. Skipping within a record changes nothing and fires no artwork request.
- **Open an album, then go back** — the album page has its own wash, and nothing of it survives onto the grid.
- **Favourites / Artists / library grids** — opaque, no wash, and the tint still comes from what is playing.
- **A record with no cover** — the wash fades out rather than washing grey.

Measured rather than eyeballed: mean pixel delta over the header strip across 6s is 30.7 while playing and 0.45 while paused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017HbjSSsL2MTmazfJFPdAst