### PR TITLE
Every sync is a whole sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,8 @@ analysis_on_scan` (now `[library] analyze_on_scan`). The others were inert.
 
 ### Fixed
 
+- **Most of the ways koan syncs never touched playlists, and koan's own auto-sync never touched favourites either.** Four callers each knew separately what a sync consists of — the app, the CLI, the GraphQL job and the background auto-sync — so a star or a playlist made on the server arrived only if you happened to press the right button. There is one `sync_remote` now and all four go through it.
+
 - **The queue quietly dropped repeats.** Adding a track already in the queue added nothing, and a playlist holding the same song twice played it once. The batch fetch behind every queue add took each row out of its map as it matched it, so an id asked for twice came back once.
 
 - **koan wrote your whole configuration to the file you commit.** Every setting koan saved itself — a visualiser toggle, the output device, dragging the album art wider — reserialised the entire `Config` struct over `config.toml`. That erased the commented-out reference `koan config init` writes, and filled the file people are told to put in a dotfiles repo with all fifty-odd keys, including `[library] folders` set to koan's *default* music directory and a `[remote]` block belonging to one machine's account. Writes now go through `Config::persist`, which diffs the mutation and touches only the keys that actually changed.

--- a/crates/koan-cli/src/commands/remote.rs
+++ b/crates/koan-cli/src/commands/remote.rs
@@ -40,67 +40,55 @@ pub fn cmd_remote_sync(full: bool) {
     let db = open_db();
     let start = std::time::Instant::now();
 
-    match koan_core::remote::sync::sync_library(
+    let synced = match koan_core::helpers::sync_remote(
         &db,
         &client,
         full,
         &cfg.remote.url,
         &cfg.remote.username,
     ) {
-        Ok(result) => {
-            let elapsed = start.elapsed();
-            let headline = if result.is_complete() {
-                "sync complete".green().bold().to_string()
-            } else {
-                "sync incomplete".yellow().bold().to_string()
-            };
-            println!(
-                "{} {} {} artists, {} albums, {} tracks",
-                headline,
-                format!("({:.1}s)", elapsed.as_secs_f64()).dimmed(),
-                result.artists_synced.to_string().bold(),
-                result.albums_synced.to_string().bold(),
-                result.tracks_synced.to_string().bold(),
-            );
-            if !result.is_complete() {
-                eprintln!(
-                    "{} {} album(s) could not be fetched — the sync watermark was left \
-                     unchanged, so the next sync will retry them",
-                    "warning:".yellow().bold(),
-                    result.albums_failed.to_string().bold(),
-                );
-            }
-        }
+        Ok(synced) => synced,
         Err(e) => {
             eprintln!("{} {}", "sync failed:".red().bold(), e);
             std::process::exit(1);
         }
+    };
+
+    let library = &synced.library;
+    let elapsed = start.elapsed();
+    let headline = if library.is_complete() {
+        "sync complete".green().bold().to_string()
+    } else {
+        "sync incomplete".yellow().bold().to_string()
+    };
+    println!(
+        "{} {} {} artists, {} albums, {} tracks",
+        headline,
+        format!("({:.1}s)", elapsed.as_secs_f64()).dimmed(),
+        library.artists_synced.to_string().bold(),
+        library.albums_synced.to_string().bold(),
+        library.tracks_synced.to_string().bold(),
+    );
+    if !library.is_complete() {
+        eprintln!(
+            "{} {} album(s) could not be fetched — the sync watermark was left \
+             unchanged, so the next sync will retry them",
+            "warning:".yellow().bold(),
+            library.albums_failed.to_string().bold(),
+        );
     }
 
-    // Sync favourites: push local → remote, pull remote → local.
-    print!("{}", "syncing favourites...".dimmed());
-    use std::io::Write;
-    std::io::stdout().flush().ok();
-
-    let synced = koan_core::helpers::reconcile_favourites(&db, &client);
-
     println!(
-        "\r{} {} pushed, {} imported",
+        "{} {} pushed, {} imported",
         "favourites synced:".green().bold(),
-        synced.pushed.to_string().bold(),
-        synced.imported.to_string().bold(),
+        synced.favourites.pushed.to_string().bold(),
+        synced.favourites.imported.to_string().bold(),
     );
-
-    print!("{}", "syncing playlists...".dimmed());
-    std::io::stdout().flush().ok();
-
-    let playlists = koan_core::playlists::reconcile_playlists(&db, &client, &cfg.remote.username);
-
     println!(
-        "\r{} {} pulled, {} pushed",
+        "{} {} pulled, {} pushed",
         "playlists synced:".green().bold(),
-        playlists.pulled.to_string().bold(),
-        playlists.pushed.to_string().bold(),
+        synced.playlists.pulled.to_string().bold(),
+        synced.playlists.pushed.to_string().bold(),
     );
 }
 

--- a/crates/koan-core/src/helpers.rs
+++ b/crates/koan-core/src/helpers.rs
@@ -180,19 +180,18 @@ pub fn spawn_auto_sync(
                     && let Ok(db) = Database::open(&db_path)
                 {
                     on_state(true);
-                    match crate::remote::sync::sync_library(
-                        &db,
-                        &client,
-                        false,
-                        &cfg.remote.url,
-                        &cfg.remote.username,
-                    ) {
-                        Ok(r) => log::info!(
-                            "auto sync: {} artists, {} albums, {} tracks ({} albums failed)",
-                            r.artists_synced,
-                            r.albums_synced,
-                            r.tracks_synced,
-                            r.albums_failed
+                    match sync_remote(&db, &client, false, &cfg.remote.url, &cfg.remote.username) {
+                        Ok(s) => log::info!(
+                            "auto sync: {} artists, {} albums, {} tracks ({} albums failed); \
+                             favourites {}↑ {}↓; playlists {}↓ {}↑",
+                            s.library.artists_synced,
+                            s.library.albums_synced,
+                            s.library.tracks_synced,
+                            s.library.albums_failed,
+                            s.favourites.pushed,
+                            s.favourites.imported,
+                            s.playlists.pulled,
+                            s.playlists.pushed,
                         ),
                         Err(e) => log::warn!("auto sync failed: {e}"),
                     }
@@ -475,6 +474,39 @@ pub fn sync_favourite_to_remote(db: &Database, path: &Path, star: bool) {
             }
         })
         .ok();
+}
+
+/// Everything a sync is.
+#[derive(Debug, Default)]
+pub struct FullSync {
+    pub library: crate::remote::sync::SyncResult,
+    pub favourites: FavouriteSync,
+    pub playlists: crate::playlists::PlaylistSync,
+}
+
+/// Pull the library, then reconcile favourites and playlists.
+///
+/// One function because there are four callers — the app, the CLI, the GraphQL
+/// job and koan's own auto-sync — and they had each been told separately what a
+/// sync consists of. Two of them never heard about playlists, and the auto-sync
+/// had never heard about favourites either, so a star made on the server only
+/// arrived if you happened to press the button yourself.
+///
+/// The library comes first: favourites and playlists both name tracks by the
+/// server's ids, and neither can find a track the library has not seen yet.
+pub fn sync_remote(
+    db: &Database,
+    client: &SubsonicClient,
+    full: bool,
+    url: &str,
+    username: &str,
+) -> Result<FullSync, crate::remote::sync::SyncError> {
+    let library = crate::remote::sync::sync_library(db, client, full, url, username)?;
+    Ok(FullSync {
+        library,
+        favourites: reconcile_favourites(db, client),
+        playlists: crate::playlists::reconcile_playlists(db, client, username),
+    })
 }
 
 /// What a favourites reconciliation did.

--- a/crates/koan-ffi/src/lib.rs
+++ b/crates/koan-ffi/src/lib.rs
@@ -1677,7 +1677,7 @@ impl KoanEngine {
                 }
             })?;
 
-            let result = koan_core::remote::sync::sync_library(
+            let synced = koan_core::helpers::sync_remote(
                 &db,
                 &client,
                 full,
@@ -1688,22 +1688,15 @@ impl KoanEngine {
                 message: e.to_string(),
             })?;
 
-            // Favourites are part of a sync, not a separate errand. Without this
-            // a star made on the server — or on another machine — never reaches
-            // the app, and one made here only leaves if you happen to run the CLI.
-            let favourites = koan_core::helpers::reconcile_favourites(&db, &client);
-            let playlists =
-                koan_core::playlists::reconcile_playlists(&db, &client, &cfg.remote.username);
-
             Ok(SyncSummary {
-                artists: result.artists_synced as u32,
-                albums: result.albums_synced as u32,
-                tracks: result.tracks_synced as u32,
-                albums_failed: result.albums_failed as u32,
-                favourites_pushed: favourites.pushed as u32,
-                favourites_imported: favourites.imported as u32,
-                playlists_pulled: playlists.pulled as u32,
-                playlists_pushed: playlists.pushed as u32,
+                artists: synced.library.artists_synced as u32,
+                albums: synced.library.albums_synced as u32,
+                tracks: synced.library.tracks_synced as u32,
+                albums_failed: synced.library.albums_failed as u32,
+                favourites_pushed: synced.favourites.pushed as u32,
+                favourites_imported: synced.favourites.imported as u32,
+                playlists_pulled: synced.playlists.pulled as u32,
+                playlists_pushed: synced.playlists.pushed as u32,
             })
         })
         .await

--- a/crates/koan-server/src/graphql/mutations.rs
+++ b/crates/koan-server/src/graphql/mutations.rs
@@ -740,7 +740,7 @@ impl MutationRoot {
             let cfg = Config::load().unwrap_or_default();
             let client = koan_core::helpers::subsonic_client(&cfg)
                 .ok_or_else(|| "remote not configured".to_string())?;
-            let result = koan_core::remote::sync::sync_library(
+            let synced = koan_core::helpers::sync_remote(
                 &db,
                 &client,
                 false,
@@ -748,12 +748,12 @@ impl MutationRoot {
                 &cfg.remote.username,
             )
             .map_err(|e| e.to_string())?;
-            if result.is_complete() {
+            if synced.library.is_complete() {
                 Ok("remote sync complete".to_string())
             } else {
                 Ok(format!(
                     "remote sync incomplete: {} album(s) failed and will be retried next sync",
-                    result.albums_failed
+                    synced.library.albums_failed
                 ))
             }
         })


### PR DESCRIPTION
Playlists arrived in #325 with reconciliation wired into two of the four places koan syncs from. The other two — the GraphQL job and koan's own background auto-sync — only ever pulled the library, and the auto-sync had never reconciled favourites either.

So a star made on the server, or a playlist made on another machine, reached you only if you happened to press the right button. The auto-sync is the one that runs on its own, on startup and on a timer, which makes it the one most people were actually relying on.

## What it does

One `helpers::sync_remote` does the library, then favourites, then playlists. All four callers go through it: the macOS app via the FFI, `koan remote sync`, `triggerRemoteSync`, and `spawn_auto_sync`.

The order is load-bearing and commented as such — favourites and playlists both name tracks by the server's ids, and neither can find a track the library has not seen yet.

The CLI reports all three counts instead of running its own three-step version, and the auto-sync logs what it reconciled rather than only what it fetched.

## Confirming it

`just check` — clippy clean, tests green. The change is a refactor of four call sites onto one function, so the interesting check is that nothing calls `sync_library` directly any more except `sync_remote` itself:

```
rg 'sync::sync_library' crates/
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NEKKssPrgcGR1qJo49KnKG
