### PR TITLE
release: v0.30.2 — favourites covers, a heart on the transport, no flash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - **Favourites rows lost their covers again.** They were given their own sleeve and album name in v0.30.0, on the grounds that a list gathered from the whole library has nothing above it saying what each row is. Rebuilding the detail column in v0.30.1 reproduced the call that draws it without the flag that turns the mode on.
 
-- **A flash of bare colour on the first keystroke of a search.** The queue drew no ground of its own and let the window's wash show through it, so for the frame between one page and the next neither was painted and the wash filled the window. Every page carries its own ground now, and the ones that are washed draw the wash over it rather than through it.
+- **A flash of bare colour on the first keystroke of a search.** The page's ground was put behind it before it was told to fill the column, and a background sizes itself to what it backs — so the ground was only ever as big as the page's content. The results page measures nothing while the query is still running, which left the window's wash showing everywhere around it. The page is filled first now, and every page carries an opaque ground of its own with the wash drawn over it rather than through it.
 
 ## v0.30.1 (2026-08-25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v0.30.2 (2026-08-25)
+
+### Added
+
+- **A heart on the transport.** ⌘D has always favourited what is playing from anywhere, but a heart you can see also tells you whether this one is already in. It sits next to the title, because that is what it acts on.
+
+### Fixed
+
+- **Favourites rows lost their covers again.** They were given their own sleeve and album name in v0.30.0, on the grounds that a list gathered from the whole library has nothing above it saying what each row is. Rebuilding the detail column in v0.30.1 reproduced the call that draws it without the flag that turns the mode on.
+
+- **A flash of bare colour on the first keystroke of a search.** The queue drew no ground of its own and let the window's wash show through it, so for the frame between one page and the next neither was painted and the wash filled the window. Every page carries its own ground now, and the ones that are washed draw the wash over it rather than through it.
+
 ## v0.30.1 (2026-08-25)
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2744,7 +2744,7 @@ dependencies = [
 
 [[package]]
 name = "koan-cli"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "chrono",
  "clap",
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "koan-core"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "argon2",
  "bliss-audio",
@@ -2810,7 +2810,7 @@ dependencies = [
 
 [[package]]
 name = "koan-ffi"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "chrono",
  "crossbeam-channel",
@@ -2830,7 +2830,7 @@ dependencies = [
 
 [[package]]
 name = "koan-server"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",
@@ -2863,7 +2863,7 @@ dependencies = [
 
 [[package]]
 name = "koan-tui"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "core-foundation 0.10.1",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/koan-core", "crates/koan-ffi", "crates/koan-server", "crates/koan-tui", "crates/koan-cli"]
 
 [workspace.package]
-version = "0.30.1"
+version = "0.30.2"
 edition = "2024"
 rust-version = "1.89"
 homepage = "https://github.com/radiosilence/koan"
@@ -13,9 +13,9 @@ license = "MIT"
 [workspace.dependencies]
 # Internal crates. Keep the version in step with [workspace.package] above —
 # a stale pin here publishes members that resolve against the wrong sibling.
-koan-core = { path = "crates/koan-core", version = "0.30.1" }
-koan-server = { path = "crates/koan-server", version = "0.30.1" }
-koan-tui = { path = "crates/koan-tui", version = "0.30.1" }
+koan-core = { path = "crates/koan-core", version = "0.30.2" }
+koan-server = { path = "crates/koan-server", version = "0.30.2" }
+koan-tui = { path = "crates/koan-tui", version = "0.30.2" }
 # Feature set is the union every member needs; `default-tls` is an alias for
 # `rustls`, so there is exactly one TLS stack.
 reqwest = { version = "0.13", default-features = false, features = [

--- a/apps/macos/Sources/Koan/Views/RootView.swift
+++ b/apps/macos/Sources/Koan/Views/RootView.swift
@@ -333,7 +333,10 @@ private struct StageView: View {
             TrackListView(
                 title: "Favourites",
                 subtitle: Format.count(Int64(library.favourites.count), "track"),
-                tracks: library.favourites
+                tracks: library.favourites,
+                // Gathered from the whole library, so a row's cover and album
+                // are what tell it from the one above it.
+                mixedAlbums: true
             )
         case .section(.playHistory):
             HistoryView()
@@ -357,16 +360,21 @@ private struct PageGround: View {
 
     @Environment(Navigator.self) private var nav
 
+    /// Whether this page is washed in a record's colour, or is its own ground.
+    private var washed: Bool {
+        if case .album = nav.current { true } else { nav.section == .queue }
+    }
+
     var body: some View {
-        if case .album = nav.current {
-            ZStack {
-                Rectangle().fill(.background)
+        ZStack {
+            // Always opaque, never a hole onto the window. Letting the queue
+            // show the window's wash through itself meant that for one frame
+            // between two pages neither was painted, and the bare wash filled
+            // the window — the flash on the first keystroke of a search.
+            Rectangle().fill(.background)
+            if washed {
                 ArtworkBleed(source: source, drifts: drifts)
             }
-        } else if nav.section == .queue {
-            Color.clear
-        } else {
-            Rectangle().fill(.background)
         }
     }
 }

--- a/apps/macos/Sources/Koan/Views/RootView.swift
+++ b/apps/macos/Sources/Koan/Views/RootView.swift
@@ -89,12 +89,17 @@ struct RootView: View {
         } detail: {
             StageView()
                 .clearsTransport(transportHeight)
+                // Filled *before* the ground goes behind it. A background sizes
+                // itself to what it backs, so expanding afterwards left the
+                // ground the size of the page's content — and a page that
+                // measures nothing, like results while the query is still
+                // running, showed the window's wash everywhere around it.
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
                 // Every page carries its own ground. The window's is the wash,
                 // so a transparent page composites onto it — and onto the page
                 // before it, which is what left an album drawing itself across
                 // the grid you came back to.
                 .background { PageGround(source: washSource, drifts: player.isPlaying) }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
         .inspector(isPresented: $showLyrics) {
             LyricsPanel()
@@ -352,8 +357,9 @@ private struct StageView: View {
 
 /// What a page sits on.
 ///
-/// A record washes itself in its own cover; everywhere else is either the
-/// window's wash showing through — the queue — or an opaque ground of its own.
+/// Every page is opaque. A washed one — the queue, a record — draws its bleed
+/// over that ground rather than in place of it, so no page ever composites onto
+/// the window or onto the page before it.
 private struct PageGround: View {
     let source: AlbumArtwork.Source?
     let drifts: Bool
@@ -367,10 +373,6 @@ private struct PageGround: View {
 
     var body: some View {
         ZStack {
-            // Always opaque, never a hole onto the window. Letting the queue
-            // show the window's wash through itself meant that for one frame
-            // between two pages neither was painted, and the bare wash filled
-            // the window — the flash on the first keystroke of a search.
             Rectangle().fill(.background)
             if washed {
                 ArtworkBleed(source: source, drifts: drifts)

--- a/apps/macos/Sources/Koan/Views/TransportBar.swift
+++ b/apps/macos/Sources/Koan/Views/TransportBar.swift
@@ -12,6 +12,7 @@ import SwiftUI
 /// glass floating on glass reads as neither.
 struct TransportBar: View {
     @Environment(PlayerModel.self) private var player
+    @Environment(LibraryModel.self) private var library
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     /// One per direction, so the arrow that was pressed is the only one that
@@ -100,6 +101,20 @@ struct TransportBar: View {
             // A cross-fade catches the corner of the eye; a hard swap doesn't.
             .contentTransition(.opacity)
             .animation(.easeInOut(duration: 0.2), value: player.currentEntry?.queueItemId)
+
+            // Next to what is playing, because that is what it acts on. ⌘D
+            // does the same from anywhere, but a heart you can see also tells
+            // you whether this one is already in.
+            if let trackId = player.currentTrackId {
+                FavouriteButton(
+                    isOn: library.isFavourite(track: trackId),
+                    size: .callout
+                ) {
+                    library.toggleFavourite(track: trackId)
+                }
+                .help(library.isFavourite(track: trackId)
+                    ? "Remove favourite (⌘D)" : "Favourite this track (⌘D)")
+            }
         }
     }
 


### PR DESCRIPTION
Three fixes and a patch bump.

## Favourites lost its album art

A regression I introduced in the v0.30.1 navigation refactor. #289 had added `mixedAlbums: true` to the Favourites `TrackListView` — favourites are gathered from the whole library, so a row's cover and album name are what tell it apart from the row above. Rebuilding the detail column, I reproduced that call from an older copy and dropped the flag. Restored.

## A heart on the transport

Next to what is playing, because that is what it acts on. Same `FavouriteButton` and the same `LibraryModel.isFavourite`/`toggleFavourite` the row hearts use, so the two can't drift apart. ⌘D already did this from anywhere; the visible heart also tells you whether the track is already in.

## The flash of bare colour on the first keystroke of a search

`.background` sizes itself to what it backs, and the detail column expanded the page *after* putting the ground behind it:

```swift
StageView()
    .background { PageGround(…) }                      // sized to the content
.frame(maxWidth: .infinity, maxHeight: .infinity)      // expanded afterwards
```

So the ground was only ever as big as the page's content. Every other page's content fills the column, which is why only one page ever showed it: the results page renders nothing at all while the query is still running — all three sections are empty and the "nothing found" branch is gated on `!isSearching` — so it measured nothing, its ground was a sliver, and the window's wash filled the rest.

The page is filled first now. `PageGround` also gives every page an opaque ground with the wash drawn *over* it rather than through it, so no page composites onto the window or onto the page before it.

## Verifying

- `just check` — 894 tests, clippy clean
- All three checked on screen against a 47,944-track library: favourites rows carry covers and album names, the heart sits next to the title in the transport, and typing the first letter of a search no longer floods the column — verified with a burst of window captures taken across the keystroke.

The first attempt at the flash fix was wrong — it assumed a transition frame between two pages. The captures showed the wash *holding* rather than flashing, which is what pointed at sizing rather than timing. Kept as two commits so the wrong reasoning isn't buried in the right fix.