### PR TITLE
feat(macos): favourites shows records and artists too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@
 
 ### Fixed
 
+- **The filter on the Favourites page did nothing.** `LibraryModel` narrowed the list into `visibleFavourites` and the page rendered the unfiltered `favourites` beside it. Every other filtered section read the right one.
 - **The favourite key flipped the database and nothing else.** `f` and ⌘D went straight to the engine, but every heart in the app reads `LibraryModel.favouriteTrackIds` — so the row changed underneath a UI that kept showing the old answer, and pressing the heart afterwards looked like it was undoing a favourite you had just added. Both routes go through the library now, which is what the hearts read.
 
 ### Added
 
+- **Favourites shows records and artists, not only tracks.** koan has always let you favourite an album or an artist — the heart is on both — and the Favourites page only ever listed tracks, so there was nowhere in the app those went. It is one page in three sections now, the way search results are: a section only appears when you have favourited something of that kind, so a tracks-only library reads exactly as it did. The filter narrows all three at once.
 - **`q` goes to the queue.** `g` and `G` already went to its ends; there was no key for simply going there.
 - **Escape clears the selection, wherever you are.** The queue also grew a Clear button beside Remove — a selection with no visible way out of it is a trap, and on a list you have scrolled away from you cannot even see what you are still holding.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@
 
   Playback is reconciled with the playlist after every undo and redo, not just this one: any undo that takes items away can strand the engine the same way — undoing an add while the added track is playing did it too. If something was playing, the restored cursor picks up where the queue says it was; if it was paused or stopped, the undo stays quiet, because an undo is not a reason to start the music. The position is not part of what a replace snapshots, so the track starts again rather than resuming mid-way.
 
-- **The favourite key flipped the database and nothing else.** `f` and ⌘D went straight to the engine, but every heart in the app reads `LibraryModel.favouriteTrackIds` — so the row changed underneath a UI that kept showing the old answer, and pressing the heart afterwards looked like it was undoing a favourite you had just added. Both routes go through the library now, which is what the hearts read.
 
 - **The format badge latched a rate the device was on its way off.** A 48 kHz track followed by a 44.1 kHz one publishes the new track's info before the device has finished reclocking, and a switch is not instant — the better part of a second on USB. A front end polling in that window paired 44.1 with the outgoing 48, and then never let go: the macOS app only republished the format when the codec, source rate or bit depth changed, and none of those move once the rate lands. "FLAC 16/44.1 → 48" could sit there, wrong, for half an hour. The output rate now reads as unknown while the device is between rates, rather than as the last track's.
 
@@ -25,7 +24,6 @@
 
 ### Changed
 
-- **The favourite key flipped the database and nothing else.** `f` and ⌘D went straight to the engine, but every heart in the app reads `LibraryModel.favouriteTrackIds` — so the row changed underneath a UI that kept showing the old answer, and pressing the heart afterwards looked like it was undoing a favourite you had just added. Both routes go through the library now, which is what the hearts read.
 - **The shortcuts sheet says what the menus say.** It listed the single-key shortcuts and then told you the rest were "in the menus", which is true and no help — nobody opens six menus to find out that Back is ⌘[. The ⌘ shortcuts are now a second table on the same sheet, and both halves are generated from the same declarations the menu bar is built from, so they cannot drift.
 - **Leaving the queue and coming back keeps your place.** The stage is one `switch`, so every move destroys the page it left and takes its scroll position with it. The queue remembers where it was.
 - **Playing something no longer throws you at the queue.** Every play button replaced the queue and then moved you to it, which is backwards: the queue runs behind whatever you are doing and is somewhere you go, not somewhere you are sent. Play a track from a record, a row in favourites, a selection in history, an album from the picker — you stay where you were and the music changes.

--- a/apps/macos/Sources/Koan/Support/LibraryModel.swift
+++ b/apps/macos/Sources/Koan/Support/LibraryModel.swift
@@ -69,8 +69,8 @@ final class LibraryModel {
     // it left the album view showing an unfilled heart on a track that was
     // already favourited.
     private(set) var favouriteTrackIds: Set<Int64> = []
-    private(set) var favouriteAlbumIds: Set<Int64> = []
-    private(set) var favouriteArtistIds: Set<Int64> = []
+    private(set) var favouriteAlbumIds: Set<Int64> = [] { didSet { refilter() } }
+    private(set) var favouriteArtistIds: Set<Int64> = [] { didSet { refilter() } }
 
     func isFavourite(track id: Int64) -> Bool { favouriteTrackIds.contains(id) }
     func isFavourite(album id: Int64) -> Bool { favouriteAlbumIds.contains(id) }
@@ -122,6 +122,12 @@ final class LibraryModel {
     private(set) var visibleAlbums: [Album] = []
     private(set) var visibleArtists: [Artist] = []
     private(set) var visibleFavourites: [Track] = []
+    /// Favourited records and artists, resolved out of the catalogue already in
+    /// memory — the engine hands back ids, and `prefetchCatalogue` holds the
+    /// rows. Taken in the catalogue's order rather than the set's, which has
+    /// none, so the grid does not reshuffle itself on every toggle.
+    private(set) var visibleFavouriteAlbums: [Album] = []
+    private(set) var visibleFavouriteArtists: [Artist] = []
     private(set) var visiblePlayHistory: [PlayHistoryEntry] = []
 
     /// Recompute what each section shows. Called whenever the filter or any of
@@ -135,6 +141,20 @@ final class LibraryModel {
         visibleFavourites = section == .favourites
             ? matching(favourites) { [$0.title, $0.artistName, $0.albumTitle] }
             : favourites
+        // Only ever built for the page that shows them: this walks the whole
+        // catalogue, and every other section would be paying for it on each
+        // keystroke of its own filter.
+        if section == .favourites {
+            visibleFavouriteAlbums = matching(
+                albums.filter { favouriteAlbumIds.contains($0.id) }
+            ) { [$0.title, $0.artistName] }
+            visibleFavouriteArtists = matching(
+                artists.filter { favouriteArtistIds.contains($0.id) }
+            ) { [$0.name] }
+        } else {
+            visibleFavouriteAlbums = []
+            visibleFavouriteArtists = []
+        }
         visiblePlayHistory = section == .playHistory
             ? matching(playHistory) { [$0.track.title, $0.track.artistName, $0.track.albumTitle] }
             : playHistory

--- a/apps/macos/Sources/Koan/Views/FavouritesView.swift
+++ b/apps/macos/Sources/Koan/Views/FavouritesView.swift
@@ -1,0 +1,153 @@
+import KoanFFI
+import SwiftUI
+
+/// Everything you have favourited, in one page.
+///
+/// koan favourites artists and records as well as tracks, and this page only
+/// ever showed the tracks — the other two were invisible from inside the app.
+/// Sections rather than a type picker, for the same reason search results are
+/// sections: they are all answers to one question, and a mode you have to
+/// remember you are in is a worse way to find out you favourited a record.
+///
+/// One `List` rather than search's `ScrollView`, because the tracks here are a
+/// working list: range-select, Return to play, a menu on the selection. The
+/// artists and records ride above them as rows that cannot be selected.
+struct FavouritesView: View {
+    @Environment(PlayerModel.self) private var player
+    @Environment(Navigator.self) private var nav
+    @Environment(LibraryModel.self) private var library
+
+    @State private var selection: Set<Int64> = []
+
+    private let columns = [GridItem(.adaptive(minimum: 140, maximum: 190), spacing: 16)]
+
+    private var artists: [Artist] { library.visibleFavouriteArtists }
+    private var albums: [Album] { library.visibleFavouriteAlbums }
+    private var tracks: [Track] { library.visibleFavourites }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+                .padding(.horizontal, 24)
+                .padding(.top, 18)
+                .padding(.bottom, 16)
+
+            if artists.isEmpty && albums.isEmpty && tracks.isEmpty {
+                EmptyState(
+                    icon: "heart",
+                    title: library.filter.isEmpty ? "Nothing favourited yet" : "No matches",
+                    detail: library.filter.isEmpty
+                        ? "Hit the heart on a track, a record or an artist."
+                        : nil
+                )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                List(selection: $selection) {
+                    if !artists.isEmpty { artistSection }
+                    if !albums.isEmpty { albumSection }
+                    if !tracks.isEmpty { trackSection }
+                }
+                .listStyle(.inset)
+                .clearsSelection($selection)
+                .contextMenu(forSelectionType: Int64.self) { ids in
+                    menu(for: ids)
+                } primaryAction: { ids in
+                    play(ids)
+                }
+                .onKeyPress(.return) {
+                    play(selection)
+                    return KeyPress.Result.handled
+                }
+            }
+        }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 1) {
+            Text("Favourites")
+                .font(.title2.weight(.semibold))
+            Text(summary)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    /// Only the kinds you actually have, so a tracks-only library reads exactly
+    /// as it did before there were three of them.
+    private var summary: String {
+        var parts: [String] = []
+        if !artists.isEmpty { parts.append(Format.count(Int64(artists.count), "artist")) }
+        if !albums.isEmpty { parts.append(Format.count(Int64(albums.count), "album")) }
+        if !tracks.isEmpty { parts.append(Format.count(Int64(tracks.count), "track")) }
+        return parts.joined(separator: " · ")
+    }
+
+    // MARK: - Sections
+
+    private var artistSection: some View {
+        Section("Artists") {
+            FlowLayout(spacing: 8) {
+                ForEach(artists, id: \.id) { artist in
+                    ArtistPill(name: artist.name, artistId: artist.id)
+                }
+            }
+            .padding(.vertical, 4)
+            .selectionDisabled()
+        }
+    }
+
+    private var albumSection: some View {
+        Section("Albums") {
+            LazyVGrid(columns: columns, spacing: 18) {
+                ForEach(albums, id: \.id) { album in
+                    AlbumGridCell(album: album)
+                }
+            }
+            .padding(.vertical, 6)
+            .selectionDisabled()
+        }
+    }
+
+    private var trackSection: some View {
+        Section("Tracks") {
+            ForEach(Array(tracks.enumerated()), id: \.element.id) { index, track in
+                TrackRow(
+                    track: track,
+                    position: index + 1,
+                    isCurrent: player.currentTrackId == track.id,
+                    isSelected: selection.contains(track.id),
+                    // Gathered from all over, so a row carries its own sleeve
+                    // and says which record it came from.
+                    showsAlbum: true,
+                    allTrackIds: tracks.map(\.id)
+                )
+                .rowBehaviour(playable: .track(track))
+            }
+        }
+    }
+
+    // MARK: - Actions
+
+    /// Plays from the first of `ids`, keeping the rest of the list behind it.
+    private func play(_ ids: Set<Int64>) {
+        guard let index = tracks.firstIndex(where: { ids.contains($0.id) }) else { return }
+        player.playNow(trackIds: tracks.map(\.id), startingAt: index)
+        nav.showQueueWhenReady(watching: player)
+    }
+
+    @ViewBuilder
+    private func menu(for ids: Set<Int64>) -> some View {
+        let chosen = tracks.filter { ids.contains($0.id) }
+        if chosen.count == 1, let track = chosen.first {
+            PlayableMenu(playable: .track(track))
+        } else if !chosen.isEmpty {
+            Button("Play") {
+                player.playNow(trackIds: chosen.map(\.id))
+                nav.showQueueWhenReady(watching: player)
+            }
+            Button("Play Next") { player.playNext(trackIds: chosen.map(\.id)) }
+            Button("Add to Queue") { player.enqueue(trackIds: chosen.map(\.id)) }
+        }
+    }
+}

--- a/apps/macos/Sources/Koan/Views/RootView.swift
+++ b/apps/macos/Sources/Koan/Views/RootView.swift
@@ -335,14 +335,7 @@ private struct StageView: View {
         case .section(.artists):
             ArtistBrowser()
         case .section(.favourites):
-            TrackListView(
-                title: "Favourites",
-                subtitle: Format.count(Int64(library.favourites.count), "track"),
-                tracks: library.favourites,
-                // Gathered from the whole library, so a row's cover and album
-                // are what tell it from the one above it.
-                mixedAlbums: true
-            )
+            FavouritesView()
         case .section(.playHistory):
             HistoryView()
         case .section(.snapshots):

--- a/apps/macos/Sources/Koan/Views/TrackListView.swift
+++ b/apps/macos/Sources/Koan/Views/TrackListView.swift
@@ -52,7 +52,6 @@ struct TrackListView: View {
                         }
                     }
                     .listStyle(.inset)
-                    .clearsSelection($selection)
                     // Gives up its ground only where there is a wash to show:
                     // otherwise the List paints over it and the record's colour
                     // stops in a line under the header. Without a cover — a
@@ -182,7 +181,7 @@ struct TrackListView: View {
     }
 }
 
-private struct TrackRow: View {
+struct TrackRow: View {
     let track: Track
     let position: Int
     let isCurrent: Bool


### PR DESCRIPTION
Two things, and the bug is what led to the feature.

## The filter did nothing

`LibraryModel.refilter()` narrows favourites into `visibleFavourites`; `RootView` handed `TrackListView` the unfiltered `favourites`, so `visibleFavourites` was computed and never read. Every other filtered section — albums, artists, history — reads the right one, which is why this was the only page where typing in the field did nothing.

## Favourited records and artists had nowhere to live

The heart is on albums and artists too, and both toggles work and sync — but the page was a track list, so nothing in the app ever showed them back to you.

One page, three sections, the way search results already do it. A section only renders when there is something in it, so a tracks-only library looks exactly as it did before. The filter narrows all three.

- Artists are pills (`ArtistPill` + `FlowLayout`), albums are the grid (`AlbumGridCell`), tracks are the same `TrackRow` the other track lists use — no new row types.
- Still a `List`, not search's `ScrollView`: the tracks here are a working list, and range-select, Return-to-play and the menu on a selection all come from the List. The artist and album sections ride above them as `.selectionDisabled()` rows.
- No new FFI. The engine returns favourite *ids*; `prefetchCatalogue` already holds the album and artist rows in memory, so the sections are those filtered by the id sets — taken in the catalogue's order, because a `Set` has none and the grid would reshuffle on every toggle. Derived only while the favourites page is showing, since it walks the whole catalogue.
- `favouriteAlbumIds` / `favouriteArtistIds` gained `didSet { refilter() }`, so hearting a record updates the page under you.
- `TrackRow` is no longer `private` to `TrackListView`.

The header counts only the kinds you have — "4 artists · 6 albums · 132 tracks", or just "132 tracks".

## Confirming it

`just macos-build` is clean. Worth clicking: the filter field on Favourites (that is the bug); heart an album from its page and watch it appear here; select several tracks and hit Return.

**Not verified on screen** — your app is running from `/Applications` against `~/.config/koan/koan.db` and a second instance would have us both writing that file, so I did not launch one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L2QYGXTN6dYC7MX5KNY8a5