### PR TITLE
release: v0.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,6 @@
 # Changelog
 
-## Unreleased
-
-### Fixed
-
-- **The playing mark crowded the sleeve beside it.** Six points pairs a status mark with a right-aligned track number, which carries slack of its own; a cover is a solid block flush to its frame and the same six points read as a squeeze. A list that draws sleeves gives the mark the same ten points the title gets on the other side.
+## v0.31.0 (2026-08-25)
 
 ### Added
 
@@ -42,23 +38,6 @@
 
   It is a fraction of bytes on an axis of time — right for lossless and CBR, out by however far the bitrate wanders on VBR — so it is drawn as a distinctly weaker mark than the played extent and the tooltip says "roughly". The question it answers is whether the music is about to run out of track, not where in the track anything is; a hard-edged fill would be read as a promise it cannot keep. The TUI has drawn the same three-way bar all along.
 
-### Removed
-
-- **Snapshots.** They were playlists with a resume position: a whole second feature, a second table, a second sidebar row and a second set of API calls, all to remember one number the server had no idea about. Existing snapshots become playlists on first launch, keeping their names, their track order and the date they were saved; only the position is lost. The Subsonic API already served them as playlists, so its clients see the same names either side of this.
-
-  ⌘6 is gone with them, and **Save as Snapshot…** in the queue menu is now **Save as Playlist…**.
-
-- **The download quality setting.** It offered Original, Opus 128 and MP3 320, wrote your choice to `config.toml`, carried it over GraphQL and FFI, and was read by nothing — no request has ever asked a server to transcode. Re-encoding a stream is the opposite of what koan is for, so the setting goes rather than gains an implementation. `remote.transcode_quality` in an existing config is ignored; the GraphQL `Config.transcodeQuality` field and its input are gone.
-
-- **`[radio] use_subsonic` and `[discovery] acoustic_weight` never did anything.** Both were documented as tuning knobs and neither was read: Subsonic similarity ran whenever a server was configured, and the acoustic signal's weight was a constant in the scoring function. Removed rather than wired up — the defaults are the behaviour everyone has been getting.
-
-- **`[playback] ticker_fps`.** The transport ticker scrolls at a fixed 8 characters per second.
-
-Unknown keys are ignored rather than rejected, so a stale config still loads. Two
-renames change behaviour silently and are worth grepping your config for:
-`[graphql] subsonic_port` (now `[subsonic] port`) and `[discovery]
-analysis_on_scan` (now `[library] analyze_on_scan`). The others were inert.
-
 ### Changed
 
 - **The queue stays locked to the playlist that filled it.** Play a playlist and the queue *is* that playlist; reorder it, remove from it or add to it and the queue follows, quietly. Rearrange the queue yourself, add to it, or let radio extend it and the two part company — from then on the playlist is a document you are editing and the queue is what you are listening to.
@@ -90,7 +69,26 @@ analysis_on_scan` (now `[library] analyze_on_scan`). The others were inert.
 
 - **The menus have their icons back.** Every action in the app now carries the same symbol wherever it appears: Add to Queue is the same icon on an album page, in the row's context menu and in the menu bar, and the Edit menu — replaced wholesale so ⌘Z can reach koan's own undo stack rather than a text field's — draws its own icons again instead of arriving bare. The symbols are named in one place, which is what stops the three copies of a verb drifting apart.
 
+### Removed
+
+- **Snapshots.** They were playlists with a resume position: a whole second feature, a second table, a second sidebar row and a second set of API calls, all to remember one number the server had no idea about. Existing snapshots become playlists on first launch, keeping their names, their track order and the date they were saved; only the position is lost. The Subsonic API already served them as playlists, so its clients see the same names either side of this.
+
+  ⌘6 is gone with them, and **Save as Snapshot…** in the queue menu is now **Save as Playlist…**.
+
+- **The download quality setting.** It offered Original, Opus 128 and MP3 320, wrote your choice to `config.toml`, carried it over GraphQL and FFI, and was read by nothing — no request has ever asked a server to transcode. Re-encoding a stream is the opposite of what koan is for, so the setting goes rather than gains an implementation. `remote.transcode_quality` in an existing config is ignored; the GraphQL `Config.transcodeQuality` field and its input are gone.
+
+- **`[radio] use_subsonic` and `[discovery] acoustic_weight` never did anything.** Both were documented as tuning knobs and neither was read: the acoustic signal's weight was a constant in the scoring function, and nothing consulted `use_subsonic` before deciding whether to ask a server — see below for what radio actually does. Removed rather than wired up — the defaults are the behaviour everyone has been getting.
+
+- **`[playback] ticker_fps`.** The transport ticker scrolls at a fixed 8 characters per second.
+
+Unknown keys are ignored rather than rejected, so a stale config still loads. Two
+renames change behaviour silently and are worth grepping your config for:
+`[graphql] subsonic_port` (now `[subsonic] port`) and `[discovery]
+analysis_on_scan` (now `[library] analyze_on_scan`). The others were inert.
+
 ### Fixed
+
+- **The playing mark crowded the sleeve beside it.** Six points pairs a status mark with a right-aligned track number, which carries slack of its own; a cover is a solid block flush to its frame and the same six points read as a squeeze. A list that draws sleeves gives the mark the same ten points the title gets on the other side.
 
 - **The queue got slower the more of it you had played.** A played row was the whole row at 45% alpha, and any alpha below 1 makes SwiftUI flatten that row into an offscreen layer before compositing it — its children overlap, so they cannot each be drawn at 45% and still look like one row. A long tail of played tracks behind the cursor was a long list of offscreen passes, on every frame the list drew. Played rows now step back in colour instead: a rung down the hierarchical styles, which costs a colour lookup. Only the sleeve still uses alpha, because no colour can dim an image — and one 34pt image is not a flattened row.
 
@@ -105,6 +103,14 @@ analysis_on_scan` (now `[library] analyze_on_scan`). The others were inert.
 - **`koan remote login` wrote your password to disk.** The macOS sign-in path already stored it in the platform credential store and explicitly cleared any plaintext copy; the CLI wrote it straight into `config.local.toml`. Both go through `helpers::set_remote_credentials` now. koan's own Subsonic secret also read the config field *before* the keychain, so a stale plaintext copy beat the real secret — the credential store wins in both, and the config field stays what it always was: the fallback for machines without one.
 
 - **`[radio] seed_window` was half honoured.** It picked the seed artists, while the acoustic seeder asked for the last five tracks regardless. One window, one answer.
+
+- **The radio documentation described a feature that does not run.** The README and the radio guide both led with Subsonic `getSimilarSongs2` and a cache of similar-artist relationships as radio's strongest signals. Neither is reached: the auto-queue loop turns the network signals off before it picks, because ListenBrainz and MusicBrainz rate-limit to one request a second per seed artist and all three are synchronous HTTP in front of a track that is needed before the current one ends. What radio actually scores is genre and era, same-artist, acoustic similarity over bliss-audio vectors, and a low-scored random tail — all database reads.
+
+  The code is unchanged; the docs now say what it does, and the guide says why the network signals are switched off and what would have to happen to switch them back on. Two things follow from the same gap and are now written down: nothing writes the `similar_artists` cache, so `similarArtists` over GraphQL and FFI and `getSimilarSongs2` on koan's own Subsonic API return empty; and radio behaving identically offline is not graceful degradation, because there is no online path to degrade from.
+
+  `koan scan --analyze` is the one thing that meaningfully improves radio, so the docs now say that instead of burying it fifth in a list.
+
+- **`remote.transcode_quality` was still documented after being removed.** It survived in the remote-servers guide — with a table of quality tiers and a note that "Navidrome and most Subsonic servers handle this natively" — and in the configuration reference. The setting was never wired to anything and is gone; so is the section describing it.
 
 - **Documented settings that were not true.** `bass_shake` defaults to `true`, not `false`. `[organize] default` preselects a pattern in the organize UI, not "the TUI modal" it had no effect on. The format-string reference showed a `koan organize --pattern` command that has never existed — organize runs from the TUI and the macOS sheet.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2744,7 +2744,7 @@ dependencies = [
 
 [[package]]
 name = "koan-cli"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "koan-core"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "argon2",
  "bliss-audio",
@@ -2811,7 +2811,7 @@ dependencies = [
 
 [[package]]
 name = "koan-ffi"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "chrono",
  "crossbeam-channel",
@@ -2831,7 +2831,7 @@ dependencies = [
 
 [[package]]
 name = "koan-server"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",
@@ -2864,7 +2864,7 @@ dependencies = [
 
 [[package]]
 name = "koan-tui"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "core-foundation 0.10.1",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/koan-core", "crates/koan-ffi", "crates/koan-server", "crates/koan-tui", "crates/koan-cli"]
 
 [workspace.package]
-version = "0.30.2"
+version = "0.31.0"
 edition = "2024"
 rust-version = "1.89"
 homepage = "https://github.com/radiosilence/koan"
@@ -13,9 +13,9 @@ license = "MIT"
 [workspace.dependencies]
 # Internal crates. Keep the version in step with [workspace.package] above —
 # a stale pin here publishes members that resolve against the wrong sibling.
-koan-core = { path = "crates/koan-core", version = "0.30.2" }
-koan-server = { path = "crates/koan-server", version = "0.30.2" }
-koan-tui = { path = "crates/koan-tui", version = "0.30.2" }
+koan-core = { path = "crates/koan-core", version = "0.31.0" }
+koan-server = { path = "crates/koan-server", version = "0.31.0" }
+koan-tui = { path = "crates/koan-tui", version = "0.31.0" }
 # Feature set is the union every member needs; `default-tls` is an alias for
 # `rustls`, so there is exactly one TLS stack.
 reqwest = { version = "0.13", default-features = false, features = [

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Local and remote tracks merge into one library. Local files take playback priori
 - **Authentication** -- Ed25519 JWT tokens, three roles (admin/user/readonly), 1Password CLI integration
 - **Subsonic/Navidrome** -- incremental sync, unified local+remote browsing, streaming playback, two-way sync of favourites and playlists
 - **Playlists** -- ordered, named, reorderable; synced both ways with Navidrome, exportable as M3U8
-- **Radio mode** -- infinite play using Subsonic similarity, cached artist relationships, and genre matching
+- **Radio mode** -- infinite play, scored from your own library: acoustic similarity over bliss-audio feature vectors (once you have run `koan scan --analyze`), genre and era matching, same-artist, and a random tail. It does not query anyone for recommendations -- [the guide says why](docs/guide/radio-mode.md#what-it-does-not-use)
 - **ReplayGain** -- track and album modes with peak limiting and configurable pre-amp
 - **Format strings** -- fb2k-compatible `%field%`, `[conditionals]`, `$functions()` — 59 of them — for display and file organization
 - **File organization** -- rename/reorganize your library from the macOS app or the TUI using format string patterns
@@ -183,7 +183,7 @@ No TUI player combines bit-perfect audio, Subsonic streaming, album art, fb2k-st
 |-------|---------------|
 | **[Getting Started](docs/getting-started.md)** | First-time setup, local and remote libraries, your first session |
 | **[Authentication](docs/guide/authentication.md)** | JWT auth, user management, 1Password integration, recovery |
-| **[Radio Mode](docs/guide/radio-mode.md)** | Infinite play, similarity scoring, tuning discovery |
+| **[Radio Mode](docs/guide/radio-mode.md)** | Infinite play, what it scores on and what it doesn't, tuning discovery |
 | **[Remote Servers](docs/guide/remote-servers.md)** | Navidrome/Subsonic setup, sync, streaming, cache management |
 | **[File Organization](docs/guide/file-organization.md)** | Rename and reorganize your library from the TUI |
 | **[GraphQL API](docs/guide/graphql-api.md)** | Headless operation, queries, mutations, daemon mode |

--- a/docs/architecture-improvements.md
+++ b/docs/architecture-improvements.md
@@ -61,4 +61,4 @@ Config fields that exist but aren't wired into anything:
 | Field | Config Location | Library Code | Wired In? |
 |-------|----------------|-------------|-----------|
 | `playback.replaygain` | config.rs | replaygain.rs (full impl) | **Yes** -- wired into decode pipeline |
-| `remote.transcode_quality` | config.rs | N/A | **No** -- needs stream URL parameter |
+| `remote.transcode_quality` | -- | -- | Removed in v0.31.0 -- re-encoding a stream is the opposite of what koan is for |

--- a/docs/guide/radio-mode.md
+++ b/docs/guide/radio-mode.md
@@ -1,6 +1,6 @@
 # Radio Mode
 
-Radio mode turns koan into an infinite jukebox. When enabled, koan automatically queues similar tracks as you listen -- you never run out of music.
+Radio mode turns koan into an infinite jukebox. When enabled, koan keeps the queue topped up from your own library as you listen -- you never run out of music.
 
 ## Quick start
 
@@ -8,19 +8,52 @@ Press `R` in the TUI to toggle radio mode. That's it. koan starts adding tracks 
 
 ## How it works
 
-Radio mode uses a multi-signal scoring system to find tracks similar to what you're currently listening to:
+Radio mode scores every candidate track on several signals and picks from the top
+with a weighted random draw, so the same seed does not produce the same queue twice.
 
-1. **Subsonic similarity** -- if you have a remote server configured, koan queries `getSimilarSongs2` for server-side recommendations. This is the strongest signal when available.
+Every signal it uses is a database read:
 
-2. **Cached artist relationships** -- koan builds a local cache of "similar artist" relationships from your Subsonic server. Even when offline, these cached relationships inform radio selections.
+1. **Genre and era matching** -- tracks sharing genres with the seed window score
+   higher, and tracks from within five years of the seed's average year higher again.
 
-3. **Genre matching** -- tracks sharing genres with the current seed tracks get a relevance boost.
+2. **Same artist** -- other tracks by the artists in the seed window.
 
-4. **Artist matching** -- other tracks by the same artist (or similar artists) score higher.
+3. **Acoustic similarity** -- if you have run `koan scan --analyze`, koan takes the
+   centroid of the seed tracks' feature vectors and finds its nearest neighbours.
+   This is the only signal that hears the music rather than reading about it, and
+   it is the one worth turning on.
 
-5. **Acoustic similarity** -- if you've run `koan scan --analyze`, radio mode factors in acoustic features (tempo, energy, spectral characteristics). The same `seed_window` that picks the seed artists picks the seed vectors.
+4. **Random** -- a handful of tracks from the rest of the library, scored low enough
+   that they only win when nothing else has anything to say. On an unanalysed library
+   with sparse genre tags this is most of what you get.
 
-The scoring system blends these signals and avoids repeating recently-played tracks (controlled by `history_window`).
+On top of those, tracks matching on more than one signal are boosted, and tracks you
+have not played recently -- or ever -- are boosted by `discovery_weight`. Anything in
+the last `history_window` plays, or already in the queue, is excluded outright.
+
+### What it does not use
+
+koan can query **ListenBrainz** and **MusicBrainz** for similar artists, and
+**Subsonic `getSimilarSongs2`** for server-side recommendations. None of them run
+when radio picks a track.
+
+They are synchronous HTTP calls, and the two metadata services rate-limit themselves
+to one request per second *per seed artist*, so a queue about to run dry would get a
+better-chosen track some seconds after the music had already stopped. The code is
+still there, behind an `allow_network` flag that the auto-queue loop turns off, and
+it is waiting on a background pass that can fill the similar-artist cache while there
+is time for it rather than in front of a pick that is needed now.
+
+Until then: radio is local metadata, acoustic vectors if you have them, and a random
+tail. It is not asking anyone what sounds like what.
+
+Two consequences worth knowing, since they follow from the same gap:
+
+- The `similar_artists` cache is only ever written by those network signals, so it
+  stays empty. `similarArtists` over GraphQL and FFI, and `getSimilarSongs2` on
+  koan's own Subsonic API, return nothing.
+- Radio works exactly the same offline as online. That is not the graceful
+  degradation it looks like -- there is no online path to degrade from.
 
 ## Configuration
 
@@ -60,7 +93,7 @@ For the best radio experience, run acoustic analysis on your library:
 koan scan --analyze
 ```
 
-This computes acoustic features (tempo, timbre, chroma, and spectral features — a 23-dimensional vector) for each track using bliss-audio. With acoustic analysis data available, radio mode can find tracks that genuinely *sound* similar, not just tracks that share metadata.
+This computes acoustic features (tempo, timbre, chroma, and spectral features — a 23-dimensional vector) for each track using bliss-audio. It is the difference between radio finding tracks that genuinely *sound* similar and radio shuffling things that share a genre string.
 
 ```toml
 [library]
@@ -74,4 +107,4 @@ Setting `analyze_on_scan = true` runs acoustic analysis on every `koan scan`, ke
 - **Start with a track you like.** Radio mode uses whatever's playing as its seed. Queue up a track that sets the vibe you want, then press `R`.
 - **Queue some variety first.** If you queue tracks from different genres before enabling radio, the seed window will pick up on the mix and produce more varied results.
 - **Still edit the queue.** Radio mode only adds tracks -- you can still remove tracks you don't want (`e` to edit, `d` to delete). Radio will refill around your changes.
-- **Works offline.** Without a Subsonic server, radio falls back to local genre/artist matching and acoustic similarity. Less accurate but still functional.
+- **Run the analysis.** `koan scan --analyze` is the single biggest thing you can do for radio quality. Without it, radio has only genre tags, artist names and chance to work with -- and genre tags on a ripped library are often blank or wrong.

--- a/docs/guide/remote-servers.md
+++ b/docs/guide/remote-servers.md
@@ -61,23 +61,6 @@ Downloads happen in the background with configurable parallelism:
 download_workers = 5    # parallel download threads (default: 5)
 ```
 
-## Transcoding
-
-By default, koan requests the original quality from the server. If bandwidth is a concern:
-
-```toml
-[remote]
-transcode_quality = "original"   # original | opus-128 | mp3-320
-```
-
-| Quality | Description |
-|---------|-------------|
-| `original` | **(default)** Bit-perfect, whatever the server has |
-| `opus-128` | Opus at 128kbps -- transparent quality, ~1/10th the bandwidth of FLAC |
-| `mp3-320` | MP3 at 320kbps -- maximum quality lossy, widest compatibility |
-
-Note: transcoding depends on the server supporting it. Navidrome and most Subsonic servers handle this natively.
-
 ## Cache management
 
 Downloaded remote tracks are cached locally so subsequent plays are instant. See [Cache Management](../recipes/cache-management.md) for size limits, eviction, and cleanup.
@@ -107,7 +90,6 @@ username = "admin"
 
 # config.toml or config.local.toml
 [remote]
-transcode_quality = "original"   # original | opus-128 | mp3-320
 download_workers = 5             # parallel download threads
 cache_limit = "50GB"             # max cache size (LRU eviction)
 cache_dir = "/custom/path"       # cache directory

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -187,7 +187,6 @@ username = "admin"
 
 # config.toml or config.local.toml
 [remote]
-transcode_quality = "original"   # original | opus-128 | mp3-320 (default: original)
 download_workers = 5             # parallel download threads (default: 5)
 cache_limit = "50GB"             # max cache size, LRU eviction on startup (default: unlimited)
 cache_dir = "/custom/path"       # explicit cache dir (default: ~/.config/koan/cache)


### PR DESCRIPTION
Cuts v0.31.0. The bulk of the changelog was already written as the work landed; this bumps the version, dates the entry, and fixes the documentation that was describing features the code does not run.

## What's in it

Playlists are the headline — named, ordered, two-way synced with Navidrome, exportable as M3U8 — and they replace snapshots, which migrate on first launch. Alongside: the queue locks to the playlist that filled it, the playing indicator follows the analyser, the seek bar shows how much of a streaming track has arrived, favourites gained records and artists, Opus stopped losing its first 40 ms, and a run of macOS performance work took playback with the window minimised from 28% of a core to 15%.

**The database schema is version 2. Older koan builds will refuse to open the library** — that is the point of the version, not a bug. Two config keys were renamed silently: `[graphql] subsonic_port` → `[subsonic] port`, `[discovery] analysis_on_scan` → `[library] analyze_on_scan`.

## The radio correction

Asked to verify the claim that radio uses Subsonic similarity. It does not, and neither do the other two network signals.

`spawn_autoqueue` — the only production caller of `pick_tracks`, used by both the TUI and the macOS app — sets `ctx.allow_network = false` and passes `client: None` (`crates/koan-core/src/radio.rs:1104`). That gates out ListenBrainz, MusicBrainz and Subsonic `getSimilarSongs2`. It is deliberate and the reasoning in the comment is sound: those are synchronous HTTP calls, the two metadata services rate-limit to one request a second per seed artist, and a queue about to run dry needs a track now.

What actually runs is genre/era matching, same-artist, acoustic KNN over bliss-audio vectors, and a low-scored random tail. So: not random, but not similarity-driven either unless you have run `koan scan --analyze`.

**No code changed.** The README and `docs/guide/radio-mode.md` now say what radio does, with a "What it does not use" section explaining why the network signals are off and what would have to happen to turn them back on.

### Two things this surfaced, not fixed here

- Nothing writes the `similar_artists` table. Its only two writers live inside the gated network paths, so `similarArtists` over GraphQL and FFI (`crates/koan-server/src/graphql/queries.rs:466`, `crates/koan-ffi/src/lib.rs:628`) and `getSimilarSongs2` on koan's own Subsonic API (`crates/koan-server/src/subsonic.rs:1716`) all read an empty table and return nothing. Documented in the guide; worth its own issue.
- `radio::fetch_and_cache_similar_artists` is `pub` and marked "kept for backward compat with the TUI trigger" — the TUI trigger is gone and it has no callers.

## Also

`remote.transcode_quality` was removed this cycle but survived in `docs/guide/remote-servers.md` (a whole Transcoding section, complete with a quality-tier table) and `docs/reference/configuration.md`. Both gone.

## Verifying

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — 930 passed, 0 failed
- Changelog entry count checked before and after the section reorder: 49 existing entries preserved, 2 added. The `Unreleased` section had two separate `### Fixed` headings; they are merged and the sections ordered Added / Changed / Removed / Fixed.

No tags pushed — that's yours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L2QYGXTN6dYC7MX5KNY8a5