### PR TITLE
fix(macos): the playing mark stops crowding the sleeve beside it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- **The playing mark crowded the sleeve beside it.** Six points pairs a status mark with a right-aligned track number, which carries slack of its own; a cover is a solid block flush to its frame and the same six points read as a squeeze. A list that draws sleeves gives the mark the same ten points the title gets on the other side.
+
 ### Added
 
 - **Playlists.** Named, ordered lists of tracks that outlive the session — the thing the queue could never be, and the thing saved queues were standing in for. They live in the sidebar under their own heading, with a 2×2 mosaic of the first four records in them for a face.

--- a/apps/macos/Sources/Koan/Views/QueueRow.swift
+++ b/apps/macos/Sources/Koan/Views/QueueRow.swift
@@ -94,7 +94,15 @@ struct QueueRow: View {
             // what it is doing — so they sit together. Apart, a mark narrower
             // than its column and a number aligned to the right of its own left
             // most of twenty points of air between them.
-            HStack(spacing: 6) {
+            //
+            // A sleeve is not a number. A right-aligned number carries its own
+            // slack, so six points between the two still reads as a gap; a
+            // cover is a solid block flush to its frame, and the same six
+            // points crowd it. It gets the ten the title gets on its other
+            // side. Constant per list either way — the spacing keys off
+            // whether the list draws sleeves at all, not off whether this row
+            // resolved one, or the titles would step in and out down the page.
+            HStack(spacing: artwork ? 10 : 6) {
                 statusIcon
                     .font(.caption)
                     .frame(width: 16, alignment: .trailing)


### PR DESCRIPTION
The leading block of a queue row is `[status | sleeve-or-number]` then the title. The inner spacing was 6pt for both cases; it was tuned for the number one.

A right-aligned track number carries slack of its own — a single digit leaves most of its 20pt column empty — so 6pt between the mark and the digits still reads as a gap. A sleeve is a solid 34pt block flush to its frame, and the same 6pt reads as a squeeze. A list that draws sleeves now gives the mark 10pt, the same the title gets on the sleeve's other side.

## The two things that constrain this

**Spacing keys off `artwork`, not off whether the row resolved a sleeve.** `artwork` is constant for the whole list; `item.sleeve` is not — a track the library has lost falls back to the number branch. Keying off the latter would give that row a 6pt gap and its neighbours 10pt, stepping the titles in and out down the page. Same reason the number column is already `artwork ? 34 : 20`.

**Alignment stays `.trailing`.** `statusIcon` is a different width in every state — 10pt for `PlayingIndicator`, 14pt for the download ring, various for the SF Symbols. Trailing alignment is what holds the gap to the sleeve constant across them; centring would make it breathe with the glyph, row to row.

## Confirming it

`swift build` is clean. **I have not looked at it** — other sessions were building and running the GUI, so I stayed off. Worth an eyeball on:

- An ungrouped queue: the mark should sit off the cover rather than against it, and titles should stay in one column whether or not a row found its sleeve.
- A grouped queue: unchanged, 6pt, mark against the number.
- A row mid-download (14pt ring) next to one playing (10pt bars) — the gap to the sleeve should be identical.

If 10 is too much, the number to turn is the `artwork ?` branch of that one `HStack(spacing:)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EXVEArLUXvHNTbGrz6Nfsi