### PR TITLE
fix(macos): favourites and history get the filter they were built for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- **Favourites and history can be filtered, which they were already built for.** Both narrow on title, artist and album, history has an empty state for when a filter matches nothing, and neither could be typed into: the toolbar offered its field to albums and artists by name, and ⌘F named the same two. Which sections have a filter is now one answer on `Navigator.Section` that the field and ⌘F both read, so a section cannot be filterable in the model and not on screen. Favourites also draws the narrowed list rather than the whole one, and counts what it is showing.
+
 - **The sidebar said no remote tracks were cached, however many were.** The count asked for tracks whose `source` is `'cached'` — a value the schema allows and nothing writes, because downloading a track does not change where it came from. What a download writes is `cached_path`, which is what `set_cached_path` sets and clearing the cache nulls. Counted from there it agrees with the files on disk.
 
 ## v0.29.1 (2026-08-24)

--- a/apps/macos/Sources/Koan/KoanApp.swift
+++ b/apps/macos/Sources/Koan/KoanApp.swift
@@ -226,9 +226,10 @@ struct KoanApp: App {
                 Divider()
                 Button("Find") {
                     guard let state else { return }
-                    switch state.nav.section {
-                    case .albums, .artists: state.ui.focusFilter()
-                    default: state.ui.focusSearch()
+                    if state.nav.section.filterPlaceholder != nil {
+                        state.ui.focusFilter()
+                    } else {
+                        state.ui.focusSearch()
                     }
                 }
                 .keyboardShortcut("f", modifiers: .command)

--- a/apps/macos/Sources/Koan/Support/Navigator.swift
+++ b/apps/macos/Sources/Koan/Support/Navigator.swift
@@ -55,6 +55,19 @@ final class Navigator {
         case snapshots
 
         var id: Self { self }
+
+        /// What the toolbar's filter field says — and, by its absence, which
+        /// sections have no filter at all. The field and ⌘F both read it, so
+        /// they cannot disagree about where narrowing is possible.
+        var filterPlaceholder: String? {
+            switch self {
+            case .albums: "Filter albums"
+            case .artists: "Filter artists"
+            case .favourites: "Filter favourites"
+            case .playHistory: "Filter history"
+            case .queue, .searchResults, .snapshots: nil
+            }
+        }
     }
 
     private(set) var location = Location(section: .queue)

--- a/apps/macos/Sources/Koan/Views/RootView.swift
+++ b/apps/macos/Sources/Koan/Views/RootView.swift
@@ -130,11 +130,10 @@ struct RootView: View {
 
             // Filtering what is on screen belongs with it, not in the sidebar
             // search, which navigates away instead of narrowing.
-            if nav.section == .albums || nav.section == .artists {
+            if let placeholder = nav.section.filterPlaceholder {
                 ToolbarItem(placement: .primaryAction) {
                     FilterField(
-                        placeholder: nav.section == .albums
-                            ? "Filter albums" : "Filter artists",
+                        placeholder: placeholder,
                         text: $library.filter,
                         focusToken: ui.filterFocusToken
                     )
@@ -255,8 +254,8 @@ private struct StageView: View {
         case .favourites:
             TrackListView(
                 title: "Favourites",
-                subtitle: Format.count(Int64(library.favourites.count), "track"),
-                tracks: library.favourites,
+                subtitle: Format.count(Int64(library.visibleFavourites.count), "track"),
+                tracks: library.visibleFavourites,
                 mixedAlbums: true
             )
         case .playHistory:

--- a/apps/macos/Sources/Koan/Views/TrackListView.swift
+++ b/apps/macos/Sources/Koan/Views/TrackListView.swift
@@ -30,7 +30,7 @@ struct TrackListView: View {
                 .padding(.bottom, 16)
 
             if tracks.isEmpty {
-                EmptyState(icon: "music.note.list", title: "No tracks")
+                EmptyState(icon: "music.note.list", title: emptyTitle)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
                 // A real List rather than a LazyVStack of tap gestures. Stacking
@@ -77,6 +77,12 @@ struct TrackListView: View {
                 }
             }
         }
+    }
+
+    /// Only a gathered list is narrowed by the filter; a record's tracklist
+    /// with nothing in it is a record with nothing in it.
+    private var emptyTitle: String {
+        mixedAlbums && !library.filter.isEmpty ? "No matches" : "No tracks"
     }
 
     /// Plays the list from the first of `ids`, keeping the rest behind it.


### PR DESCRIPTION
`LibraryModel` narrows favourites and history on title, artist and album, and `HistoryView` has an empty state for a filter that matches nothing. Neither could be typed into: the toolbar offered its field to `.albums` and `.artists` by name, ⌘F named the same two, and `visibleFavourites` was recomputed on every refilter and read by nobody.

Which sections have a filter is now one answer — `Navigator.Section.filterPlaceholder`, nil where there is none — that both the field and ⌘F read. That is the actual fix: the three places that had to agree about it are two, and neither names sections.

Favourites also draws `visibleFavourites` instead of the whole list, counts what it is showing in its subtitle, and says "No matches" rather than "No tracks" when a filter emptied it. An album's tracklist keeps "No tracks" — it is not filtered, so an empty one is an empty record.

## Verifying

`just macos-build` is clean. ⌘3/⌘4, filter field in the toolbar, ⌘F focuses it; type and rows narrow, header count follows. Queue, search results and snapshots have no field and ⌘F there still goes to the sidebar lookup, as before.

Same caveat as #289 — I could not screenshot it running, because another worktree of this repo has koan up and `macos-run` pkills any running instance by bundle path, so the two kill each other.

## Dependency

Based on #289, which touches the same lines in `RootView`. Merge that first and this retargets to main on its own.