### PR TITLE
fix: the cover reaches Now Playing, and progress stops pretending to be a queue change

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -191,6 +191,8 @@ Advancing parks on the next item that is not `Failed`, including one still downl
 
 A download that gives up sends `TrackFailed` instead, and the parked cursor advances past the item rather than waiting for a `TrackReady` that cannot come. The reason rides on the item as `LoadState::Failed(reason)` and out through `QueueEntry::error`, because a queue of unplayable tracks and a queue still fetching look identical without it.
 
+**Download progress is not a queue mutation.** `LoadState::Downloading` says *that* a transfer is running and carries the `Arc<AtomicU64>` the download thread writes bytes into; the state itself is set once per attempt. Progress therefore moves without the playlist lock and without bumping `playlist_version` — which matters because every front end reads that version as "refetch the queue", and a transfer produces a byte count several hundred times a second. Anything that wants to *watch* progress reads `downloads_in_flight()` on its own poll rather than waiting for a version change.
+
 ## koan-core modules
 
 ### `audio/`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- **The Now Playing widget had no cover on it.** Control Center, the lock screen and the media-key HUD showed the title and the artist against a blank square. Now Playing was only ever handed the artwork if the cover happened to already be in the cache at the instant the track started — and it never is: fetching it is an HTTP round trip on a remote library, and it lands a moment later. By then the guard that stops a 10 Hz poll republishing unchanged metadata saw the same track, the same state and no seek, and returned. The art arriving is now a reason to republish, and Now Playing asks for the cover itself rather than hoping the transport bar's request has landed, so it works with the window closed.
+
+- **The cached count sat still while an album downloaded.** "N of M remote cached" in the sidebar was read once at launch and again after a scan or a sync, and a download is neither — the count moved in the database and nothing told the library to look again. A finished transfer refreshes it now.
+
+- **Download progress juddered, and everything else slowed down while it ran.** Progress was announced by rewriting the queue item's load state after every 64KB — which took the playlist write lock and bumped the queue version, a thousand times a transfer, five transfers at once. Every front end reads that version as "the queue changed", so the macOS app was refetching the whole queue across the FFI ten to twenty times a second for what is a byte counter.
+
+  The load state says *that* a download is running and hands out the counter; the counter is where progress lives, and the download thread writes it without taking a lock at all. It is announced once per attempt. Progress reaches the macOS app as its own event instead of as a queue change, so it moves at 10 Hz without anything being rebuilt — and the last few tracks of an album no longer freeze at whatever fraction they had reached, which is what happened when nothing was left *waiting* to download and the old nudge stopped firing.
+
 ## v0.30.1 (2026-08-25)
 
 ### Changed

--- a/apps/macos/Sources/Koan/KoanApp.swift
+++ b/apps/macos/Sources/Koan/KoanApp.swift
@@ -48,6 +48,11 @@ final class AppState {
         activity.mirror("Scanning library") { engine.isAutoScanning() }
         activity.cancelLibraryTask = { engine.cancelLibraryTask() }
 
+        // A finished download changes the library's cached count and nothing
+        // else would say so — the count is a database read, and the download
+        // ran in the engine.
+        player.onDownloadsLanded = { [weak library] in library?.loadStats() }
+
         // Control Center and the media keys ride the player's existing poll.
         let centre = NowPlayingCentre(player: player, art: art)
         self.nowPlaying = centre

--- a/apps/macos/Sources/Koan/Support/NowPlayingCentre.swift
+++ b/apps/macos/Sources/Koan/Support/NowPlayingCentre.swift
@@ -22,6 +22,16 @@ final class NowPlayingCentre {
     private var publishedTrack: Int64?
     private var publishedState: PlayState?
     private var publishedPosition: UInt64 = 0
+    /// Which track's artwork actually made it into the published info.
+    ///
+    /// Art arrives after the track does — on a remote library the fetch is an
+    /// HTTP round trip — so the first publish for a track carries none, and
+    /// without this nothing would ever publish it: the guard below sees an
+    /// unchanged track, an unchanged state and no seek, and returns.
+    private var publishedArtwork: Int64?
+    /// The track a fetch has already been started for, so a record with no art
+    /// doesn't start one on every tick.
+    private var requestedArtwork: Int64?
 
     init(player: PlayerModel, art: CoverArtCache) {
         self.player = player
@@ -92,10 +102,15 @@ final class NowPlayingCentre {
             return
         }
 
-        // Republish on a track change, a state change, or a jump the system
-        // couldn't have extrapolated — a seek, in other words.
+        // Republish on a track change, a state change, a jump the system
+        // couldn't have extrapolated — a seek, in other words — or the artwork
+        // finally arriving.
+        let artwork = entry.trackId.flatMap { art.cached(.track($0)) }
         let drifted = abs(Int64(now.positionMs) - Int64(publishedPosition)) > 2000
-        guard entry.trackId != publishedTrack || now.state != publishedState || drifted else {
+        let artworkArrived = artwork != nil && publishedArtwork != entry.trackId
+        guard entry.trackId != publishedTrack || now.state != publishedState || drifted
+            || artworkArrived
+        else {
             return
         }
 
@@ -109,10 +124,7 @@ final class NowPlayingCentre {
         if now.durationMs > 0 {
             info[MPMediaItemPropertyPlaybackDuration] = Double(now.durationMs) / 1000
         }
-        // Whatever is already loaded — the transport bar is showing this same
-        // cover, so it usually is. Fetching here would put a network round trip
-        // on the path of every position update.
-        if let trackId = entry.trackId, let image = art.cached(.track(trackId)) {
+        if let image = artwork {
             info[MPMediaItemPropertyArtwork] = Self.artwork(for: image)
         }
 
@@ -126,5 +138,24 @@ final class NowPlayingCentre {
         publishedTrack = entry.trackId
         publishedState = now.state
         publishedPosition = now.positionMs
+        publishedArtwork = artwork == nil ? nil : entry.trackId
+
+        if artwork == nil, let trackId = entry.trackId {
+            fetchArtwork(trackId)
+        }
+    }
+
+    /// Load the cover so a later `refresh` finds it.
+    ///
+    /// The transport bar asks for this same key, but relying on that makes Now
+    /// Playing depend on a view being on screen. The cache shares one fetch per
+    /// key, so asking twice costs nothing.
+    private func fetchArtwork(_ trackId: Int64) {
+        guard requestedArtwork != trackId else { return }
+        requestedArtwork = trackId
+        Task {
+            _ = await art.image(for: .track(trackId))
+            refresh()
+        }
     }
 }

--- a/apps/macos/Sources/Koan/Support/PlayerModel.swift
+++ b/apps/macos/Sources/Koan/Support/PlayerModel.swift
@@ -86,6 +86,8 @@ final class PlayerModel {
                     await self.applyQueueChange()
                 case .positionChanged(let positionMs):
                     self.applyPosition(positionMs)
+                case .downloadsChanged(let downloads):
+                    self.applyDownloads(downloads)
                 }
             }
         }
@@ -134,6 +136,43 @@ final class PlayerModel {
             uniquingKeysWith: { a, b in b.status == .queued ? a : b }
         )
     }
+
+    /// Queue items mid-transfer at the last report.
+    ///
+    /// A track leaving this set has landed on disk, which is the only thing
+    /// that moves the library's cached count — and nothing else would tell it.
+    private var downloading: Set<String> = []
+
+    /// Download progress moved.
+    ///
+    /// Patched into the queue in place rather than refetching it. This arrives
+    /// several times a second while the queue behind it has not changed, and
+    /// rebuilding the whole list for a byte counter is what made the rest of
+    /// the app stutter while an album cached.
+    fileprivate func applyDownloads(_ downloads: [DownloadProgress]) {
+        let byItem = Dictionary(
+            downloads.map { ($0.queueItemId, $0.progress) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        for index in queue.indices {
+            let progress = byItem[queue[index].queueItemId] ?? nil
+            guard queue[index].downloadProgress != progress else { continue }
+            queue[index].downloadProgress = progress
+            if let trackId = queue[index].trackId {
+                queuedByTrack[trackId] = queue[index]
+            }
+        }
+
+        let active = Set(byItem.keys)
+        if !downloading.subtracting(active).isEmpty {
+            onDownloadsLanded?()
+        }
+        downloading = active
+    }
+
+    /// A download finished. Set by `AppState` — the library's cached count is
+    /// the only thing that knows it moved, and it has no other way to find out.
+    var onDownloadsLanded: (() -> Void)?
 
     /// The queue changed — rebuild it and refresh what depends on it.
     fileprivate func applyQueueChange() async {

--- a/crates/koan-core/src/helpers.rs
+++ b/crates/koan-core/src/helpers.rs
@@ -1145,16 +1145,25 @@ pub fn download_track(
     let progress_tx = tx.clone();
     let stream_ready_sent = Arc::new(std::sync::atomic::AtomicBool::new(false));
     let stream_ready_flag = stream_ready_sent.clone();
+    // Announced once, not per chunk. The load state says *that* a download is
+    // running and hands out the counter; the counter itself is where progress
+    // lives. Rewriting the state every 64KB took the playlist write lock and
+    // bumped the queue version a thousand times a transfer, and every front end
+    // reads that version as "the queue changed" and rebuilds it.
+    //
+    // A retry restarts the byte count from zero, so a changed total re-announces.
+    let announced_total = AtomicU64::new(u64::MAX);
     let result = client.download_with_progress(&remote_id, &dest, move |downloaded, total| {
         bytes_written_progress.store(downloaded, Ordering::Release);
-        progress_state.update_load_state(
-            progress_qid,
-            LoadState::Downloading {
-                downloaded,
-                total,
-                bytes_written: bytes_written_progress.clone(),
-            },
-        );
+        if announced_total.swap(total, Ordering::Relaxed) != total {
+            progress_state.update_load_state(
+                progress_qid,
+                LoadState::Downloading {
+                    total,
+                    bytes_written: bytes_written_progress.clone(),
+                },
+            );
+        }
         if !stream_ready_flag.load(Ordering::Relaxed)
             && downloaded >= crate::player::state::STREAM_THRESHOLD
         {

--- a/crates/koan-core/src/player/state.rs
+++ b/crates/koan-core/src/player/state.rs
@@ -70,9 +70,11 @@ pub const STREAM_THRESHOLD: u64 = 256 * 1024; // 256 KB
 pub enum LoadState {
     Pending,
     Downloading {
-        downloaded: u64,
+        /// Total bytes expected, or 0 when the server sent no Content-Length.
         total: u64,
-        /// Shared counter updated atomically by the download thread after each chunk.
+        /// How many bytes have landed. The download thread writes it per chunk
+        /// without taking the playlist lock — which is the point: progress
+        /// moves far too often to be worth a queue mutation each time.
         bytes_written: Arc<AtomicU64>,
     },
     Ready,
@@ -621,6 +623,25 @@ impl SharedPlayerState {
             .collect()
     }
 
+    /// Every item mid-transfer, with the bytes it has and the bytes it expects.
+    ///
+    /// Progress moves without the playlist version moving — the download thread
+    /// writes the byte counter directly — so anything following the version
+    /// alone shows a frozen bar. This is how a watcher sees it move.
+    pub fn downloads_in_flight(&self) -> Vec<(QueueItemId, u64, u64)> {
+        let pl = self.playlist.read();
+        pl.items
+            .iter()
+            .filter_map(|item| match &item.load_state {
+                LoadState::Downloading {
+                    total,
+                    bytes_written,
+                } => Some((item.id, bytes_written.load(Ordering::Relaxed), *total)),
+                _ => None,
+            })
+            .collect()
+    }
+
     /// Get the db_id for a specific playlist item.
     pub fn item_db_id(&self, id: QueueItemId) -> Option<i64> {
         let pl = self.playlist.read();
@@ -799,11 +820,16 @@ impl SharedPlayerState {
             let is_cursor = cursor_pos == Some(i);
             let is_before_cursor = cursor_pos.is_some_and(|cp| i < cp);
 
-            // Derive download progress from load_state uniformly for all tracks.
+            // Byte count comes from the shared atomic, not from the load
+            // state's own copy: the download thread writes it per chunk
+            // without taking the playlist lock, which is what keeps a
+            // transfer from bumping the playlist version a thousand times.
             let dl_progress = match &item.load_state {
                 LoadState::Downloading {
-                    downloaded, total, ..
-                } => Some((*downloaded, *total)),
+                    total,
+                    bytes_written,
+                    ..
+                } => Some((bytes_written.load(Ordering::Relaxed), *total)),
                 _ => None,
             };
 
@@ -1112,7 +1138,6 @@ mod tests {
         let dl_cursor = make_item(
             "downloading-at-cursor",
             LoadState::Downloading {
-                downloaded: 0,
                 total: 1_000_000,
                 bytes_written: bytes_cursor.clone(),
             },
@@ -1120,7 +1145,6 @@ mod tests {
         let dl_queued = make_item(
             "downloading-queued",
             LoadState::Downloading {
-                downloaded: 0,
                 total: 500_000,
                 bytes_written: bytes_queued.clone(),
             },
@@ -1134,6 +1158,38 @@ mod tests {
 
         assert_eq!(snap.entries[0].status, QueueEntryStatus::PriorityPending);
         assert_eq!(snap.entries[1].status, QueueEntryStatus::Downloading);
+    }
+
+    #[test]
+    fn progress_follows_the_counter_without_touching_the_playlist() {
+        // The download thread writes bytes and nothing else. A queue derived
+        // afterwards must see them — the version has not moved, and the load
+        // state it was given is the one it still holds.
+        let state = SharedPlayerState::new();
+        let bytes = Arc::new(AtomicU64::new(0));
+        let item = make_item(
+            "downloading",
+            LoadState::Downloading {
+                total: 1_000,
+                bytes_written: bytes.clone(),
+            },
+        );
+        state.add_items(vec![item]);
+
+        let version = state.playlist_version();
+        bytes.store(250, Ordering::Release);
+
+        let snap = state.derive_visible_queue();
+        assert_eq!(snap.entries[0].download_progress, Some((250, 1_000)));
+        assert_eq!(
+            state.playlist_version(),
+            version,
+            "progress must not read as a queue mutation"
+        );
+        assert_eq!(
+            state.downloads_in_flight(),
+            vec![(snap.entries[0].id, 250, 1_000)]
+        );
     }
 
     #[test]

--- a/crates/koan-ffi/src/lib.rs
+++ b/crates/koan-ffi/src/lib.rs
@@ -78,6 +78,15 @@ pub enum PlayerEvent {
     QueueChanged { version: u64 },
     /// Playback position, while playing.
     PositionChanged { position_ms: u64 },
+    /// What is downloading, and how far each has got.
+    ///
+    /// Separate from `QueueChanged` because progress moves several times a
+    /// second while the queue itself does not — announcing it as a queue change
+    /// makes every client refetch the whole list for a byte counter, which is
+    /// the thing the version guard exists to avoid. An empty list means nothing
+    /// is in flight any more, which is also how a client learns a download
+    /// finished.
+    DownloadsChanged { downloads: Vec<DownloadProgress> },
 }
 
 /// Reports how far a long task has got.
@@ -1789,7 +1798,7 @@ impl KoanEngine {
                 let mut last_version = u64::MAX;
                 let mut last_position = u64::MAX;
                 let mut last_signature: Option<(PlaybackState, Option<String>)> = None;
-                let mut ticks_since_download_nudge = 0u32;
+                let mut last_downloads: Vec<DownloadProgress> = Vec::new();
 
                 loop {
                     std::thread::sleep(std::time::Duration::from_millis(100));
@@ -1817,17 +1826,24 @@ impl KoanEngine {
                     if version != last_version {
                         last_version = version;
                         publish(PlayerEvent::QueueChanged { version });
-                        ticks_since_download_nudge = 0;
-                    } else if !engine.state.pending_downloads().is_empty() {
-                        // Download progress moves without bumping the version,
-                        // so nothing above would announce it. Once a second is
-                        // plenty for a progress bar and keeps the client from
-                        // having to poll for the one thing events don't cover.
-                        ticks_since_download_nudge += 1;
-                        if ticks_since_download_nudge >= 10 {
-                            ticks_since_download_nudge = 0;
-                            publish(PlayerEvent::QueueChanged { version });
-                        }
+                    }
+
+                    // Progress moves without the version moving, so it gets its
+                    // own event — one per tick while bytes are landing, and one
+                    // empty list when the last transfer ends.
+                    let downloads: Vec<DownloadProgress> = engine
+                        .state
+                        .downloads_in_flight()
+                        .into_iter()
+                        .map(|(id, done, total)| DownloadProgress {
+                            queue_item_id: id.0.to_string(),
+                            progress: (total > 0)
+                                .then(|| (done as f64 / total as f64).clamp(0.0, 1.0)),
+                        })
+                        .collect();
+                    if downloads != last_downloads {
+                        last_downloads = downloads.clone();
+                        publish(PlayerEvent::DownloadsChanged { downloads });
                     }
 
                     // Only while playing: a paused position doesn't move, and

--- a/crates/koan-ffi/src/types.rs
+++ b/crates/koan-ffi/src/types.rs
@@ -236,6 +236,17 @@ pub struct QueueItem {
     pub failure_reason: Option<String>,
 }
 
+/// How far one in-flight download has got.
+///
+/// Its own record rather than a queue refetch: progress moves several times a
+/// second and the queue does not, so the two travel separately.
+#[derive(uniffi::Record, Debug, Clone, PartialEq)]
+pub struct DownloadProgress {
+    pub queue_item_id: String,
+    /// 0.0–1.0, or `None` when the server sent no Content-Length.
+    pub progress: Option<f64>,
+}
+
 impl QueueItem {
     /// Build directly from a playlist item, skipping `derive_visible_queue()`.
     /// The transport bar polls several times a second and only ever wants the

--- a/crates/koan-server/src/graphql/subscriptions.rs
+++ b/crates/koan-server/src/graphql/subscriptions.rs
@@ -60,7 +60,9 @@ impl SubscriptionRoot {
         }
     }
 
-    /// Queue updates — pushes the full queue snapshot whenever the playlist version changes.
+    /// Queue updates — pushes the full queue snapshot whenever the playlist
+    /// version changes, and while anything is downloading, since progress moves
+    /// without the version moving.
     async fn queue_updated(
         &self,
         ctx: &Context<'_>,
@@ -75,8 +77,9 @@ impl SubscriptionRoot {
 
             loop {
                 let version = state.playlist_version();
+                let downloading = !state.downloads_in_flight().is_empty();
 
-                if version != last_version {
+                if version != last_version || downloading {
                     last_version = version;
                     yield GqlQueueSnapshot::capture(&state);
                 }

--- a/crates/koan-tui/src/app.rs
+++ b/crates/koan-tui/src/app.rs
@@ -2860,8 +2860,22 @@ impl App {
     /// Call once per frame before any queue-related reads.
     pub fn refresh_visible_queue(&mut self) {
         let v = self.state.playlist_version();
-        if v != self.queue.vq_version {
-            self.queue.vq_cache = self.state.derive_visible_queue();
+        let mutated = v != self.queue.vq_version;
+        // Download progress lives in an atomic the download thread writes
+        // directly, so it moves without the version moving. A queue with
+        // something in flight re-derives every frame; nothing else does.
+        let downloading = self
+            .queue
+            .vq_cache
+            .entries
+            .iter()
+            .any(|e| e.download_progress.is_some());
+        if !mutated && !downloading {
+            return;
+        }
+
+        self.queue.vq_cache = self.state.derive_visible_queue();
+        if mutated {
             self.queue.vq_version = v;
             self.state_dirty = true; // Queue mutated — persist.
             // Clamp cursor after every external playlist change.

--- a/crates/koan-tui/src/remote_bridge.rs
+++ b/crates/koan-tui/src/remote_bridge.rs
@@ -190,16 +190,20 @@ fn download_and_play(
     let bytes_written = Arc::new(AtomicU64::new(0));
     let stream_ready_sent = std::sync::atomic::AtomicBool::new(false);
 
+    // Once per attempt, not per chunk — see `helpers::download_track`. The
+    // counter carries progress; the load state only carries the fact.
+    let announced_total = AtomicU64::new(u64::MAX);
     let result = streamer.stream_to_file(&track_id.to_string(), dest, |downloaded, total| {
         bytes_written.store(downloaded, Ordering::Release);
-        state.update_load_state(
-            queue_id,
-            LoadState::Downloading {
-                downloaded,
-                total,
-                bytes_written: bytes_written.clone(),
-            },
-        );
+        if announced_total.swap(total, Ordering::Relaxed) != total {
+            state.update_load_state(
+                queue_id,
+                LoadState::Downloading {
+                    total,
+                    bytes_written: bytes_written.clone(),
+                },
+            );
+        }
         if !stream_ready_sent.load(Ordering::Relaxed)
             && downloaded >= koan_core::player::state::STREAM_THRESHOLD
         {


### PR DESCRIPTION
Two reported bugs and the two gripes attached to them. They share a cause: something changed and nothing said so — or said so far too often.

## Album art missing from Control Center / media keys

`NowPlayingCentre` only attached artwork if the cover was *already* in `CoverArtCache` at the instant the track started. On a remote library it never is — the fetch is an HTTP round trip and lands a moment later. By then the guard that stops the 10 Hz poll republishing unchanged metadata saw the same track, the same state and no seek, and returned. The art was fetched, cached, drawn in the transport bar, and never handed to `MPNowPlayingInfoCenter`.

Artwork arriving is now a republish trigger, tracked separately from the track id. Now Playing also starts the fetch itself instead of relying on the transport bar having asked for the same key — one fetch per key is shared by the cache, so it costs nothing, and it means the widget works with the window closed.

## Cached count frozen

`library.stats` was loaded at launch and after a scan or a sync. A download is neither. `PlayerModel` now notices a queue item leaving the in-flight set and the app refreshes the count.

## Progress judder, and the app slowing down while an album cached

The load-bearing one. `download_track` reported progress by rewriting `LoadState::Downloading` after every 64KB — `update_load_state` takes the playlist write lock and bumps `playlist_version`. That is ~800 version bumps a second across five workers, and every front end reads that version as "the queue changed": the macOS app was refetching the whole queue across the FFI 10–20 times a second (twice per event — `applyQueueChange` rebuilds, then `tick` sees a version that moved again and rebuilds a second time).

`LoadState::Downloading` now carries only the total and the `Arc<AtomicU64>`; the stale `downloaded` copy is gone. The download thread writes the counter without any lock, and the state is announced once per attempt. Readers take the live counter:

- **macOS** — a new `PlayerEvent::DownloadsChanged` carries just `(queueItemId, progress)`, patched into the queue in place. 10 Hz, nothing rebuilt.
- **TUI** — `refresh_visible_queue` re-derives while anything is in flight, without the mutation side effects (persist, clamp cursor, note failures) that only belong on a real change. As a bonus the queue is no longer marked dirty for persistence 800 times a second.
- **GraphQL** — `queueUpdated` emits while anything is in flight.

This also fixes a straight bug in the old FFI nudge: it fired only while `pending_downloads()` was non-empty, and that returns `LoadState::Pending` items only. Once the last tracks of an album were all actively *downloading* with nothing left waiting, no nudge fired at all and their progress rings froze wherever they'd got to.

Transfer speed itself is the link and the server — `transcode_quality = "original"`, 5 workers, no throttle in koan's path — but the lock and FFI churn removed here was competing with it.

## Verifying

- `just check` — green, including a new `progress_follows_the_counter_without_touching_the_playlist` asserting the derived queue sees a counter write and that the version does *not* move.
- `just macos-build` — green.
- By hand: enqueue a remote album. Ring fills smoothly on every row including the last ones, the sidebar count climbs as tracks land, and Control Center shows the sleeve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rh7zyzdRYzdRfR3ZdKjk4t