### PR TITLE
ci: only run the build matrix when source changes

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -24,29 +24,28 @@ jobs:
       - id: filter
         env:
           EVENT: ${{ github.event_name }}
-        # Documentation-only pull requests do not need three toolchains and two
-        # operating systems to tell them the prose compiles. Everything else --
-        # a push to main, a manual run, a PR that touches one line of Rust --
-        # builds the lot.
+        # Only a change to something that feeds a build is worth two operating
+        # systems and three toolchains. Prose, plans and the licence are not.
         #
-        # Written to fail open: any surprise here leaves code=true, because a
-        # skipped job satisfies a required status check and a gate that guesses
-        # wrong in the other direction would merge untested code.
+        # An allowlist, so the question is "did any source change?" rather than
+        # "was everything recognisably documentation?". The cost is that a new
+        # top-level directory of code is invisible here until it is added below.
         run: |
           code=true
           if [ "$EVENT" = "pull_request" ]; then
             # HEAD is the merge commit GitHub built for this PR and its first
-            # parent is the base branch, so this is exactly the PR's diff.
-            files=$(git diff --name-only HEAD^1 HEAD)
-            # Default-deny: a path has to be recognisably documentation to be
-            # ignored, so anything unfamiliar -- a new build script, a workflow
-            # -- counts as code until this list says otherwise.
-            docs='(^|/)[^/]*\.md$|^docs/|^\.claude/|^LICENSE$|^\.gitignore$'
-            if [ -n "$files" ] && ! printf '%s\n' "$files" | grep -qvE "$docs"; then
-              code=false
-              echo "documentation only -- skipping build, test and lint:"
+            # parent is the base branch, so this is exactly the PR's diff. If it
+            # cannot be worked out, code stays true and everything runs.
+            if files=$(git diff --name-only HEAD^1 HEAD); then
+              src='^crates/|^apps/|^Cargo\.(toml|lock)$|^\.cargo/|^\.github/workflows/|^justfile$|^mise\.toml$|^rust-toolchain'
+              # Markdown is documentation wherever it sits, including beside code.
+              hits=$(printf '%s\n' "$files" | grep -E "$src" | grep -vE '\.md$')
+              if [ -z "$hits" ]; then
+                code=false
+                echo "no source changes -- skipping build, test and lint:"
+              fi
+              printf '%s\n' "$files" | sed 's/^/  /'
             fi
-            printf '%s\n' "$files" | sed 's/^/  /'
           fi
           echo "code=$code" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -11,9 +11,50 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  changes:
+    name: Changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 2
+      - id: filter
+        env:
+          EVENT: ${{ github.event_name }}
+        # Documentation-only pull requests do not need three toolchains and two
+        # operating systems to tell them the prose compiles. Everything else --
+        # a push to main, a manual run, a PR that touches one line of Rust --
+        # builds the lot.
+        #
+        # Written to fail open: any surprise here leaves code=true, because a
+        # skipped job satisfies a required status check and a gate that guesses
+        # wrong in the other direction would merge untested code.
+        run: |
+          code=true
+          if [ "$EVENT" = "pull_request" ]; then
+            # HEAD is the merge commit GitHub built for this PR and its first
+            # parent is the base branch, so this is exactly the PR's diff.
+            files=$(git diff --name-only HEAD^1 HEAD)
+            # Default-deny: a path has to be recognisably documentation to be
+            # ignored, so anything unfamiliar -- a new build script, a workflow
+            # -- counts as code until this list says otherwise.
+            docs='(^|/)[^/]*\.md$|^docs/|^\.claude/|^LICENSE$|^\.gitignore$'
+            if [ -n "$files" ] && ! printf '%s\n' "$files" | grep -qvE "$docs"; then
+              code=false
+              echo "documentation only -- skipping build, test and lint:"
+            fi
+            printf '%s\n' "$files" | sed 's/^/  /'
+          fi
+          echo "code=$code" >> "$GITHUB_OUTPUT"
+
   fmt:
     name: Format
     runs-on: macos-latest
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     timeout-minutes: 45
     concurrency:
       group: fmt-${{ github.ref }}
@@ -29,6 +70,8 @@ jobs:
   clippy:
     name: Clippy (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     timeout-minutes: 45
     concurrency:
       group: clippy-${{ matrix.os }}-${{ github.ref }}
@@ -50,6 +93,8 @@ jobs:
   test:
     name: Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     timeout-minutes: 45
     concurrency:
       group: test-${{ matrix.os }}-${{ github.ref }}
@@ -72,6 +117,8 @@ jobs:
   build:
     name: Build (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     timeout-minutes: 45
     concurrency:
       group: build-${{ matrix.os }}-${{ github.ref }}
@@ -93,6 +140,8 @@ jobs:
   macos-app:
     name: macOS App
     runs-on: macos-latest
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     timeout-minutes: 45
     concurrency:
       group: macos-app-${{ github.ref }}
@@ -114,6 +163,8 @@ jobs:
   msrv:
     name: MSRV (1.89)
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     timeout-minutes: 30
     concurrency:
       group: msrv-${{ github.ref }}
@@ -135,6 +186,8 @@ jobs:
   audit:
     name: Security Audit
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     timeout-minutes: 15
     # Blocking. The advisories already in the lockfile are acknowledged in
     # .cargo/audit.toml so this fails on anything new.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,10 @@ just fmt
 4. Keep commits focused. We squash-merge PRs, so don't stress about perfect history.
 5. Describe what your PR does and why in the PR description.
 
+A PR that touches only Markdown, `docs/`, `LICENSE` or `.gitignore` skips the
+build, test and lint jobs — they report as skipped, which counts as passing.
+Touch anything else and the full matrix runs.
+
 ## Architecture
 
 Four crates: `koan-core` (library -- audio engine, player, database, indexer), `koan-tui` (TUI, visualizers, media keys), `koan-server` (GraphQL, Subsonic REST, MCP), and `koan-cli` (binary -- CLI entry point). See [ARCHITECTURE.md](ARCHITECTURE.md) for the full technical manual.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,9 +29,12 @@ just fmt
 4. Keep commits focused. We squash-merge PRs, so don't stress about perfect history.
 5. Describe what your PR does and why in the PR description.
 
-A PR that touches only Markdown, `docs/`, `LICENSE` or `.gitignore` skips the
-build, test and lint jobs — they report as skipped, which counts as passing.
-Touch anything else and the full matrix runs.
+The build, test and lint jobs only run when a PR touches something that feeds
+a build — `crates/`, `apps/`, `Cargo.toml`, `Cargo.lock`, `.cargo/`, `justfile`,
+`mise.toml` or `.github/workflows/`. A documentation PR sees them reported as
+skipped, which counts as passing. Adding a new top-level source directory means
+adding it to the `changes` job in `.github/workflows/ci-cd.yml`, or CI will sit
+the PR out.
 
 ## Architecture
 


### PR DESCRIPTION
A README change currently costs the full matrix: fmt, clippy ×2, test ×2, build ×2, the macOS app, MSRV and audit. This gates all of them on whether the PR touches anything that actually feeds a build.

## How it works

A `changes` job runs first, diffs the PR's merge commit against its first parent, and emits `code=true|false`. Every heavy job gets `needs: changes` and `if: needs.changes.outputs.code == 'true'`.

Source is an allowlist: `crates/`, `apps/`, `Cargo.toml`, `Cargo.lock`, `.cargo/`, `justfile`, `mise.toml`, `rust-toolchain*`, `.github/workflows/`. Markdown is documentation wherever it sits, so `crates/koan-core/README.md` does not count.

Load-bearing decisions:

- **A gate job, not `paths-ignore`.** The ruleset on `main` requires Format, Clippy ×2, Test ×2 and Build ×2. Filtering at the trigger would leave those checks pending forever and wedge every docs PR; a job skipped by `if:` reports as successful, so they merge.
- **Non-PR events always run everything**, so the release chain on `main` is untouched — the filter only ever narrows a pull request.
- **A diff that cannot be computed runs everything.** `code` starts true and only the successful-diff branch can clear it.
- **Diffed with git, not a new action.** `HEAD^1 HEAD` on the PR merge commit at `fetch-depth: 2`, so no third-party action joins the SHA-pinned set.

## The trade-off

An allowlist means a **new top-level source directory is invisible until it is added to the list** — CI would sit the PR out rather than fail it. That is the deliberate cost of asking "did source change?" instead of "was everything prose?", and `CONTRIBUTING.md` says so where someone adding one will read it.

## Confirming it

The script was extracted from the workflow with `yq` and run against real merge commits over a replica of this repo's layout:

| changed | result |
|---|---|
| `README.md` | skip |
| `CHANGELOG.md` + `CONTRIBUTING.md` | skip |
| `docs/*.md` + `docs/images/*.png` | skip |
| `.claude/plans/`, `LICENSE`, `.gitignore` | skip |
| `crates/koan-core/README.md` | skip |
| `.github/dependabot.yml` | skip |
| `crates/**/*.rs`, `crates/**/Cargo.toml`, a new crate | run |
| `apps/macos/**` (Swift and resources) | run |
| `Cargo.toml`, `Cargo.lock`, `mise.toml`, `justfile`, `.cargo/` | run |
| `.github/workflows/` | run |
| `README.md` + one line of Rust | run |

This PR touches a workflow, so it runs the full matrix — that is the check on the change itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L2QYGXTN6dYC7MX5KNY8a5