### PR TITLE
feat(macos): favourites rows carry their own cover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- **Favourites rows carry their own cover.** A record's tracklist has one sleeve above it and numbers down the side; favourites is a list gathered from the whole library, where the cover and the album name are what tell one row from the next. The shared track list learned the mode history rows already used, so both now look the same and there is one row to change.
+
 ### Fixed
 
 - **The sidebar said no remote tracks were cached, however many were.** The count asked for tracks whose `source` is `'cached'` — a value the schema allows and nothing writes, because downloading a track does not change where it came from. What a download writes is `cached_path`, which is what `set_cached_path` sets and clearing the cache nulls. Counted from there it agrees with the files on disk.

--- a/apps/macos/Sources/Koan/Views/RootView.swift
+++ b/apps/macos/Sources/Koan/Views/RootView.swift
@@ -256,7 +256,8 @@ private struct StageView: View {
             TrackListView(
                 title: "Favourites",
                 subtitle: Format.count(Int64(library.favourites.count), "track"),
-                tracks: library.favourites
+                tracks: library.favourites,
+                mixedAlbums: true
             )
         case .playHistory:
             HistoryView()

--- a/apps/macos/Sources/Koan/Views/TrackListView.swift
+++ b/apps/macos/Sources/Koan/Views/TrackListView.swift
@@ -12,6 +12,10 @@ struct TrackListView: View {
     var artistLink: Int64?
     /// What the header's play button acts on.
     var playable: Playable?
+    /// Set when the tracks come from all over rather than from one record.
+    /// Those rows carry their own cover and name the album they came from —
+    /// a single record's tracklist has both in the header above it.
+    var mixedAlbums = false
 
     @Environment(PlayerModel.self) private var player
     @Environment(Navigator.self) private var nav
@@ -41,6 +45,7 @@ struct TrackListView: View {
                                 position: index + 1,
                                 isCurrent: player.currentTrackId == track.id,
                                 isSelected: selection.contains(track.id),
+                                showsAlbum: mixedAlbums,
                                 allTrackIds: tracks.map(\.id)
                             )
                             .rowBehaviour(playable: .track(track))
@@ -167,6 +172,8 @@ private struct TrackRow: View {
     let position: Int
     let isCurrent: Bool
     let isSelected: Bool
+    /// Draws the cover and names the album — see `TrackListView.mixedAlbums`.
+    let showsAlbum: Bool
     /// The whole list, so playing this row keeps the rest queued behind it.
     let allTrackIds: [Int64]
 
@@ -195,6 +202,21 @@ private struct TrackRow: View {
             .font(.caption.monospacedDigit())
             .frame(width: 22, alignment: .trailing)
 
+            if showsAlbum {
+                // The cover is what you recognise a record by, and a list
+                // gathered from the whole library is exactly that job.
+                Group {
+                    if let albumId = track.albumId {
+                        AlbumArtwork(source: .album(albumId), cornerRadius: 3)
+                    } else {
+                        Image(systemName: "music.note")
+                            .font(.caption)
+                            .foregroundStyle(.tertiary)
+                    }
+                }
+                .frame(width: 34, height: 34)
+            }
+
             VStack(alignment: .leading, spacing: 1) {
                 Text(track.title)
                     .lineLimit(1)
@@ -205,13 +227,24 @@ private struct TrackRow: View {
                             ? AnyShapeStyle(.tint)
                             : AnyShapeStyle(.primary)
                     )
-                LinkText(
-                    text: track.artistName,
-                    target: track.artistId.map { .artist($0) },
-                    font: .caption
-                )
+                HStack(spacing: 5) {
+                    LinkText(
+                        text: track.artistName,
+                        target: track.artistId.map { .artist($0) },
+                        font: .caption
+                    )
+                    if showsAlbum {
+                        Text("·")
+                            .font(.caption)
+                            .foregroundStyle(.tertiary)
+                        LinkText(
+                            text: track.albumTitle,
+                            target: track.albumId.map { .album($0) },
+                            font: .caption
+                        )
+                    }
+                }
             }
-
 
             Spacer(minLength: 8)
 
@@ -233,7 +266,7 @@ private struct TrackRow: View {
                 .foregroundStyle(.secondary)
                 .frame(width: 48, alignment: .trailing)
         }
-        .frame(height: 34)
+        .frame(height: showsAlbum ? 44 : 34)
         // The row is only clickable where a view sits; the Spacer would
         // otherwise be a dead zone.
         .contentShape(Rectangle())


### PR DESCRIPTION
Favourites already went through the shared `TrackListView` — the issue predates that. What was missing is the art.

A record's tracklist has one sleeve in the header and a number down the side, both of which mean something there. Favourites is gathered from across the library, where neither does: the cover and the album name are what tell one row from the next. `HistoryView` already drew exactly that row by hand, so rather than a third row view, `TrackListView` gains the mode — `mixedAlbums: true` gives each row a 34pt cover, an `artist · album` subline with both linked, and the taller row height to fit it.

The number column stays. Favourites is a list and a position in it is real, and it keeps the hover play button and the playing bars where they already live.

## Verifying

`just macos-build` is clean. ⌘4 for Favourites: covers down the left, album names beside the artist, both clickable through to where they live. Rows in an album's tracklist are untouched — `mixedAlbums` defaults to false and `AlbumDetailView` doesn't pass it.

I couldn't get a screenshot of it running: another worktree of this repo has an app up, and `macos-run`/`macos-dev` pkill any running koan by bundle path, so the two instances killed each other on every attempt. The row layout is a copy of the shipping `HistoryRow`, which is the mitigation.

Closes #288