### PR TITLE
release: v0.31.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v0.31.1 (2026-08-25)
+
+### Changed
+
+- **Every page takes the record's colour, not just the ones about a record.** The wash was drawn on the queue, on an album page and on a playlist, and nowhere else — so the albums grid, the artist list, an artist's page, favourites, history and search results were flat grey rooms you passed through on the way back to a coloured one. Each of those pages was opaque precisely to hide the wash the window was already drawing behind it.
+
+  They give that ground up. A page about one record still answers with it — an album with its own sleeve, a playlist with the first of its records — and every other page answers with what is playing. The room is coloured by the music wherever you have wandered off to, and only a page that disagrees says otherwise.
+
+  The wash and the control tint were two properties computing nearly the same answer, and now they are one: what the room is washed in and what the buttons are tinted with can no longer disagree about which record you are looking at. Nothing new is drawn — there is still exactly one `ArtworkBleed`, on the window, which is what `backgroundExtensionEffect` mirrors out under the sidebar and toolbar. The pages simply stop covering it up.
+
+- **Artist chips are a plain fill rather than glass.** Glass samples what is behind it and adapts its own luminance to stay legible against it — right for something floating over content, wrong for a chip sitting in it. On a flat page ground every pill sampled the same colour and they all matched; over the wash they each answered to a different part of it, so a row of them read as a scatter of half-transparent ones rather than a set. A fixed fill takes its share of the colour behind it without arguing with it.
+
 ## v0.31.0 (2026-08-25)
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2744,7 +2744,7 @@ dependencies = [
 
 [[package]]
 name = "koan-cli"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "chrono",
  "clap",
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "koan-core"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "argon2",
  "bliss-audio",
@@ -2811,7 +2811,7 @@ dependencies = [
 
 [[package]]
 name = "koan-ffi"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "chrono",
  "crossbeam-channel",
@@ -2831,7 +2831,7 @@ dependencies = [
 
 [[package]]
 name = "koan-server"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",
@@ -2864,7 +2864,7 @@ dependencies = [
 
 [[package]]
 name = "koan-tui"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "core-foundation 0.10.1",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/koan-core", "crates/koan-ffi", "crates/koan-server", "crates/koan-tui", "crates/koan-cli"]
 
 [workspace.package]
-version = "0.31.0"
+version = "0.31.1"
 edition = "2024"
 rust-version = "1.89"
 homepage = "https://github.com/radiosilence/koan"
@@ -13,9 +13,9 @@ license = "MIT"
 [workspace.dependencies]
 # Internal crates. Keep the version in step with [workspace.package] above —
 # a stale pin here publishes members that resolve against the wrong sibling.
-koan-core = { path = "crates/koan-core", version = "0.31.0" }
-koan-server = { path = "crates/koan-server", version = "0.31.0" }
-koan-tui = { path = "crates/koan-tui", version = "0.31.0" }
+koan-core = { path = "crates/koan-core", version = "0.31.1" }
+koan-server = { path = "crates/koan-server", version = "0.31.1" }
+koan-tui = { path = "crates/koan-tui", version = "0.31.1" }
 # Feature set is the union every member needs; `default-tls` is an alias for
 # `rustls`, so there is exactly one TLS stack.
 reqwest = { version = "0.13", default-features = false, features = [

--- a/apps/macos/Sources/Koan/Views/ArtistBrowser.swift
+++ b/apps/macos/Sources/Koan/Views/ArtistBrowser.swift
@@ -13,6 +13,7 @@ struct ArtistBrowser: View {
             ArtistRow(artist: artist)
         }
         .clearsSelection($selection)
+        .washedGround()
         .contextMenu(forSelectionType: Int64.self) { ids in
             if let id = ids.first,
                let artist = library.visibleArtists.first(where: { $0.id == id }) {

--- a/apps/macos/Sources/Koan/Views/ArtistPill.swift
+++ b/apps/macos/Sources/Koan/Views/ArtistPill.swift
@@ -35,7 +35,15 @@ struct ArtistPill: View {
         .padding(.horizontal, 11)
         .padding(.vertical, 6)
         .fixedSize(horizontal: true, vertical: false)
-        .glassEffect(.regular.interactive(), in: .capsule)
+        // A plain chip rather than glass. Glass samples what is behind it and
+        // adapts its own luminance to stay legible on it — which is right for
+        // something floating over content, and wrong for a chip sitting *in*
+        // it. On a flat page ground every pill sampled the same colour and they
+        // all matched; over the wash they each answer to a different part of
+        // it, and a row of them reads as a scatter of half-transparent ones
+        // rather than a set. A fixed fill takes its share of the colour behind
+        // it without arguing with it.
+        .background(.quaternary, in: .capsule)
         .contentShape(Capsule())
         .onTapGesture { nav.open(artist: artistId) }
         .help("Go to \(name)")

--- a/apps/macos/Sources/Koan/Views/ArtworkBleed.swift
+++ b/apps/macos/Sources/Koan/Views/ArtworkBleed.swift
@@ -136,3 +136,15 @@ struct ArtworkBleed: View {
         generation += 1
     }
 }
+
+extension View {
+    /// Stands a list's own ground down so the window's wash shows through it.
+    ///
+    /// A `List` paints an opaque background by default, which lands on top of
+    /// the wash and stops the record's colour in a hard line under the header
+    /// instead of letting it fade out across the first few rows. Every list in
+    /// the app sits in the wash, so every list gives its ground up.
+    func washedGround() -> some View {
+        scrollContentBackground(.hidden)
+    }
+}

--- a/apps/macos/Sources/Koan/Views/FavouritesView.swift
+++ b/apps/macos/Sources/Koan/Views/FavouritesView.swift
@@ -48,6 +48,7 @@ struct FavouritesView: View {
                     if !tracks.isEmpty { trackSection }
                 }
                 .listStyle(.inset)
+                .washedGround()
                 .clearsSelection($selection)
                 .contextMenu(forSelectionType: Int64.self) { ids in
                     menu(for: ids)

--- a/apps/macos/Sources/Koan/Views/HistoryView.swift
+++ b/apps/macos/Sources/Koan/Views/HistoryView.swift
@@ -47,6 +47,7 @@ struct HistoryView: View {
                     }
                 }
                 .listStyle(.inset)
+                .washedGround()
                 .clearsSelection($selection)
                 .contextMenu(forSelectionType: Int64.self) { ids in
                     menu(for: ids)

--- a/apps/macos/Sources/Koan/Views/PlaylistView.swift
+++ b/apps/macos/Sources/Koan/Views/PlaylistView.swift
@@ -62,11 +62,7 @@ struct PlaylistView: View {
                     endOfList
                 }
                 .listStyle(.inset)
-                // Otherwise the List paints its own ground over the wash and
-                // the record's colour stops in a hard line under the header,
-                // rather than fading out across the first few rows. The queue
-                // and every album page give theirs up for the same reason.
-                .scrollContentBackground(.hidden)
+                .washedGround()
                 .contextMenu(forSelectionType: String.self) { ids in
                     menu(forRows: ids)
                 } primaryAction: { ids in

--- a/apps/macos/Sources/Koan/Views/QueueView.swift
+++ b/apps/macos/Sources/Koan/Views/QueueView.swift
@@ -76,10 +76,7 @@ struct QueueView: View {
                         guard ui.queueScrollY > 0 else { return }
                         scrollPosition.scrollTo(y: ui.queueScrollY)
                     }
-                    // Otherwise the List paints over the wash and it stops at
-                    // the header in a hard line, rather than fading out across
-                    // the first few rows.
-                    .scrollContentBackground(.hidden)
+                    .washedGround()
                     // `g` / `G`. Watches the token rather than the edge: jumping
                     // to where you already are still has to scroll, because the
                     // list may have been moved since.

--- a/apps/macos/Sources/Koan/Views/RootView.swift
+++ b/apps/macos/Sources/Koan/Views/RootView.swift
@@ -43,23 +43,17 @@ struct RootView: View {
     /// it used to be.
     @State private var columns: NavigationSplitViewVisibility = .automatic
 
-    /// What the window is washed in: the record you opened, or the one playing,
-    /// and only where either means something. A library grid is its own colour.
-    private var washSource: AlbumArtwork.Source? {
-        switch nav.current {
-        case .album(let id): .album(id)
-        case .section(.queue): player.currentArtwork
-        // A playlist is a page about a set of records, so it is washed in the
-        // first of them — the same one that leads its mosaic.
-        case .section(.playlist(let id)): playlists.covers[id]?.first
-        default: nil
-        }
-    }
-
-    /// What the *controls* take their colour from. The page you are on first —
-    /// an album's own record — and what is playing everywhere else, so a
-    /// favourites list is still coloured by the music rather than by nothing.
-    private var tintSource: AlbumArtwork.Source? {
+    /// The record the room takes its colour from — both the wash on the window
+    /// and the tint on the controls, which are the same answer and were once
+    /// two.
+    ///
+    /// A page about one record answers with it: an album with its own sleeve, a
+    /// playlist with the first of its records, the same one that leads its
+    /// mosaic. Every other page — a grid, a list of artists, favourites,
+    /// history — is not about any record in particular, so it answers with the
+    /// one playing. The room is coloured by the music wherever you have
+    /// wandered off to, and only a page that disagrees says otherwise.
+    private var colourSource: AlbumArtwork.Source? {
         switch nav.current {
         case .album(let id): .album(id)
         case .section(.playlist(let id)): playlists.covers[id]?.first ?? player.currentArtwork
@@ -76,7 +70,7 @@ struct RootView: View {
         // environment `RootView` was handed, so anything it needs is captured
         // here. Reading an `@Environment` inside that closure — including to
         // put one back — traps, and the app dies on launch.
-        let wash = washSource
+        let wash = colourSource
         let washDrifts = player.isPlaying
         let artCache = art
 
@@ -86,17 +80,11 @@ struct RootView: View {
         } detail: {
             StageView()
                 .clearsTransport(transportHeight)
-                // Filled *before* the ground goes behind it. A background sizes
-                // itself to what it backs, so expanding afterwards left the
-                // ground the size of the page's content — and a page that
-                // measures nothing, like results while the query is still
-                // running, showed the window's wash everywhere around it.
+                // A page fills the column whether or not it has anything in it
+                // to fill it with. Results while the query is still running
+                // measure nothing, and an unfilled page leaves the transport
+                // and the scroll edges sized to it.
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-                // Every page carries its own ground. The window's is the wash,
-                // so a transparent page composites onto it — and onto the page
-                // before it, which is what left an album drawing itself across
-                // the grid you came back to.
-                .background { PageGround() }
         }
         .inspector(isPresented: $showLyrics) {
             LyricsPanel()
@@ -132,7 +120,7 @@ struct RootView: View {
                     .environment(artCache)
             }
         }
-        .task(id: tintSource) {
+        .task(id: colourSource) {
             // Animated at the point the colour changes rather than by an
             // `.animation(_:value:)` on the view. That modifier animates *every*
             // animatable change in the subtree it is attached to whenever its
@@ -141,7 +129,7 @@ struct RootView: View {
             // record was dragged out over two seconds along with it.
             // A thumbnail: the dominant colour of a sleeve is the same at 128
             // pixels as at 512, and this is a size the grid already holds.
-            guard let tintSource, let cover = await art.image(for: tintSource, size: .thumb)
+            guard let colourSource, let cover = await art.image(for: colourSource, size: .thumb)
             else {
                 withAnimation(.easeInOut(duration: 2)) { recordTint = nil }
                 return
@@ -344,37 +332,6 @@ private struct StageView: View {
             AlbumDetailView(albumId: id)
         case .artist(let id):
             ArtistDetailView(artistId: id)
-        }
-    }
-}
-
-/// What a page sits on.
-///
-/// An unwashed page is opaque, so it never composites onto the window or onto
-/// the page before it — which is what left an album drawing itself across the
-/// grid you came back to.
-///
-/// A washed page draws nothing at all and lets the window's own wash through.
-/// There is only ever one bleed: two of them meant the page's copy sat on an
-/// opaque ground hiding the window's, and the window's kept animating behind it
-/// for no one. The window is the one that survives because it is the one
-/// `backgroundExtensionEffect` mirrors out under the sidebar and toolbar.
-private struct PageGround: View {
-    @Environment(Navigator.self) private var nav
-
-    /// Whether this page is washed in a record's colour, or is its own ground.
-    /// Matches `RootView.washSource` — where that has a wash, this stands back.
-    private var washed: Bool {
-        switch nav.current {
-        case .album: true
-        case .section(.queue), .section(.playlist): true
-        default: false
-        }
-    }
-
-    var body: some View {
-        if !washed {
-            Rectangle().fill(.background)
         }
     }
 }

--- a/apps/macos/Sources/Koan/Views/TrackListView.swift
+++ b/apps/macos/Sources/Koan/Views/TrackListView.swift
@@ -52,13 +52,7 @@ struct TrackListView: View {
                         }
                     }
                     .listStyle(.inset)
-                    // Gives up its ground only where there is a wash to show:
-                    // otherwise the List paints over it and the record's colour
-                    // stops in a line under the header. Without a cover — a
-                    // favourites list — it keeps its ground, or it composites
-                    // onto whatever the window is drawing, which is the page
-                    // you came from.
-                    .scrollContentBackground(artwork == nil ? .visible : .hidden)
+                    .washedGround()
 
                     // The List's own double-click hook. Wired into selection
                     // rather than the gesture system, so it doesn't steal the


### PR DESCRIPTION
The wash reaches every page, and v0.31.1 cuts it.

## The wash

It was drawn on three pages — the queue, an album, a playlist — and every other page was **opaque precisely to hide the one the window was already drawing behind it**. So the albums grid, the artist list, an artist's page, favourites, history and search results were flat grey rooms you passed through on the way back to a coloured one.

They give that ground up. `washSource` and `tintSource` were two properties computing nearly the same answer, so they collapse into one `colourSource`: a page about one record answers with it (an album with its sleeve, a playlist with the first of its records), everything else answers with what is playing. What the room is washed in and what the controls are tinted with can no longer disagree about which record you are looking at.

**Nothing new is drawn.** There is still exactly one `ArtworkBleed`, on the window, which is what `backgroundExtensionEffect` mirrors out under the sidebar and toolbar. The pages just stop covering it up, so this costs nothing at render time. `PageGround` is gone — every page is washed, so the property it switched on was always true.

Six lists were painting their own opaque ground over it. Three already gave it up with the same paragraph copied above each one; the reason is now named once as `washedGround()` next to the wash it is about, and the other three call it too. `TrackListView`'s `artwork == nil ? .visible : .hidden` was dead — its only call site is `AlbumDetailView`, which always passes a sleeve.

## Artist chips

Fallout from the above, caught in review. `ArtistPill` was `.glassEffect(.regular.interactive())`, and glass samples what is behind it and adapts its own luminance to stay legible against it. On a flat page ground every pill sampled the same colour and they all matched; over the wash they each answered to a different part of it, so a row read as a scatter of half-transparent ones rather than a set.

It is a plain `.quaternary` capsule now. Glass is right for something floating over content — the transport, the picker, the toast — and wrong for a chip sitting *in* it. This is the only content-level glass in the app; the rest is chrome and stays.

## Verifying

Built and driven through queue → albums → artists → favourites → history → search, playing something with a strongly coloured sleeve. The wash carries under the sidebar on each, fades down the page, and no page ghosts through the one before it — the thing `PageGround`'s opaque ground was guarding against. Album and playlist overrides are untouched: those branches of the switch are byte-identical to before.

`cargo clippy --workspace --all-targets -- -D warnings` and `cargo test --workspace` are running alongside CI.

No tags pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L2QYGXTN6dYC7MX5KNY8a5