### PR TITLE
fix(macos): give ungrouped queue rows room for their covers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- **Ungrouped queue rows had no room for their covers.** Every row carries its own sleeve when the queue is not grouped by album, and the fixed row height around it left the art all but touching the separators above and below. It gets the same six points the album heading already gives its own cover — they are rows in the same list and should breathe alike.
 - **The favourite key flipped the database and nothing else.** `f` and ⌘D went straight to the engine, but every heart in the app reads `LibraryModel.favouriteTrackIds` — so the row changed underneath a UI that kept showing the old answer, and pressing the heart afterwards looked like it was undoing a favourite you had just added. Both routes go through the library now, which is what the hearts read.
 
 ### Added

--- a/apps/macos/Sources/Koan/Views/QueueView.swift
+++ b/apps/macos/Sources/Koan/Views/QueueView.swift
@@ -636,6 +636,11 @@ private struct QueueRow: View {
         // Fixed height so a row doesn't grow when a download indicator appears
         // and shrink when it finishes, reflowing the list each time.
         .frame(height: artwork ? 40 : 34)
+        // Ungrouped, the row carries a sleeve and two lines of text, and the
+        // frame around them left the cover all but touching the separators.
+        // The same six points the album heading gives its own cover — the two
+        // kinds of row are in the same list and should breathe alike.
+        .padding(.vertical, artwork ? 6 : 0)
         // Without this the row is only clickable where a view actually sits —
         // the Spacer between the title and the duration is a dead zone, and
         // clicks landing there select nothing.


### PR DESCRIPTION
Ungrouped, every queue row carries its own sleeve — and sat in a frame sized for a row that does not, so the art was hard against the separators above and below.

`QueueRow` sets `.frame(height: artwork ? 40 : 34)` and no padding, while `QueueAlbumHeader`, a row in the same list, pads itself `.vertical, 6` around a 52pt cover. Grouped mode never showed the difference: those rows are 34pt with one line of text and no image. Ungrouped they are 40pt holding a 28pt sleeve and two lines, and the frame has nothing left to give.

The track row now takes the same six points, and only when it is carrying a cover — grouped mode is byte-for-byte unchanged.

**Not verified on screen.** Your app is running from `/Applications` against `~/.config/koan/koan.db`, and a second instance would have both of us writing that SQLite file and fighting over the audio device, so I did not launch one. It builds; if six points is the wrong number, say so and I will change it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L2QYGXTN6dYC7MX5KNY8a5