### PR TITLE
feat(macos): playing something leaves you where you are

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- **Playing something no longer throws you at the queue.** Every play button replaced the queue and then moved you to it, which is backwards: the queue runs behind whatever you are doing and is somewhere you go, not somewhere you are sent. Play a track from a record, a row in favourites, a selection in history, an album from the picker — you stay where you were and the music changes.
+
+  Two places still move you, because staying put would show you nothing. An artist page is a wall of covers with no tracks on it, so its play and shuffle buttons go to the queue. And a click on an album's cover art opens the record it just started, since that is where its tracks are.
+
 ## v0.30.2 (2026-08-25)
 
 ### Added

--- a/apps/macos/Sources/Koan/Support/Navigator.swift
+++ b/apps/macos/Sources/Koan/Support/Navigator.swift
@@ -172,10 +172,10 @@ final class Navigator {
 
     /// Show the queue once it holds what was just started.
     ///
-    /// Called after anything that starts playback outright, so you end up
-    /// looking at what you started. Not called for "add to queue" or "play
-    /// next" — those are things you do while browsing, and being thrown across
-    /// the app for them would be rude.
+    /// Playing something is not a reason to move: you stay where you were, and
+    /// the queue keeps running behind you until you go to it yourself. The one
+    /// exception is the artist page — a wall of covers with no tracks on it,
+    /// where nothing on screen would show that playback had started at all.
     ///
     /// Queue mutations run off the main actor, so switching immediately shows
     /// the old queue for a frame or two and then flickers. Waiting for the

--- a/apps/macos/Sources/Koan/Views/HistoryView.swift
+++ b/apps/macos/Sources/Koan/Views/HistoryView.swift
@@ -14,7 +14,6 @@ import SwiftUI
 /// usual play/queue menu, but there is nothing here to reorder or remove.
 struct HistoryView: View {
     @Environment(LibraryModel.self) private var library
-    @Environment(Navigator.self) private var nav
     @Environment(PlayerModel.self) private var player
     @State private var selection: Set<Int64> = []
     @State private var confirmingClear = false
@@ -92,7 +91,6 @@ struct HistoryView: View {
         let chosen = tracks(for: ids)
         guard !chosen.isEmpty else { return }
         player.playNow(trackIds: chosen.map(\.id))
-        nav.showQueueWhenReady(watching: player)
     }
 
     /// Forgets the selected plays. The tracks themselves are untouched —
@@ -111,10 +109,7 @@ struct HistoryView: View {
             PlayableMenu(playable: .track(track))
         } else if !chosen.isEmpty {
             let trackIds = chosen.map(\.id)
-            Button("Play") {
-                player.playNow(trackIds: trackIds)
-                nav.showQueueWhenReady(watching: player)
-            }
+            Button("Play") { player.playNow(trackIds: trackIds) }
             Button("Play Next") { player.playNext(trackIds: trackIds) }
             Button("Add to Queue") { player.enqueue(trackIds: trackIds) }
         }

--- a/apps/macos/Sources/Koan/Views/LinkText.swift
+++ b/apps/macos/Sources/Koan/Views/LinkText.swift
@@ -67,8 +67,11 @@ struct LinkText: View {
     }
 }
 
-/// Album art that plays the record when clicked, with the affordance only
-/// showing on hover so a wall of covers stays a wall of covers.
+/// Album art that plays the record when clicked and opens it, with the
+/// affordance only showing on hover so a wall of covers stays a wall of covers.
+///
+/// The record is where the tracks are, so that is where a click on its cover
+/// leaves you — not the queue, which is behind everything and stays there.
 struct PlayableArtwork: View {
     let albumId: Int64
     var cornerRadius: CGFloat = 6
@@ -107,19 +110,20 @@ struct PlayableArtwork: View {
     }
 
     /// Resolving the tracks is the slow half, so it happens off the main actor
-    /// and the queue command follows once they're in hand.
+    /// and the queue command follows once they're in hand. The move to the
+    /// record doesn't wait on it — the click should land immediately.
     private func play() {
         guard !loading else { return }
         loading = true
         let engine = library.engine
         let albumId = self.albumId
+        nav.open(album: albumId)
         Task {
             let ids = ((try? await engine.tracks(
                 albumId: albumId, artistId: nil, sort: .album, limit: 500, offset: 0
             )) ?? []).map(\.id)
             loading = false
             player.playNow(trackIds: ids)
-            nav.showQueueWhenReady(watching: player)
         }
     }
 }

--- a/apps/macos/Sources/Koan/Views/PickerSheet.swift
+++ b/apps/macos/Sources/Koan/Views/PickerSheet.swift
@@ -11,7 +11,6 @@ struct PickerSheet: View {
     @Binding var isPresented: Bool
 
     @Environment(PlayerModel.self) private var player
-    @Environment(Navigator.self) private var nav
     @Environment(LibraryModel.self) private var library
 
     @State private var kind: SearchKind = .track
@@ -224,7 +223,6 @@ struct PickerSheet: View {
                 }
             case .replace:
                 player.playNow(trackIds: trackIds)
-                nav.showQueueWhenReady(watching: player)
             }
             isPresented = false
         }

--- a/apps/macos/Sources/Koan/Views/PlayableMenu.swift
+++ b/apps/macos/Sources/Koan/Views/PlayableMenu.swift
@@ -52,21 +52,11 @@ struct PlayableMenu: View {
     @Environment(\.openWindow) private var openWindow
 
     var body: some View {
-        Button("Play") {
-            act {
-                player.playNow(trackIds: $0)
-                nav.showQueueWhenReady(watching: player)
-            }
-        }
+        Button("Play") { act { player.playNow(trackIds: $0) } }
         Button("Play Next") { act { player.playNext(trackIds: $0) } }
         Button("Add to Queue") { act { player.enqueue(trackIds: $0) } }
         if playable.hasChildren {
-            Button("Shuffle") {
-                act {
-                    player.playNow(trackIds: $0.shuffled())
-                    nav.showQueueWhenReady(watching: player)
-                }
-            }
+            Button("Shuffle") { act { player.playNow(trackIds: $0.shuffled()) } }
         }
 
         Divider()
@@ -262,6 +252,11 @@ struct FavouriteHeaderButton: View {
 }
 
 /// The big play button on an album or artist page, sat beside the title.
+///
+/// On an album you can already see what you started, so the page stays put. An
+/// artist page is a wall of covers with no tracks on it, and is the one place
+/// where nothing on screen would show that anything happened — so that one, and
+/// only that one, goes to the queue.
 struct PlayableHeaderButton: View {
     let playable: Playable
 
@@ -280,7 +275,7 @@ struct PlayableHeaderButton: View {
                 let ids = await playable.trackIds(using: engine)
                 loading = false
                 player.playNow(trackIds: ids)
-                nav.showQueueWhenReady(watching: player)
+                if case .artist = playable { nav.showQueueWhenReady(watching: player) }
             }
         } label: {
             ZStack {

--- a/apps/macos/Sources/Koan/Views/RowPlayButton.swift
+++ b/apps/macos/Sources/Koan/Views/RowPlayButton.swift
@@ -15,7 +15,6 @@ struct RowPlayButton: View {
     var inContext: (trackIds: [Int64], startAt: Int)?
 
     @Environment(PlayerModel.self) private var player
-    @Environment(Navigator.self) private var nav
     @Environment(LibraryModel.self) private var library
     @State private var loading = false
 
@@ -33,13 +32,12 @@ struct RowPlayButton: View {
         .help("Play \(playable.name)")
     }
 
-    /// Replaces the queue. Resolution happens off the main actor — an artist is
-    /// a lot of rows.
+    /// Replaces the queue and stays put. Resolution happens off the main actor
+    /// — an artist is a lot of rows.
     private func play() {
         guard !loading else { return }
         if let context = inContext {
             player.playNow(trackIds: context.trackIds, startingAt: context.startAt)
-            nav.showQueueWhenReady(watching: player)
             return
         }
         loading = true
@@ -49,7 +47,6 @@ struct RowPlayButton: View {
             let ids = await playable.trackIds(using: engine)
             loading = false
             player.playNow(trackIds: ids)
-            nav.showQueueWhenReady(watching: player)
         }
     }
 }

--- a/apps/macos/Sources/Koan/Views/TrackListView.swift
+++ b/apps/macos/Sources/Koan/Views/TrackListView.swift
@@ -97,7 +97,6 @@ struct TrackListView: View {
     private func play(_ ids: Set<Int64>) {
         guard let index = tracks.firstIndex(where: { ids.contains($0.id) }) else { return }
         player.playNow(trackIds: tracks.map(\.id), startingAt: index)
-        nav.showQueueWhenReady(watching: player)
     }
 
     private func playSelection() { play(selection) }
@@ -112,7 +111,6 @@ struct TrackListView: View {
         } else if !chosen.isEmpty {
             Button("Play") {
                 player.playNow(trackIds: chosen.map(\.id))
-                nav.showQueueWhenReady(watching: player)
             }
             Button("Play Next") { player.playNext(trackIds: chosen.map(\.id)) }
             Button("Add to Queue") { player.enqueue(trackIds: chosen.map(\.id)) }


### PR DESCRIPTION
Play buttons replaced the queue and then dragged you to it. The queue sits behind whatever you're doing — somewhere you go, not somewhere you get sent — so starting playback no longer moves the page.

**Stays put now:** track rows (`RowPlayButton`), list and multi-selection plays (`TrackListView`), the `PlayableMenu` Play/Shuffle items, history rows, the picker's replace-queue action, and the album page's header button.

**Still navigates, because staying put would show you nothing:**
- **Artist header play + shuffle** → the queue. An artist page is a wall of covers with no tracks on it, so nothing on screen would reflect that playback started. This is the only play button in the app that navigates.
- **Album cover art** → that album's page. It's where the tracks are. The move fires immediately rather than after the track ids resolve, so the click lands at once.

## Verifying

Build: `just macos-build` (clean). No Rust touched.

Worth a click through: play a track from an album page, a favourites row, a history selection, a right-click menu, and ⇧⌘K → replace — none should move you. Then the artist page's play and shuffle (→ queue) and an album cover in the grid (→ that album).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELxvs3BiMCULV5NE9k4xX5