### PR TITLE
feat(macos): the artist and album in the transport bar are links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- **The artist and album in the transport bar are links.** The bar named what was playing and gave you no way to get to it — its second line was the artist as plain text, and the record it came from was not shown at all. It reads `artist — album` now, each name going where its own name says, through the same `LinkText` the rows, grid cells and queue headers use. That was the last place in the app an artist name was not a link.
+
 ## v0.29.1 (2026-08-24)
 
 ### Changed

--- a/apps/macos/Sources/Koan/Support/PlayerModel.swift
+++ b/apps/macos/Sources/Koan/Support/PlayerModel.swift
@@ -176,10 +176,39 @@ final class PlayerModel {
     private(set) var currentEntry: QueueItem?
     private(set) var currentFormat: StreamFormat?
 
+    /// Where what is playing lives, so the transport bar can link to it.
+    ///
+    /// A `QueueItem` carries names, not ids — it has to stand for things that
+    /// were never in the library. Resolved once when the track changes rather
+    /// than per frame: the transport polls at 10 Hz and this is a database
+    /// read.
+    private(set) var currentAlbumId: Int64?
+    private(set) var currentArtistId: Int64?
+
+    private func resolveCurrentPlace(trackId: Int64?) {
+        guard let trackId else {
+            currentAlbumId = nil
+            currentArtistId = nil
+            return
+        }
+        let engine = self.engine
+        Task { @MainActor in
+            let track = (try? await engine.track(trackId: trackId)) ?? nil
+            // The track moved on while we were asking, so whatever came back
+            // belongs to something that is no longer playing.
+            guard trackId == self.currentTrackId else { return }
+            self.currentAlbumId = track?.albumId
+            self.currentArtistId = track?.artistId
+        }
+    }
+
     private func updateDerived(_ now: NowPlaying) {
         let playing = now.state == .playing
         if playing != isPlaying { isPlaying = playing }
-        if now.entry?.trackId != currentTrackId { currentTrackId = now.entry?.trackId }
+        if now.entry?.trackId != currentTrackId {
+            currentTrackId = now.entry?.trackId
+            resolveCurrentPlace(trackId: currentTrackId)
+        }
         if now.queueItemId != currentItemId { currentItemId = now.queueItemId }
         if now.radioEnabled != radioEnabled { radioEnabled = now.radioEnabled }
         if now.playlistVersion != queueVersion { queueVersion = now.playlistVersion }

--- a/apps/macos/Sources/Koan/Views/TransportBar.swift
+++ b/apps/macos/Sources/Koan/Views/TransportBar.swift
@@ -59,10 +59,28 @@ struct TransportBar: View {
                     Text(entry.title)
                         .font(.callout.weight(.medium))
                         .lineLimit(1)
-                    Text(entry.artist)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
+                    // Both names go where they say they go, rather than the
+                    // line as a whole meaning one of them. `LinkText` is the
+                    // same one the rows and headers use — this was the last
+                    // place an artist name was not a link.
+                    HStack(spacing: 0) {
+                        LinkText(
+                            text: entry.artist,
+                            target: player.currentArtistId.map { .artist($0) },
+                            font: .caption
+                        )
+                        if !entry.album.isEmpty {
+                            Text(" — ")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            LinkText(
+                                text: entry.album,
+                                target: player.currentAlbumId.map { .album($0) },
+                                font: .caption
+                            )
+                        }
+                    }
+                    .lineLimit(1)
                 } else {
                     Text("Nothing playing")
                         .font(.callout)


### PR DESCRIPTION
Feedback from Oliver Byrne: the now-playing text should take you to the record.

The transport bar named what was playing and gave you no way to reach it. Its second line was `Text(entry.artist)` — plain text — and the album was not shown at all. The one view that is always on screen was the only one you could not navigate from.

It reads `artist — album` now, **each name going where its own name says**, through the same `LinkText` the rows, grid cells and queue headers already use. That component's own doc comment says why it exists:

> Artist and album names should behave the same way wherever they appear — in a grid cell, a track row, a queue header — so the behaviour lives in one place rather than being re-hand-rolled per view.

The transport bar was the last place that never got it.

## Resolving the ids

`QueueItem` carries names rather than ids, because it stands for things that were never in the library. So `PlayerModel` resolves the album and artist when the **track changes** rather than per frame — the transport polls at 10 Hz and this is a database read — and discards an answer that lands after you have already skipped on.

## Not done: click anywhere in the bar

Also suggested, and deliberately left out. That bar holds play/pause, skip, the seek bar, the format badge and the output device picker. Making the whole thing a navigation target means every near-miss on a control sends you somewhere, and scrubbing becomes a gamble. Named links reach the same place with a target you can see. Easy to revisit if the links do not feel like enough.

## Verifying

Play something, hover the second line — both names underline and take the pointer. Artist goes to the artist, album to the album. A track with no library row shows the names unlinked rather than dead links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L2QYGXTN6dYC7MX5KNY8a5