### PR TITLE
feat(core): say when the output is being resampled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- **The format badge says when the output is being resampled.** koan switches the device to the source rate, and when a device refuses — MPEG-2 and MPEG-2.5 MP3 rates routinely are — the system resamples to reach it. The player has always known which of those happened, because `set_device_sample_rate` returns the rate the device settled at, and it compared the two and wrote a line to the log. Nothing else ever saw it. Meanwhile the badge showed the source format either way, captioned "koan matches the device rate rather than resampling" — an unconditional claim that is false in exactly the case worth knowing about.
+
+  The settled rate now reaches the front ends: the macOS badge appends it — `FLAC 24/96 → 48` — the TUI's format line does the same, and `nowPlaying.track.outputSampleRate` carries it over GraphQL. What it does not do is claim bit-perfection. koan never takes the device exclusively, so another application's audio can be mixed in and the volume stage may scale in software, and none of that is visible from inside the process. What koan can say for certain is whether it handed the device the samples as they are, or something had to resample to reach it — so that is all it says.
+
 ## v0.30.0 (2026-08-24)
 
 ### Changed

--- a/apps/macos/Sources/Koan/Support/Formatting.swift
+++ b/apps/macos/Sources/Koan/Support/Formatting.swift
@@ -16,8 +16,11 @@ enum Format {
             : String(format: "%d:%02d", m, s)
     }
 
-    /// The bit that makes this a bit-perfect player rather than iTunes:
-    /// what the DAC is actually being fed. "FLAC 24/96" and so on.
+    /// What the source is: "FLAC 24/96" and so on.
+    ///
+    /// A rate the device refused is appended — "FLAC 24/96 → 48" — because a
+    /// badge that reads the same whether or not something resampled is the one
+    /// claim this player cannot afford to get wrong.
     static func quality(_ f: StreamFormat) -> String {
         var parts = [f.codec.uppercased()]
         if let depth = f.bitDepth {
@@ -28,7 +31,29 @@ enum Format {
         if f.channels != 2 {
             parts.append("\(f.channels)ch")
         }
+        if isResampled(f), let out = f.outputSampleRate {
+            parts.append("→ \(rate(out))")
+        }
         return parts.joined(separator: " ")
+    }
+
+    /// Whether anything had to resample to reach the device. `false` while the
+    /// device rate is unknown — silence is better than a guess here.
+    static func isResampled(_ f: StreamFormat) -> Bool {
+        guard let out = f.outputSampleRate else { return false }
+        return out != f.sampleRate
+    }
+
+    /// What koan can honestly say about the path to the DAC. It never claims
+    /// bit-perfection outright: the device is shared, so another app's audio
+    /// and the system volume stage are both past the point koan can see.
+    static func outputExplanation(_ f: StreamFormat) -> String {
+        guard let out = f.outputSampleRate else {
+            return "Source format — koan matches the device to the source rate rather than resampling"
+        }
+        return out == f.sampleRate
+            ? "Device is running at \(rate(out)) kHz, the source rate — koan is resampling nothing"
+            : "Device stayed at \(rate(out)) kHz, so \(rate(f.sampleRate)) kHz is being resampled to reach it"
     }
 
     static func quality(_ t: Track) -> String? {

--- a/apps/macos/Sources/Koan/Views/TransportBar.swift
+++ b/apps/macos/Sources/Koan/Views/TransportBar.swift
@@ -156,11 +156,14 @@ struct TransportBar: View {
             if let format = player.currentFormat {
                 Text(Format.quality(format))
                     .font(.caption.monospaced())
+                    // A refused rate isn't a fault to raise an alarm over, so
+                    // it reads at the same weight as the rest of the badge and
+                    // explains itself only to someone who looks.
                     .foregroundStyle(.secondary)
                     .padding(.horizontal, 8)
                     .padding(.vertical, 3)
                     .background(.quaternary, in: Capsule())
-                    .help("Source format — koan matches the device rate rather than resampling")
+                    .help(Format.outputExplanation(format))
             }
 
             Toggle(isOn: Binding(

--- a/crates/koan-core/src/player/mod.rs
+++ b/crates/koan-core/src/player/mod.rs
@@ -151,27 +151,35 @@ impl Player {
         let device_rate = self.backend.get_device_sample_rate(&device)?;
         let source_rate = info.sample_rate as f64;
 
-        if (device_rate - source_rate).abs() > 0.1 {
+        let settled = if (device_rate - source_rate).abs() > 0.1 {
             log::info!(
                 "switching device sample rate: {}Hz → {}Hz",
                 device_rate,
                 source_rate
             );
-            let settled = match self.backend.set_device_sample_rate(&device, source_rate) {
+            match self.backend.set_device_sample_rate(&device, source_rate) {
                 Ok(rate) => rate,
                 Err(e) => {
                     log::warn!("failed to set device sample rate: {}", e);
                     device_rate
                 }
-            };
-            if (settled - source_rate).abs() > 0.1 {
-                log::warn!(
-                    "device stayed at {}Hz (wanted {}Hz) — output is resampled, not bit-perfect",
-                    settled,
-                    source_rate
-                );
             }
+        } else {
+            device_rate
+        };
+
+        if (settled - source_rate).abs() > 0.1 {
+            log::warn!(
+                "device stayed at {}Hz (wanted {}Hz) — output is resampled, not bit-perfect",
+                settled,
+                source_rate
+            );
         }
+
+        // The front ends compare this against the source rate to say whether
+        // anything had to resample. A log line was the only place it went.
+        self.shared_state
+            .set_output_sample_rate(settled.round() as u32);
 
         Ok(self.backend.create_engine(
             &device,
@@ -2231,5 +2239,39 @@ mod tests {
     #[test]
     fn engine_uses_source_channel_count() {
         assert_eq!(engine_format_for(44100, 1, 44100.0), (44100.0, 1));
+    }
+
+    /// The rate the device settled at, as the front ends read it.
+    fn settled_rate_for(source_rate: u32, device_rate: f64) -> Option<u32> {
+        let mut player = Player::new();
+        player.backend = Box::new(StuckBackend {
+            rate: device_rate,
+            asked: Arc::new(std::sync::Mutex::new(None)),
+        });
+        let state = player.shared_state.clone();
+
+        let info = buffer::StreamInfo {
+            codec: "MP3".into(),
+            sample_rate: source_rate,
+            channels: 2,
+            bit_depth: Some(16),
+            bitrate_kbps: None,
+            duration_ms: 1000,
+        };
+        let (_producer, consumer) = rtrb::RingBuffer::new(16);
+        player
+            .create_engine_for(&info, consumer)
+            .expect("engine creation should succeed");
+        state.output_sample_rate()
+    }
+
+    #[test]
+    fn settled_device_rate_reaches_the_shared_state() {
+        // A device that refuses the switch is being fed resampled audio, and
+        // that is the case the front ends have to be able to see. Before this
+        // the comparison happened once, in a log line.
+        assert_eq!(settled_rate_for(22050, 48000.0), Some(48000));
+        // No switch needed, so nothing resampled: the two rates agree.
+        assert_eq!(settled_rate_for(44100, 44100.0), Some(44100));
     }
 }

--- a/crates/koan-core/src/player/state.rs
+++ b/crates/koan-core/src/player/state.rs
@@ -185,6 +185,14 @@ pub struct SharedPlayerState {
     /// The UI loop checks this to force a souvlaki/cover-art update without a track change.
     metadata_refresh_pending: AtomicBool,
 
+    /// The rate the output device settled at for the current track, or 0 when
+    /// nothing has played yet. Compared against the source rate, it is the one
+    /// thing koan can say for certain about the path to the DAC: whether it
+    /// handed the device the samples as they are, or something had to resample
+    /// to reach it. Everything past that — other clients, the volume stage — is
+    /// the system's, and not ours to claim.
+    output_sample_rate: AtomicU64,
+
     /// Radio mode — automatically queue similar tracks when the queue runs low.
     /// Shared so GQL/MCP can toggle it without going through the TUI.
     radio_mode: AtomicBool,
@@ -200,6 +208,7 @@ impl SharedPlayerState {
             playlist_version: AtomicU64::new(0),
             quit_requested: AtomicBool::new(false),
             metadata_refresh_pending: AtomicBool::new(false),
+            output_sample_rate: AtomicU64::new(0),
             radio_mode: AtomicBool::new(false),
         })
     }
@@ -291,6 +300,21 @@ impl SharedPlayerState {
 
     pub fn set_radio_mode(&self, enabled: bool) {
         self.radio_mode.store(enabled, Ordering::Release);
+    }
+
+    // --- Output device rate ---
+
+    /// `None` until a track has started and the device rate is known.
+    pub fn output_sample_rate(&self) -> Option<u32> {
+        match self.output_sample_rate.load(Ordering::Acquire) {
+            0 => None,
+            rate => Some(rate as u32),
+        }
+    }
+
+    pub fn set_output_sample_rate(&self, rate: u32) {
+        self.output_sample_rate
+            .store(u64::from(rate), Ordering::Release);
     }
 
     // --- Playlist version ---

--- a/crates/koan-ffi/src/lib.rs
+++ b/crates/koan-ffi/src/lib.rs
@@ -2013,7 +2013,9 @@ impl KoanEngine {
             duration_ms: info.as_ref().map(|i| i.duration_ms).unwrap_or(0),
             queue_item_id: cursor.map(|c| c.0.to_string()),
             entry,
-            format: info.as_ref().map(StreamFormat::from),
+            format: info
+                .as_ref()
+                .map(|i| StreamFormat::of(i, self.state.output_sample_rate())),
             playlist_version: self.state.playlist_version(),
             radio_enabled: self.state.radio_mode(),
         }

--- a/crates/koan-ffi/src/types.rs
+++ b/crates/koan-ffi/src/types.rs
@@ -188,11 +188,18 @@ pub struct StreamFormat {
     pub bit_depth: Option<u16>,
     pub bitrate_kbps: Option<u32>,
     pub channels: u16,
+    /// What the output device settled at, where it is known. Equal to
+    /// `sample_rate` means koan handed the device the samples as they are;
+    /// anything else means something resampled to reach it. What happens
+    /// past the device — other clients, the volume stage — is the system's,
+    /// and this says nothing about it.
+    pub output_sample_rate: Option<u32>,
 }
 
-impl From<&TrackInfo> for StreamFormat {
-    fn from(t: &TrackInfo) -> Self {
+impl StreamFormat {
+    pub(crate) fn of(t: &TrackInfo, output_sample_rate: Option<u32>) -> Self {
         Self {
+            output_sample_rate,
             codec: t.codec.clone(),
             sample_rate: t.sample_rate,
             bit_depth: t.bit_depth,

--- a/crates/koan-server/src/graphql/types.rs
+++ b/crates/koan-server/src/graphql/types.rs
@@ -379,6 +379,10 @@ pub(super) struct GqlNowPlayingTrack {
     pub bitrate_kbps: Option<u32>,
     pub channels: u16,
     pub duration_ms: u64,
+    /// What the output device settled at, where it is known. Equal to
+    /// `sampleRate` means koan handed the device the samples as they are;
+    /// anything else means something resampled to reach it.
+    pub output_sample_rate: Option<u32>,
 }
 
 impl GqlNowPlaying {
@@ -419,6 +423,7 @@ impl GqlNowPlaying {
                 bitrate_kbps: info.bitrate_kbps,
                 channels: info.channels,
                 duration_ms: info.duration_ms,
+                output_sample_rate: state.output_sample_rate(),
             }),
             queue_item_id: Some(info.id.0.to_string()),
         }

--- a/crates/koan-tui/src/transport.rs
+++ b/crates/koan-tui/src/transport.rs
@@ -11,13 +11,22 @@ use super::theme::Theme;
 /// Format audio quality info as a human-readable string.
 ///
 /// Examples: "CD quality", "FLAC 96kHz/24bit", "Opus 48kHz/128kbps", "MP3 320kbps"
+///
+/// `output_rate` is what the device settled at. Where it differs from the
+/// source, the string says so — a device that refused the rate is being fed
+/// resampled audio, and the one claim this player cannot afford to leave
+/// unqualified is the one about what reaches the DAC.
 #[allow(clippy::manual_is_multiple_of)]
-pub fn format_quality(info: &TrackInfo) -> String {
-    let rate = info.sample_rate;
-    let ch = info.channels;
+pub fn format_quality(info: &TrackInfo, output_rate: Option<u32>) -> String {
+    let resampled = match output_rate {
+        Some(out) if out != info.sample_rate => format!(" → {}", rate_label(out)),
+        _ => String::new(),
+    };
+    format!("{}{}", format_source(info), resampled)
+}
 
-    // Human-friendly sample rate.
-    let rate_str = match rate {
+fn rate_label(rate: u32) -> String {
+    match rate {
         44100 => "44.1kHz".to_string(),
         48000 => "48kHz".to_string(),
         88200 => "88.2kHz".to_string(),
@@ -26,9 +35,15 @@ pub fn format_quality(info: &TrackInfo) -> String {
         192000 => "192kHz".to_string(),
         352800 => "352.8kHz".to_string(),
         384000 => "384kHz".to_string(),
-        _ if rate % 1000 == 0 => format!("{}kHz", rate / 1000),
+        _ if rate.is_multiple_of(1000) => format!("{}kHz", rate / 1000),
         _ => format!("{}Hz", rate),
-    };
+    }
+}
+
+fn format_source(info: &TrackInfo) -> String {
+    let rate = info.sample_rate;
+    let ch = info.channels;
+    let rate_str = rate_label(rate);
 
     // Red-book audio gets its own name.
     match (rate, info.bit_depth, ch) {
@@ -66,6 +81,8 @@ pub struct TransportBar<'a> {
     ticker_offset: usize,
     /// Download fraction (0.0..1.0) for streaming tracks. None = fully downloaded.
     download_fraction: Option<f64>,
+    /// What the output device settled at. None until a track has started.
+    output_rate: Option<u32>,
 }
 
 impl<'a> TransportBar<'a> {
@@ -84,6 +101,7 @@ impl<'a> TransportBar<'a> {
             theme,
             ticker_offset: 0,
             download_fraction: None,
+            output_rate: None,
         }
     }
 
@@ -94,6 +112,11 @@ impl<'a> TransportBar<'a> {
 
     pub fn with_download_fraction(mut self, fraction: Option<f64>) -> Self {
         self.download_fraction = fraction;
+        self
+    }
+
+    pub fn with_output_rate(mut self, rate: Option<u32>) -> Self {
+        self.output_rate = rate;
         self
     }
 
@@ -303,7 +326,7 @@ impl Widget for TransportBar<'_> {
                     album_spans.push(Span::styled(format!(" ({})", year), self.theme.hint_desc));
                 }
 
-                let format_info = format!(" \u{00B7} {}", format_quality(info));
+                let format_info = format!(" \u{00B7} {}", format_quality(info, self.output_rate));
                 album_spans.push(Span::styled(format_info, self.theme.hint_desc));
 
                 let album_line = Line::from(album_spans);
@@ -318,7 +341,7 @@ impl Widget for TransportBar<'_> {
                 .to_string_lossy()
                 .to_string();
 
-            let format_info = format_quality(info);
+            let format_info = format_quality(info, self.output_rate);
 
             let info_line = Line::from(vec![
                 Span::raw(" "),

--- a/crates/koan-tui/src/ui.rs
+++ b/crates/koan-tui/src/ui.rs
@@ -138,7 +138,8 @@ pub fn render(frame: &mut Frame, app: &mut App) {
         &app.theme,
     )
     .with_ticker_offset(app.ticker_offset)
-    .with_download_fraction(dl_fraction);
+    .with_download_fraction(dl_fraction)
+    .with_output_rate(app.state.output_sample_rate());
     frame.render_widget(transport, text_area);
 
     // Visualizer — renders in the space above the transport text.


### PR DESCRIPTION
The player has always known whether the output device took the source rate or refused it — `set_device_sample_rate` returns the rate the device settled at, and `player/mod.rs` compared the two to write:

```
device stayed at 48000Hz (wanted 22050Hz) — output is resampled, not bit-perfect
```

…to the log, where nothing read it. The macOS badge showed the source format either way, captioned *"koan matches the device rate rather than resampling"* — unconditional, and false in exactly the case worth knowing about. Same shape as the failure-reason bug in v0.29.0.

## What it does

The settled rate goes into `SharedPlayerState` and out to all three front ends:

- **macOS** — the badge appends it: `FLAC 24/96 → 48`. Same weight as the rest of the badge, no alarm colour: a device refusing a rate is not a fault, and the tooltip is where it explains itself.
- **TUI** — the format line does the same.
- **GraphQL** — `nowPlaying.track.outputSampleRate`, so a client that can't link the core isn't blind to it either.

## The claim it deliberately doesn't make

Not "bit-perfect". koan never takes `kAudioDevicePropertyHogMode`, so the device is shared: another application's audio can be mixed in, and the volume stage may scale in software. None of that is visible from inside the process, so asserting an untouched path to the DAC would be a claim koan cannot back. What it *can* say with certainty is whether it handed the device the samples as they are or something had to resample to reach them — so that is all it says, in the badge text and in both tooltips.

Where the device rate isn't known yet, nothing is appended and the tooltip falls back to describing intent. Silence beats a guess here.

## Verifying

`just check` — 895 tests, clippy clean. New test `settled_device_rate_reaches_the_shared_state` drives the existing `StuckBackend` (a device that refuses every switch) and asserts the state carries 48000 for a 22050 Hz source, and 44100 when no switch was needed.

By hand: play a 22.05 or 32 kHz MP3 — most DACs refuse both — and the badge should gain its `→`. Anything at a rate your device supports should look exactly as it did.

Closes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L2XEkoE45iGuLYHQ7CNXiu