### PR TITLE
feat(macos): motion where a state change had nothing to mark it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- **The transport and the queue show what changed.** The playing indicator's rule — motion tells you a state is live, where a glyph only names it — applied to the four places that most needed it. Play/pause morphs between its symbols rather than swapping them. A skip bounces the arrow that was pressed: on a remote library the next track takes a moment to load, and until it does nothing else on the bar has moved, so the press reads as dropped and gets repeated. The transport's title and artist cross-fade on a track change, which gapless playback otherwise leaves unmarked. Cover art fades in rather than cutting, because in the album grid covers land tens of milliseconds apart and the hard cut reads as a stutter of pops.
+
+  A downloading queue row said the same thing twice — a static arrow in the status column and a progress bar further along it — so the bar is gone and the arrow is the ring that fills, in the column the eye already reads for state. Reduce Motion drops the bounce; the cross-fades stay, being fades rather than movement.
+
 ## v0.29.1 (2026-08-24)
 
 ### Changed

--- a/apps/macos/Sources/Koan/Views/AlbumArtwork.swift
+++ b/apps/macos/Sources/Koan/Views/AlbumArtwork.swift
@@ -35,6 +35,7 @@ struct AlbumArtwork: View {
                         .resizable()
                         .interpolation(.high)
                         .aspectRatio(contentMode: .fill)
+                        .transition(.opacity)
                 } else {
                     Rectangle()
                         .fill(.quaternary)
@@ -47,6 +48,9 @@ struct AlbumArtwork: View {
                         }
                 }
             }
+            // Covers in the grid land tens of milliseconds apart, and cutting
+            // straight from placeholder to art reads as a stutter of pops.
+            .animation(.easeOut(duration: 0.2), value: image == nil)
             .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
             .overlay {
                 RoundedRectangle(cornerRadius: cornerRadius)

--- a/apps/macos/Sources/Koan/Views/QueueView.swift
+++ b/apps/macos/Sources/Koan/Views/QueueView.swift
@@ -577,12 +577,6 @@ private struct QueueRow: View {
 
             Spacer(minLength: 8)
 
-            if let progress = item.downloadProgress {
-                ProgressView(value: progress)
-                    .progressViewStyle(.linear)
-                    .frame(width: 54, height: 12)
-            }
-
             if let trackId = item.trackId {
                 FavouriteButton(
                     isOn: library.isFavourite(track: trackId),
@@ -628,9 +622,25 @@ private struct QueueRow: View {
         case .playing:
             PlayingIndicator(isPlaying: player.isPlaying)
         case .downloading:
-            Image(systemName: "arrow.down.circle").foregroundStyle(.secondary)
+            // The ring is the whole indicator — a static arrow beside a
+            // separate bar said the same thing twice, in two places, and the
+            // column the eye already reads for state was the mute one.
+            if let progress = item.downloadProgress {
+                ProgressView(value: progress)
+                    .progressViewStyle(.circular)
+                    .controlSize(.mini)
+                    .frame(width: 14, height: 14)
+                    .help("Downloading — \(Int(progress * 100))%")
+            } else {
+                ProgressView()
+                    .progressViewStyle(.circular)
+                    .controlSize(.mini)
+                    .help("Downloading")
+            }
         case .priorityPending:
-            Image(systemName: "arrow.down.circle.fill").foregroundStyle(.tint)
+            Image(systemName: "arrow.down.circle")
+                .foregroundStyle(.tint)
+                .help("Queued for download")
         case .failed:
             Image(systemName: "exclamationmark.triangle.fill")
                 .foregroundStyle(.orange)

--- a/apps/macos/Sources/Koan/Views/TransportBar.swift
+++ b/apps/macos/Sources/Koan/Views/TransportBar.swift
@@ -3,6 +3,12 @@ import SwiftUI
 
 struct TransportBar: View {
     @Environment(PlayerModel.self) private var player
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    /// One per direction, so the arrow that was pressed is the only one that
+    /// bounces — `symbolEffect` fires on any change to the value it watches.
+    @State private var backSkips = 0
+    @State private var forwardSkips = 0
 
     var body: some View {
         // Three equal-weight columns so the transport stays centred as the
@@ -70,6 +76,10 @@ struct TransportBar: View {
                 }
             }
             .frame(minWidth: 90, alignment: .leading)
+            // Gapless means a track can change with nothing else to mark it.
+            // A cross-fade catches the corner of the eye; a hard swap doesn't.
+            .contentTransition(.opacity)
+            .animation(.easeInOut(duration: 0.2), value: player.currentEntry?.queueItemId)
         }
     }
 
@@ -77,8 +87,18 @@ struct TransportBar: View {
 
     private var controls: some View {
         HStack(spacing: 20) {
-            Button(action: player.previous) {
+            // A skip is acknowledged by the arrow itself. On a remote library
+            // the next track can take a moment to load, and until it does
+            // nothing else on the bar has changed — so the press reads as
+            // dropped, and gets repeated. Reduce Motion watches a frozen
+            // value, which is how a symbol effect is opted out of: it fires
+            // on a change and there is never one.
+            Button {
+                backSkips += 1
+                player.previous()
+            } label: {
                 Image(systemName: "backward.fill")
+                    .symbolEffect(.bounce, value: reduceMotion ? 0 : backSkips)
             }
             .keyboardShortcut(.leftArrow, modifiers: .command)
             .help("Previous track (⌘←)")
@@ -87,11 +107,16 @@ struct TransportBar: View {
                 Image(systemName: player.isPlaying ? "pause.fill" : "play.fill")
                     .font(.system(size: 19))
                     .frame(width: 26)
+                    .contentTransition(.symbolEffect(.replace))
             }
             .help(player.isPlaying ? "Pause (Space)" : "Play (Space)")
 
-            Button(action: player.next) {
+            Button {
+                forwardSkips += 1
+                player.next()
+            } label: {
                 Image(systemName: "forward.fill")
+                    .symbolEffect(.bounce, value: reduceMotion ? 0 : forwardSkips)
             }
             .keyboardShortcut(.rightArrow, modifiers: .command)
             .help("Next track (⌘→)")


### PR DESCRIPTION
Four of the places #282 lists, all in the macOS app. Nothing here is decoration for its own sake — each one marks a change the UI was making silently.

## What changed

- **Play/pause morphs** (`.contentTransition(.symbolEffect(.replace))`) instead of swapping symbols. `FavouriteButton` already did this; the transport didn't.
- **A skip bounces the arrow that was pressed.** On a remote library the next track takes a moment to load, and until it does nothing else on the bar has moved — so the press reads as dropped and gets repeated. One counter per direction, because `symbolEffect` fires on any change to the value it watches and a shared counter would bounce both arrows.
- **The transport's title and artist cross-fade** on a track change, keyed on `queueItemId`. Gapless playback otherwise gives a track change no mark at all.
- **Cover art fades in.** In the album grid covers land tens of milliseconds apart, and cutting from placeholder to image reads as a stutter of pops.
- **A downloading queue row stops saying it twice.** It drew a static `arrow.down.circle` in the status column *and* a 54pt progress bar further along the row. The bar is gone and the status column carries the ring that fills — which is what `TrackListView` already draws, so the two lists now agree. `priorityPending` becomes the plain tinted arrow ("queued, not started"), also matching the track list.

## Decisions

**Reduce Motion watches a frozen counter** (`value: reduceMotion ? 0 : skips`) rather than branching the view — a symbol effect only fires on a change, so no change means no effect, and there's no second code path to keep in step. The cross-fades stay under Reduce Motion: a fade is not movement.

**Two of the ticket's items aren't here.** The ensō drawing itself on with `.trim` is decoration that carries no information, which is the one thing #282 says not to do — I'd rather it stayed a still mark. The seek bar's fetched extent needs `downloadProgress`, which is a fraction of *bytes*, mapped onto a *time* axis; that's honest for lossless and a lie for VBR, so it wants thinking about rather than a quick fill. Both left on the ticket.

## Verifying

`just macos-build` is clean. Play something and: hit space (symbol morphs), hit ⌘→ (that arrow bounces, the other doesn't), let a gapless album roll over (title cross-fades), scroll the album grid cold (covers fade rather than pop), queue an album from a remote library (one ring per downloading row, no second bar). Then turn Reduce Motion on and confirm the arrows go still.

Part of #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L2XEkoE45iGuLYHQ7CNXiu