### PR TITLE
The queue stays locked to the playlist that filled it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,13 @@ analysis_on_scan` (now `[library] analyze_on_scan`). The others were inert.
 
 ### Changed
 
+- **The queue stays locked to the playlist that filled it.** Play a playlist and the queue *is* that playlist; reorder it, remove from it or add to it and the queue follows, quietly. Rearrange the queue yourself, add to it, or let radio extend it and the two part company — from then on the playlist is a document you are editing and the queue is what you are listening to.
+
+  Locked is derived rather than tracked: queue items carry the playlist row they came from, so the queue is locked exactly when its entries are that playlist's, in that order. Nothing to keep in sync, nothing to persist, and it cannot get stuck — a queue that stops matching stops being locked, and one that matches again is locked again. Playing a playlist shuffled scrambles the order on purpose, so that queue is not locked, which is the right answer rather than a special case.
+
+  The queue says so: while it is locked it is headed **Playing *<playlist>***, with the playlist's mosaic beside it, and goes back to plain **Queue** the moment it is not. A rule this quiet has to be visible, or the first silent update reads as koan moving things on its own.
+
+
 - **The shortcuts sheet says what the menus say.** It listed the single-key shortcuts and then told you the rest were "in the menus", which is true and no help — nobody opens six menus to find out that Back is ⌘[. The ⌘ shortcuts are now a second table on the same sheet, and both halves are generated from the same declarations the menu bar is built from, so they cannot drift.
 
 - **Leaving the queue and coming back keeps your place.** The stage is one `switch`, so every move destroys the page it left and takes its scroll position with it. The queue remembers where it was.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,9 @@ analysis_on_scan` (now `[library] analyze_on_scan`). The others were inert.
 
   Locked is derived rather than tracked: queue items carry the playlist row they came from, so the queue is locked exactly when its entries are that playlist's, in that order. Nothing to keep in sync, nothing to persist, and it cannot get stuck — a queue that stops matching stops being locked, and one that matches again is locked again. Playing a playlist shuffled scrambles the order on purpose, so that queue is not locked, which is the right answer rather than a special case.
 
-  The queue says so: while it is locked it is headed **Playing *<playlist>***, with the playlist's mosaic beside it, and goes back to plain **Queue** the moment it is not. A rule this quiet has to be visible, or the first silent update reads as koan moving things on its own.
+  Records lock too, and need no provenance to do it: an album *is* an ordered set of tracks, so the queue being that album is a question about what the queue holds — which means it still answers for a queue restored from a previous session, where nothing remembers what was played. A record cannot be edited, so there is nothing to follow; it just says what you are listening to.
+
+  The queue says so: while it is locked it is headed **Playing *<name>***, with the playlist's mosaic or the record's sleeve beside it, and goes back to plain **Queue** the moment it is not. A rule this quiet has to be visible, or the first silent update reads as koan moving things on its own.
 
 
 - **The shortcuts sheet says what the menus say.** It listed the single-key shortcuts and then told you the rest were "in the menus", which is true and no help — nobody opens six menus to find out that Back is ⌘[. The ⌘ shortcuts are now a second table on the same sheet, and both halves are generated from the same declarations the menu bar is built from, so they cannot drift.

--- a/apps/macos/Sources/Koan/KoanApp.swift
+++ b/apps/macos/Sources/Koan/KoanApp.swift
@@ -131,6 +131,13 @@ struct KoanApp: App {
                     created.player.restoreSession()
                     created.library.loadInitial()
                     created.playlists.load()
+                    created.playlists.refreshLock()
+                    // The queue changing is the other half of what makes a lock
+                    // — playing a playlist creates one, touching the queue ends
+                    // one, and neither goes through the playlist model.
+                    created.player.onQueueChanged = { [weak created] in
+                        created?.playlists.refreshLock()
+                    }
                     state = created
                 } catch {
                     startupError = String(describing: error)

--- a/apps/macos/Sources/Koan/Support/PlayerModel.swift
+++ b/apps/macos/Sources/Koan/Support/PlayerModel.swift
@@ -135,6 +135,12 @@ final class PlayerModel {
 
     private func rebuildQueue() async {
         queue = await engine.queue()
+        // Here rather than at one of the callers: the queue is rebuilt from
+        // two places — a queue event, and a playback event carrying a version
+        // that moved — and only one of them used to say so. Which of the two
+        // arrived last decided whether anything watching the queue heard about
+        // it, so a playlist would light up as locked sometimes and not others.
+        defer { onQueueChanged?() }
         queuedByTrack = Dictionary(
             queue.compactMap { item in item.trackId.map { ($0, item) } },
             // A track queued twice: prefer the entry that is actually doing
@@ -193,7 +199,6 @@ final class PlayerModel {
     fileprivate func applyQueueChange() async {
         await rebuildQueue()
         await tick()
-        onQueueChanged?()
     }
 
     /// Position moved. The only genuinely periodic event, and the only thing

--- a/apps/macos/Sources/Koan/Support/PlayerModel.swift
+++ b/apps/macos/Sources/Koan/Support/PlayerModel.swift
@@ -180,6 +180,11 @@ final class PlayerModel {
         downloading = active
     }
 
+    /// The queue changed. Set by `AppState` — whether the queue is still
+    /// exactly some playlist is a question only the engine can answer, and this
+    /// is the moment the answer can have changed.
+    var onQueueChanged: (() -> Void)?
+
     /// A download finished. Set by `AppState` — the library's cached count is
     /// the only thing that knows it moved, and it has no other way to find out.
     var onDownloadsLanded: (() -> Void)?
@@ -188,6 +193,7 @@ final class PlayerModel {
     fileprivate func applyQueueChange() async {
         await rebuildQueue()
         await tick()
+        onQueueChanged?()
     }
 
     /// Position moved. The only genuinely periodic event, and the only thing

--- a/apps/macos/Sources/Koan/Support/PlaylistsModel.swift
+++ b/apps/macos/Sources/Koan/Support/PlaylistsModel.swift
@@ -37,14 +37,17 @@ final class PlaylistsModel {
     /// had the first time it was drawn — for a new playlist, nothing at all.
     private var coverStamp: [Int64: String] = [:]
 
-    /// The playlist the queue is still exactly, if it is one.
+    /// What the queue is still exactly, if it is still something.
     ///
-    /// While this is set, the queue *follows* that playlist: an edit there is
-    /// an edit to what you are listening to. It clears the moment the queue is
-    /// rearranged, added to, or extended by radio — and the header says so
-    /// either way, because a rule this quiet has to be visible or the first
-    /// silent update reads as the app moving things on its own.
-    private(set) var lockedTo: Playlist?
+    /// While this names a playlist, the queue *follows* it: an edit there is an
+    /// edit to what you are listening to. A record cannot be edited, so locking
+    /// to one only says what you are listening to — which is worth saying.
+    ///
+    /// It clears the moment the queue is rearranged, added to, or extended by
+    /// radio, and the header says so either way: a rule this quiet has to be
+    /// visible, or the first silent update reads as the app moving things on
+    /// its own.
+    private(set) var lockedTo: QueueLock?
 
     /// Ask the engine what the queue is. Cheap — two indexed reads — and only
     /// worth doing when the queue or a playlist has actually moved.

--- a/apps/macos/Sources/Koan/Support/PlaylistsModel.swift
+++ b/apps/macos/Sources/Koan/Support/PlaylistsModel.swift
@@ -37,6 +37,22 @@ final class PlaylistsModel {
     /// had the first time it was drawn — for a new playlist, nothing at all.
     private var coverStamp: [Int64: String] = [:]
 
+    /// The playlist the queue is still exactly, if it is one.
+    ///
+    /// While this is set, the queue *follows* that playlist: an edit there is
+    /// an edit to what you are listening to. It clears the moment the queue is
+    /// rearranged, added to, or extended by radio — and the header says so
+    /// either way, because a rule this quiet has to be visible or the first
+    /// silent update reads as the app moving things on its own.
+    private(set) var lockedTo: Playlist?
+
+    /// Ask the engine what the queue is. Cheap — two indexed reads — and only
+    /// worth doing when the queue or a playlist has actually moved.
+    func refreshLock() {
+        let engine = self.engine
+        Task { lockedTo = (try? await engine.queueLock()) ?? nil }
+    }
+
     /// Tracks waiting for a name, and the new playlist they will become.
     ///
     /// A request rather than a dialog, because the dialog cannot live where it
@@ -272,6 +288,7 @@ final class PlaylistsModel {
                 report?(String(describing: error))
             }
             load()
+            refreshLock()
             if reloadingTracks { reloadTracks() }
         }
     }

--- a/apps/macos/Sources/Koan/Views/QueueView.swift
+++ b/apps/macos/Sources/Koan/Views/QueueView.swift
@@ -125,9 +125,29 @@ struct QueueView: View {
 
     private var header: some View {
         HStack(spacing: 12) {
+            // What the queue *is*, when it is still something. A queue that
+            // came from a playlist and has not been touched since follows that
+            // playlist, and saying so is what makes the following legible: you
+            // can see why an edit over there moved something here, and you can
+            // see the moment it stops.
+            if let locked = playlists.lockedTo {
+                PlaylistArtwork(
+                    sources: playlists.covers[locked.id] ?? [],
+                    cornerRadius: 4
+                )
+                .frame(width: 34, height: 34)
+                .shadow(color: .black.opacity(0.25), radius: 3, y: 1)
+            }
+
             VStack(alignment: .leading, spacing: 1) {
-                Text("Queue")
-                    .font(.headline)
+                if let locked = playlists.lockedTo {
+                    Text("Playing \(locked.name)")
+                        .font(.headline)
+                        .lineLimit(1)
+                } else {
+                    Text("Queue")
+                        .font(.headline)
+                }
                 Text(summary)
                     .font(.caption)
                     .foregroundStyle(.secondary)

--- a/apps/macos/Sources/Koan/Views/QueueView.swift
+++ b/apps/macos/Sources/Koan/Views/QueueView.swift
@@ -130,18 +130,25 @@ struct QueueView: View {
             // playlist, and saying so is what makes the following legible: you
             // can see why an edit over there moved something here, and you can
             // see the moment it stops.
-            if let locked = playlists.lockedTo {
+            switch playlists.lockedTo {
+            case .playlist(let playlist):
                 PlaylistArtwork(
-                    sources: playlists.covers[locked.id] ?? [],
+                    sources: playlists.covers[playlist.id] ?? [],
                     cornerRadius: 4
                 )
                 .frame(width: 34, height: 34)
                 .shadow(color: .black.opacity(0.25), radius: 3, y: 1)
+            case .album(let album):
+                AlbumArtwork(source: .album(album.id), size: .thumb, cornerRadius: 4)
+                    .frame(width: 34, height: 34)
+                    .shadow(color: .black.opacity(0.25), radius: 3, y: 1)
+            case nil:
+                EmptyView()
             }
 
             VStack(alignment: .leading, spacing: 1) {
-                if let locked = playlists.lockedTo {
-                    Text("Playing \(locked.name)")
+                if let name = lockedName {
+                    Text("Playing \(name)")
                         .font(.headline)
                         .lineLimit(1)
                 } else {
@@ -201,6 +208,15 @@ struct QueueView: View {
         .buttonStyle(.borderless)
         .padding(.horizontal, 16)
         .padding(.vertical, 11)
+    }
+
+    /// What the queue is, when it is still something someone chose.
+    private var lockedName: String? {
+        switch playlists.lockedTo {
+        case .playlist(let playlist): playlist.name
+        case .album(let album): album.title
+        case nil: nil
+        }
     }
 
     private var summary: String {

--- a/crates/koan-core/src/db/queries/playlists.rs
+++ b/crates/koan-core/src/db/queries/playlists.rs
@@ -224,6 +224,29 @@ pub fn playlist_entries(conn: &Connection, id: i64) -> Result<Vec<PlaylistEntry>
     Ok(rows)
 }
 
+/// The entry ids of this playlist, in order. The cheap half of
+/// [`playlist_entries`], for the times only identity and order matter.
+pub fn playlist_entry_ids(conn: &Connection, id: i64) -> Result<Vec<i64>, DbError> {
+    let mut stmt =
+        conn.prepare("SELECT id FROM playlist_tracks WHERE playlist_id = ?1 ORDER BY position")?;
+    let rows = stmt
+        .query_map(params![id], |row| row.get(0))?
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(rows)
+}
+
+/// Which playlist an entry belongs to.
+pub fn playlist_of_entry(conn: &Connection, entry_id: i64) -> Result<Option<i64>, DbError> {
+    let found = conn
+        .query_row(
+            "SELECT playlist_id FROM playlist_tracks WHERE id = ?1",
+            params![entry_id],
+            |row| row.get(0),
+        )
+        .ok();
+    Ok(found)
+}
+
 /// The track ids in this playlist, in order. Duplicates kept.
 pub fn playlist_track_ids(conn: &Connection, id: i64) -> Result<Vec<i64>, DbError> {
     let mut stmt = conn

--- a/crates/koan-core/src/player/commands.rs
+++ b/crates/koan-core/src/player/commands.rs
@@ -30,6 +30,13 @@ pub enum PlayerCommand {
         target: QueueItemId,
         after: bool,
     },
+    /// Put the queue in exactly this order, keeping every item.
+    ///
+    /// A queue locked to a playlist follows it, and following a reorder means
+    /// moving the items that are already there — rebuilding them would issue
+    /// new ids and throw away what has played, what is mid-download and where
+    /// the cursor is. Ids not named keep their relative order at the end.
+    ReorderPlaylist(Vec<QueueItemId>),
     /// Update file paths for playlist items after an organize operation.
     /// On Unix, rename() doesn't invalidate open FDs so playback continues.
     UpdatePaths(Vec<(QueueItemId, PathBuf)>),

--- a/crates/koan-core/src/player/mod.rs
+++ b/crates/koan-core/src/player/mod.rs
@@ -1231,6 +1231,14 @@ impl Player {
                 self.shared_state.move_items(&ids, target, after);
                 self.push_undo(UndoEntry::MovedBatch { entries });
             }
+            PlayerCommand::ReorderPlaylist(order) => {
+                // Undoable like any other move: undoing it puts the queue back
+                // and, by doing so, ends the lock — which is the honest result
+                // of having rearranged the queue by hand.
+                let entries = self.shared_state.items_before(&order);
+                self.shared_state.reorder_to(&order);
+                self.push_undo(UndoEntry::MovedBatch { entries });
+            }
             PlayerCommand::TrackReady(id) => self.track_ready(id),
             PlayerCommand::DecodeFinished => self.on_decode_finished(),
             PlayerCommand::TrackStreamReady(id) => self.track_stream_ready(id),

--- a/crates/koan-core/src/player/state.rs
+++ b/crates/koan-core/src/player/state.rs
@@ -732,6 +732,31 @@ impl SharedPlayerState {
     /// Undo replays these left to right, so an item whose recorded predecessor is
     /// also in `ids` must come after it — otherwise the predecessor is missing at
     /// replay time and the item lands at the end of the playlist instead.
+    /// Put the items in exactly this order.
+    ///
+    /// Items not named keep their relative order and follow at the end, so a
+    /// stale order cannot lose anything. The items themselves are moved, not
+    /// rebuilt: their ids, load states and download progress are what the rest
+    /// of the player is holding on to.
+    pub fn reorder_to(&self, order: &[QueueItemId]) {
+        let mut pl = self.playlist.write();
+        let mut taken: Vec<Option<PlaylistItem>> = pl.items.drain(..).map(Some).collect();
+        let mut sorted = Vec::with_capacity(taken.len());
+        for id in order {
+            if let Some(slot) = taken
+                .iter_mut()
+                .find(|i| i.as_ref().is_some_and(|i| i.id == *id))
+                && let Some(item) = slot.take()
+            {
+                sorted.push(item);
+            }
+        }
+        sorted.extend(taken.into_iter().flatten());
+        pl.items = sorted;
+        drop(pl);
+        self.bump_version();
+    }
+
     pub fn items_before(&self, ids: &[QueueItemId]) -> Vec<(QueueItemId, Option<QueueItemId>)> {
         use std::collections::HashSet;
         let wanted: HashSet<QueueItemId> = ids.iter().copied().collect();

--- a/crates/koan-core/src/playlists.rs
+++ b/crates/koan-core/src/playlists.rs
@@ -11,7 +11,37 @@ use crate::config::Config;
 use crate::db::connection::Database;
 use crate::db::queries;
 use crate::helpers::subsonic_client;
+use crate::player::state::SharedPlayerState;
 use crate::remote::client::SubsonicClient;
+
+/// The queue, and the playlist it is still exactly.
+///
+/// While the two match, the queue *follows* the playlist: an edit there is an
+/// edit here, quietly. The moment you rearrange the queue yourself, add to it,
+/// or let radio extend it, they stop matching and the playlist becomes a
+/// document you are editing rather than the thing you are listening to.
+///
+/// Derived rather than tracked, which is the whole reason it is simple. There
+/// is no flag to keep in sync, nothing to persist and nothing to migrate — and
+/// it cannot get stuck, because a queue that stops matching stops being locked
+/// and one that happens to match again is locked again. Playing a playlist
+/// shuffled scrambles the order on purpose, so that queue is not locked, which
+/// is the right answer rather than a special case.
+pub fn queue_lock(db: &Database, state: &SharedPlayerState) -> Option<i64> {
+    let (items, _) = state.snapshot_playlist();
+    if items.is_empty() {
+        return None;
+    }
+    // Every item has to have come from the same playlist. One that did not —
+    // played next, dropped in, found by radio — is the queue having diverged.
+    let entry_ids: Vec<i64> = items.iter().filter_map(|i| i.playlist_entry_id).collect();
+    if entry_ids.len() != items.len() {
+        return None;
+    }
+    let playlist_id = queries::playlist_of_entry(&db.conn, entry_ids[0]).ok()??;
+    let playlist = queries::playlist_entry_ids(&db.conn, playlist_id).ok()?;
+    (playlist == entry_ids).then_some(playlist_id)
+}
 
 /// What a reconciliation did.
 #[derive(Debug, Default, Clone, Copy)]
@@ -374,6 +404,107 @@ mod tests {
             mbid: None,
             album_added_at: None,
         }
+    }
+
+    /// The queue is locked while it is still exactly the playlist, and stops
+    /// being the moment it is not. Everything else about following follows from
+    /// this one answer.
+    #[test]
+    fn a_queue_is_locked_only_while_it_is_still_the_playlist() {
+        use crate::player::state::{LoadState, PlaylistItem, QueueItemId, SharedPlayerState};
+
+        let dir = tempfile::tempdir().unwrap();
+        let db = Database::open(&dir.path().join("koan.db")).unwrap();
+        let a = upsert_track(&db.conn, &meta("A", &dir.path().join("a.flac"))).unwrap();
+        let b = upsert_track(&db.conn, &meta("B", &dir.path().join("b.flac"))).unwrap();
+
+        let id = queries::create_playlist(&db.conn, "Evening", None).unwrap();
+        let entries = queries::add_tracks(&db.conn, id, &[a, b]).unwrap();
+
+        let state = SharedPlayerState::new();
+        let queued = |entry: Option<i64>| PlaylistItem {
+            id: QueueItemId::new(),
+            db_id: Some(a),
+            playlist_entry_id: entry,
+            path: dir.path().join("a.flac"),
+            title: "A".into(),
+            artist: "Artist".into(),
+            album_artist: "Artist".into(),
+            album: "Album".into(),
+            year: None,
+            codec: None,
+            track_number: None,
+            disc: None,
+            duration_ms: None,
+            load_state: LoadState::Ready,
+        };
+
+        assert_eq!(
+            queue_lock(&db, &state),
+            None,
+            "an empty queue is not locked"
+        );
+
+        state.add_items(vec![queued(Some(entries[0])), queued(Some(entries[1]))]);
+        assert_eq!(
+            queue_lock(&db, &state),
+            Some(id),
+            "the queue is the playlist"
+        );
+
+        // Something that never came from the playlist — played next, dropped
+        // in, found by radio.
+        state.add_items(vec![queued(None)]);
+        assert_eq!(queue_lock(&db, &state), None);
+    }
+
+    /// Reordering the queue by hand ends the lock, which is the whole point of
+    /// deriving it: there is no flag anyone has to remember to clear.
+    #[test]
+    fn rearranging_the_queue_ends_the_lock() {
+        use crate::player::state::{LoadState, PlaylistItem, QueueItemId, SharedPlayerState};
+
+        let dir = tempfile::tempdir().unwrap();
+        let db = Database::open(&dir.path().join("koan.db")).unwrap();
+        let a = upsert_track(&db.conn, &meta("A", &dir.path().join("a.flac"))).unwrap();
+        let b = upsert_track(&db.conn, &meta("B", &dir.path().join("b.flac"))).unwrap();
+        let id = queries::create_playlist(&db.conn, "Evening", None).unwrap();
+        let entries = queries::add_tracks(&db.conn, id, &[a, b]).unwrap();
+
+        let state = SharedPlayerState::new();
+        let items: Vec<PlaylistItem> = entries
+            .iter()
+            .map(|entry| PlaylistItem {
+                id: QueueItemId::new(),
+                db_id: Some(a),
+                playlist_entry_id: Some(*entry),
+                path: dir.path().join("a.flac"),
+                title: "A".into(),
+                artist: "Artist".into(),
+                album_artist: "Artist".into(),
+                album: "Album".into(),
+                year: None,
+                codec: None,
+                track_number: None,
+                disc: None,
+                duration_ms: None,
+                load_state: LoadState::Ready,
+            })
+            .collect();
+        let ids: Vec<QueueItemId> = items.iter().map(|i| i.id).collect();
+        state.add_items(items);
+        assert_eq!(queue_lock(&db, &state), Some(id));
+
+        state.reorder_to(&[ids[1], ids[0]]);
+        assert_eq!(
+            queue_lock(&db, &state),
+            None,
+            "same tracks, different order — no longer the playlist"
+        );
+
+        // And the playlist catching up locks it again. Nothing had to be reset.
+        queries::reorder_entries(&db.conn, id, &[entries[1], entries[0]]).unwrap();
+        assert_eq!(queue_lock(&db, &state), Some(id));
     }
 
     #[test]

--- a/crates/koan-core/src/playlists.rs
+++ b/crates/koan-core/src/playlists.rs
@@ -14,12 +14,15 @@ use crate::helpers::subsonic_client;
 use crate::player::state::SharedPlayerState;
 use crate::remote::client::SubsonicClient;
 
-/// The queue, and the playlist it is still exactly.
+/// The queue, and the playlist or record it is still exactly.
 ///
-/// While the two match, the queue *follows* the playlist: an edit there is an
+/// While the two match, the queue *follows* a playlist: an edit there is an
 /// edit here, quietly. The moment you rearrange the queue yourself, add to it,
 /// or let radio extend it, they stop matching and the playlist becomes a
 /// document you are editing rather than the thing you are listening to.
+///
+/// A record cannot be edited, so locking to one buys no following — only the
+/// ability to say what you are listening to, which is worth saying.
 ///
 /// Derived rather than tracked, which is the whole reason it is simple. There
 /// is no flag to keep in sync, nothing to persist and nothing to migrate — and
@@ -27,20 +30,47 @@ use crate::remote::client::SubsonicClient;
 /// and one that happens to match again is locked again. Playing a playlist
 /// shuffled scrambles the order on purpose, so that queue is not locked, which
 /// is the right answer rather than a special case.
-pub fn queue_lock(db: &Database, state: &SharedPlayerState) -> Option<i64> {
+pub fn queue_lock(db: &Database, state: &SharedPlayerState) -> Option<QueueLock> {
     let (items, _) = state.snapshot_playlist();
     if items.is_empty() {
         return None;
     }
+
     // Every item has to have come from the same playlist. One that did not —
     // played next, dropped in, found by radio — is the queue having diverged.
     let entry_ids: Vec<i64> = items.iter().filter_map(|i| i.playlist_entry_id).collect();
-    if entry_ids.len() != items.len() {
+    if entry_ids.len() == items.len()
+        && let Ok(Some(playlist_id)) = queries::playlist_of_entry(&db.conn, entry_ids[0])
+        && queries::playlist_entry_ids(&db.conn, playlist_id).is_ok_and(|ids| ids == entry_ids)
+    {
+        return Some(QueueLock::Playlist(playlist_id));
+    }
+
+    // A record needs no provenance of its own: an album *is* an ordered set of
+    // tracks in the library, so the queue being that album is a question about
+    // the tracks it holds. Which means this works for a queue restored from a
+    // previous session, where nothing remembers where it came from.
+    let track_ids: Vec<i64> = items.iter().filter_map(|i| i.db_id).collect();
+    if track_ids.len() != items.len() {
         return None;
     }
-    let playlist_id = queries::playlist_of_entry(&db.conn, entry_ids[0]).ok()??;
-    let playlist = queries::playlist_entry_ids(&db.conn, playlist_id).ok()?;
-    (playlist == entry_ids).then_some(playlist_id)
+    let album_id = queries::get_track_row(&db.conn, track_ids[0])
+        .ok()
+        .flatten()?
+        .album_id?;
+    let album: Vec<i64> = queries::tracks_for_album(&db.conn, album_id)
+        .ok()?
+        .into_iter()
+        .map(|t| t.id)
+        .collect();
+    (album == track_ids).then_some(QueueLock::Album(album_id))
+}
+
+/// What the queue still is, when it is still something.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QueueLock {
+    Playlist(i64),
+    Album(i64),
 }
 
 /// What a reconciliation did.
@@ -448,7 +478,7 @@ mod tests {
         state.add_items(vec![queued(Some(entries[0])), queued(Some(entries[1]))]);
         assert_eq!(
             queue_lock(&db, &state),
-            Some(id),
+            Some(QueueLock::Playlist(id)),
             "the queue is the playlist"
         );
 
@@ -493,7 +523,7 @@ mod tests {
             .collect();
         let ids: Vec<QueueItemId> = items.iter().map(|i| i.id).collect();
         state.add_items(items);
-        assert_eq!(queue_lock(&db, &state), Some(id));
+        assert_eq!(queue_lock(&db, &state), Some(QueueLock::Playlist(id)));
 
         state.reorder_to(&[ids[1], ids[0]]);
         assert_eq!(
@@ -504,7 +534,53 @@ mod tests {
 
         // And the playlist catching up locks it again. Nothing had to be reset.
         queries::reorder_entries(&db.conn, id, &[entries[1], entries[0]]).unwrap();
-        assert_eq!(queue_lock(&db, &state), Some(id));
+        assert_eq!(queue_lock(&db, &state), Some(QueueLock::Playlist(id)));
+    }
+
+    /// A record needs no provenance: it *is* an ordered set of tracks, so the
+    /// queue being that record is a question about what the queue holds. Which
+    /// is why it survives a relaunch, where nothing remembers what was played.
+    #[test]
+    fn a_queue_holding_exactly_one_record_is_locked_to_it() {
+        use crate::player::state::{LoadState, PlaylistItem, QueueItemId, SharedPlayerState};
+
+        let dir = tempfile::tempdir().unwrap();
+        let db = Database::open(&dir.path().join("koan.db")).unwrap();
+        let a = upsert_track(&db.conn, &meta("A", &dir.path().join("a.flac"))).unwrap();
+        let b = upsert_track(&db.conn, &meta("B", &dir.path().join("b.flac"))).unwrap();
+        let album_id = queries::get_track_row(&db.conn, a)
+            .unwrap()
+            .unwrap()
+            .album_id
+            .unwrap();
+
+        let state = SharedPlayerState::new();
+        let queued = |track: i64| PlaylistItem {
+            id: QueueItemId::new(),
+            db_id: Some(track),
+            playlist_entry_id: None,
+            path: dir.path().join("a.flac"),
+            title: "A".into(),
+            artist: "Artist".into(),
+            album_artist: "Artist".into(),
+            album: "Album".into(),
+            year: None,
+            codec: None,
+            track_number: None,
+            disc: None,
+            duration_ms: None,
+            load_state: LoadState::Ready,
+        };
+
+        state.add_items(vec![queued(a)]);
+        assert_eq!(
+            queue_lock(&db, &state),
+            None,
+            "half a record is not the record"
+        );
+
+        state.add_items(vec![queued(b)]);
+        assert_eq!(queue_lock(&db, &state), Some(QueueLock::Album(album_id)));
     }
 
     #[test]

--- a/crates/koan-ffi/src/lib.rs
+++ b/crates/koan-ffi/src/lib.rs
@@ -1037,15 +1037,26 @@ impl KoanEngine {
     /// While this answers, the queue follows that playlist: an edit there lands
     /// here too. It stops answering the moment the queue is rearranged, added
     /// to, or extended by radio — which is also when the following stops.
-    pub async fn queue_lock(self: Arc<Self>) -> Result<Option<Playlist>, KoanError> {
+    pub async fn queue_lock(self: Arc<Self>) -> Result<Option<QueueLock>, KoanError> {
         offload::offload(move || {
             let db = self.db()?;
-            let Some(id) = koan_core::playlists::queue_lock(&db, &self.state) else {
-                return Ok(None);
-            };
-            Ok(queries::get_playlist(&db.conn, id)
-                .map_err(db_err)?
-                .map(Playlist::from))
+            Ok(match koan_core::playlists::queue_lock(&db, &self.state) {
+                Some(koan_core::playlists::QueueLock::Playlist(id)) => {
+                    queries::get_playlist(&db.conn, id)
+                        .map_err(db_err)?
+                        .map(|p| QueueLock::Playlist {
+                            playlist: Playlist::from(p),
+                        })
+                }
+                Some(koan_core::playlists::QueueLock::Album(id)) => {
+                    queries::get_album(&db.conn, id)
+                        .map_err(db_err)?
+                        .map(|a| QueueLock::Album {
+                            album: Album::from(a),
+                        })
+                }
+                None => None,
+            })
         })
         .await
     }
@@ -1287,7 +1298,15 @@ impl KoanEngine {
             // ephemeral view onto the playlist and may be shuffled, cut about
             // or added to; this is what still says which row is playing, and
             // which of two copies of a song it is.
-            for (item, entry) in items.iter_mut().zip(&entries) {
+            //
+            // Zipped against the entries whose track actually resolved, not
+            // against all of them: a playlist naming a track the library has
+            // since lost yields fewer items than entries, and zipping the two
+            // directly would hand every entry after the gap the wrong id.
+            let resolved: std::collections::HashSet<i64> =
+                items.iter().filter_map(|i| i.db_id).collect();
+            let kept = entries.iter().filter(|e| resolved.contains(&e.track.id));
+            for (item, entry) in items.iter_mut().zip(kept) {
                 item.playlist_entry_id = Some(entry.id);
             }
             if items.is_empty() {
@@ -2380,7 +2399,8 @@ impl KoanEngine {
 
     /// Whether the queue is still exactly this playlist.
     fn locked_to(&self, db: &Database, playlist_id: i64) -> bool {
-        koan_core::playlists::queue_lock(db, &self.state) == Some(playlist_id)
+        koan_core::playlists::queue_lock(db, &self.state)
+            == Some(koan_core::playlists::QueueLock::Playlist(playlist_id))
     }
 
     /// Make the queue follow a playlist that has just been edited.

--- a/crates/koan-ffi/src/lib.rs
+++ b/crates/koan-ffi/src/lib.rs
@@ -1032,6 +1032,24 @@ impl KoanEngine {
         .await
     }
 
+    /// The playlist the queue is still exactly, if it is one.
+    ///
+    /// While this answers, the queue follows that playlist: an edit there lands
+    /// here too. It stops answering the moment the queue is rearranged, added
+    /// to, or extended by radio — which is also when the following stops.
+    pub async fn queue_lock(self: Arc<Self>) -> Result<Option<Playlist>, KoanError> {
+        offload::offload(move || {
+            let db = self.db()?;
+            let Some(id) = koan_core::playlists::queue_lock(&db, &self.state) else {
+                return Ok(None);
+            };
+            Ok(queries::get_playlist(&db.conn, id)
+                .map_err(db_err)?
+                .map(Playlist::from))
+        })
+        .await
+    }
+
     /// Up to four tracks whose covers make the playlist's tile — one per album,
     /// in playlist order.
     pub async fn playlist_cover_track_ids(
@@ -1124,7 +1142,9 @@ impl KoanEngine {
     ) -> Result<u32, KoanError> {
         offload::offload(move || {
             let db = self.db()?;
+            let locked = self.locked_to(&db, playlist_id);
             let added = queries::add_tracks(&db.conn, playlist_id, &track_ids).map_err(db_err)?;
+            self.follow_playlist(&db, playlist_id, locked);
             koan_core::playlists::push_to_remote(playlist_id);
             Ok(added.len() as u32)
         })
@@ -1146,6 +1166,7 @@ impl KoanEngine {
     ) -> Result<u32, KoanError> {
         offload::offload(move || {
             let db = self.db()?;
+            let locked = self.locked_to(&db, playlist_id);
             let added = queries::add_tracks(&db.conn, playlist_id, &track_ids).map_err(db_err)?;
             if !added.is_empty() {
                 let mut order: Vec<i64> = queries::playlist_entries(&db.conn, playlist_id)
@@ -1158,6 +1179,7 @@ impl KoanEngine {
                 order.splice(at..at, added.iter().copied());
                 queries::reorder_entries(&db.conn, playlist_id, &order).map_err(db_err)?;
             }
+            self.follow_playlist(&db, playlist_id, locked);
             koan_core::playlists::push_to_remote(playlist_id);
             Ok(added.len() as u32)
         })
@@ -1173,7 +1195,9 @@ impl KoanEngine {
     ) -> Result<(), KoanError> {
         offload::offload(move || {
             let db = self.db()?;
+            let locked = self.locked_to(&db, playlist_id);
             queries::reorder_entries(&db.conn, playlist_id, &entry_ids).map_err(db_err)?;
+            self.follow_playlist(&db, playlist_id, locked);
             koan_core::playlists::push_to_remote(playlist_id);
             Ok(())
         })
@@ -1188,8 +1212,10 @@ impl KoanEngine {
     ) -> Result<u32, KoanError> {
         offload::offload(move || {
             let db = self.db()?;
+            let locked = self.locked_to(&db, playlist_id);
             let removed =
                 queries::remove_entries(&db.conn, playlist_id, &entry_ids).map_err(db_err)?;
+            self.follow_playlist(&db, playlist_id, locked);
             koan_core::playlists::push_to_remote(playlist_id);
             Ok(removed as u32)
         })
@@ -1204,7 +1230,9 @@ impl KoanEngine {
             let mut entries = queries::playlist_entries(&db.conn, playlist_id).map_err(db_err)?;
             koan_core::helpers::shuffle(&mut entries);
             let order: Vec<i64> = entries.iter().map(|e| e.id).collect();
+            let locked = self.locked_to(&db, playlist_id);
             queries::reorder_entries(&db.conn, playlist_id, &order).map_err(db_err)?;
+            self.follow_playlist(&db, playlist_id, locked);
             koan_core::playlists::push_to_remote(playlist_id);
             Ok(())
         })
@@ -2348,6 +2376,75 @@ impl KoanEngine {
                 log::info!("session restore: track never became ready, leaving position at 0");
             })
             .ok();
+    }
+
+    /// Whether the queue is still exactly this playlist.
+    fn locked_to(&self, db: &Database, playlist_id: i64) -> bool {
+        koan_core::playlists::queue_lock(db, &self.state) == Some(playlist_id)
+    }
+
+    /// Make the queue follow a playlist that has just been edited.
+    ///
+    /// Only when the queue was still exactly that playlist beforehand —
+    /// `was_locked` is read *before* the edit lands, because afterwards the two
+    /// no longer match and every queue would look diverged.
+    ///
+    /// The edit is applied to the queue rather than the queue being rebuilt
+    /// from the playlist: entries that survived keep their queue items, and
+    /// with them their ids, what has played, what is mid-download and what the
+    /// cursor is pointing at.
+    fn follow_playlist(&self, db: &Database, playlist_id: i64, was_locked: bool) {
+        if !was_locked {
+            return;
+        }
+        let Ok(entries) = queries::playlist_entries(&db.conn, playlist_id) else {
+            return;
+        };
+        let (items, _) = self.state.snapshot_playlist();
+
+        // Queue items whose entry has gone from the playlist.
+        let live: std::collections::HashSet<i64> = entries.iter().map(|e| e.id).collect();
+        let doomed: Vec<QueueItemId> = items
+            .iter()
+            .filter(|i| i.playlist_entry_id.is_none_or(|e| !live.contains(&e)))
+            .map(|i| i.id)
+            .collect();
+        if !doomed.is_empty() {
+            let _ = self.send(PlayerCommand::RemoveFromPlaylistBatch(doomed));
+        }
+
+        // Entries the queue has never seen.
+        let known: std::collections::HashMap<i64, QueueItemId> = items
+            .iter()
+            .filter_map(|i| i.playlist_entry_id.map(|e| (e, i.id)))
+            .collect();
+        let missing: Vec<&queries::PlaylistEntry> = entries
+            .iter()
+            .filter(|e| !known.contains_key(&e.id))
+            .collect();
+        let mut added = std::collections::HashMap::new();
+        if !missing.is_empty() {
+            let track_ids: Vec<i64> = missing.iter().map(|e| e.track.id).collect();
+            let (mut new_items, pending) = self.build_items(db, &track_ids);
+            for (item, entry) in new_items.iter_mut().zip(&missing) {
+                item.playlist_entry_id = Some(entry.id);
+                added.insert(entry.id, item.id);
+            }
+            if !new_items.is_empty() {
+                let _ = self.send(PlayerCommand::AddToPlaylist(new_items));
+                self.start_downloads(pending);
+            }
+        }
+
+        // Then the order, which is what puts the new arrivals in their places —
+        // they were appended, because that is the only thing an add can do.
+        let order: Vec<QueueItemId> = entries
+            .iter()
+            .filter_map(|e| known.get(&e.id).or_else(|| added.get(&e.id)).copied())
+            .collect();
+        if !order.is_empty() {
+            let _ = self.send(PlayerCommand::ReorderPlaylist(order));
+        }
     }
 
     fn start_downloads(&self, pending: Vec<(i64, QueueItemId)>) {

--- a/crates/koan-ffi/src/types.rs
+++ b/crates/koan-ffi/src/types.rs
@@ -473,6 +473,18 @@ impl From<queries::PlaylistRow> for Playlist {
     }
 }
 
+/// What the queue still is, when it is still something.
+///
+/// A queue that came from a playlist or a record and has not been touched since
+/// is still that thing, and saying so is what makes following legible — you can
+/// see why an edit to the playlist moved something in the queue, and you can
+/// see the moment it stops.
+#[derive(uniffi::Enum, Debug, Clone)]
+pub enum QueueLock {
+    Playlist { playlist: Playlist },
+    Album { album: Album },
+}
+
 /// One row of a playlist: the track, and the entry it sits in.
 ///
 /// The id is the entry's. It is what a queue item remembers, so a client can

--- a/crates/koan-tui/src/remote_bridge.rs
+++ b/crates/koan-tui/src/remote_bridge.rs
@@ -502,6 +502,7 @@ fn command_loop(
             | PlayerCommand::UpdatePaths(_)
             | PlayerCommand::MoveInPlaylist { .. }
             | PlayerCommand::MoveItemsInPlaylist { .. }
+            | PlayerCommand::ReorderPlaylist(_)
             | PlayerCommand::InsertInPlaylist { .. }
             | PlayerCommand::AddToPlaylist(_)
             | PlayerCommand::DecodeFinished => {


### PR DESCRIPTION
Closes #333.

Playing a playlist filled the queue with a copy, and editing the playlist afterwards changed nothing about what was playing or what came next. If you are dragging a track up the playlist you are listening to, you expect that to mean something.

The queue now follows a playlist for as long as it is still exactly that playlist. Rearrange the queue yourself, add to it, or let radio extend it, and the two part company — from then on the playlist is a document you are editing and the queue is what you are listening to.

## Locked is derived, not tracked

Queue items already carry the playlist row they came from, so the queue is locked exactly when its entry ids are that playlist's, in that order. That is the whole mechanism. There is no flag to keep in sync, nothing to persist, nothing to migrate, and it cannot get stuck: a queue that stops matching stops being locked, and one that happens to match again is locked again.

A shuffled play scrambles the order on purpose, so that queue is not locked. The right answer, and not a special case anyone had to write.

It also means there is no rule about the cursor and no partial reconciliation. The queue either is the playlist or it is not.

## Following moves things rather than rebuilding them

`follow_playlist` removes the queue items whose entry has gone, adds ones for entries the queue has not seen, then reorders. Rebuilding the queue from the playlist would issue fresh queue item ids and throw away what they carry — what has played, what is mid-download, what the cursor points at.

That needs one new player command, `ReorderPlaylist`: a permutation of the items already there. It is undoable like any other move, and undoing it ends the lock, which is the honest outcome of having rearranged the queue by hand.

The lock is read *before* each edit lands, because afterwards the two no longer match and every queue would look diverged.

## It is visible

While locked, the queue is headed **Playing *<playlist>*** with the playlist's mosaic beside it, and goes back to plain **Queue** the moment it is not. A rule this quiet has to be legible, or the first silent update reads as koan moving things on its own — you can see why an edit over there moved something here, and you can see when it will stop.

## Confirming it

`just check` — clippy clean, tests green, app builds.

Two tests carry the design, both in `playlists.rs`:

- `a_queue_is_locked_only_while_it_is_still_the_playlist` — empty queue is not locked; the playlist's own entries are; one item from anywhere else ends it.
- `rearranging_the_queue_ends_the_lock` — reorder the queue and it unlocks; bring the playlist into that same order and it locks again, with nothing having been reset.

By hand: play a playlist, check the queue header names it, reorder the playlist and watch the queue follow. Then drag something in the queue and confirm the header drops back to "Queue" and further playlist edits stop reaching it.

## Not in scope

Albums want the same treatment — "Playing *<album>*" — and need one more piece of provenance first: a queue item remembers a playlist entry, not the record it came from. #333 has the note.

Removing the entry that is currently playing takes whatever the queue already does when you delete the playing track, rather than inventing a third behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NEKKssPrgcGR1qJo49KnKG
