### PR TITLE
chore(ci): the macOS app builds once, for Apple silicon

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -318,21 +318,25 @@ jobs:
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # stable
         with:
           toolchain: stable
-          targets: aarch64-apple-darwin,x86_64-apple-darwin
       - uses: Swatinem/rust-cache@63fed3e2fecf6f7b51dc6f043341b79ef82a9ae7 # v2.9.2
         with:
           key: macos-app
       - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
-      # Both slices, lipo'd into one static library, so the app runs on Intel
-      # and Apple silicon from a single download.
-      - run: just macos-ffi "aarch64-apple-darwin x86_64-apple-darwin"
-      - run: cd apps/macos && swift build -c release --arch arm64 --arch x86_64
       # Bundle, check, then package. `macos-verify` inspects the assembled
       # kōan.app, so it has to come after something that assembles one —
       # `macos-dmg` does that itself via `macos-bundle`, which put the check
       # before the thing it checks.
+      #
+      # `macos-bundle` builds what it needs, so nothing is asked for twice.
+      # The job used to run `macos-ffi` for both slices and a universal
+      # `swift build` itself, and then call `macos-bundle`, which re-entered
+      # `macos-ffi` with no targets — a third full optimised build of koan-ffi
+      # that overwrote the universal archive staged for SwiftPM and forced a
+      # single-arch relink on top of the universal build that had just
+      # finished. The app stayed universal only because the bundle step
+      # preferred a product left over from that earlier build.
       - run: just macos-bundle
-      - run: just macos-verify arm64 x86_64
+      - run: just macos-verify arm64
       - run: just macos-dmg
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Removed
+
+- **The macOS app is Apple silicon only.** It shipped as a universal binary, and the Intel slice was over half the release build: two cross compilations of the engine, lipo'd together, then a universal Swift build on top. That is a long time and a lot of a runner's disk — enough that the v0.31.1 release ran out of it partway through writing the disk image — to serve machines whose newest supported macOS is the app's minimum.
+
+  koan itself is unchanged on Intel: `koan` the terminal player still builds and ships for `x86_64-apple-darwin`, and an Intel Mac that wants koan can run that. It is the SwiftUI app, and only the app, that now needs Apple silicon.
+
 ## v0.31.1 (2026-08-25)
 
 ### Changed

--- a/justfile
+++ b/justfile
@@ -69,36 +69,29 @@ macos-icon:
     echo "built {{app_dir}}/Resources/AppIcon.icns"
 
 # Build the FFI static library and regenerate the Swift bindings.
-macos-ffi *TARGETS:
+#
+# One slice, for the machine doing the building. The app used to ship as a
+# universal binary: two cross builds, lipo'd together, which was most of the
+# release job's fifteen minutes and most of the disk it needed. `macos-verify`
+# is what holds this honest — it fails if the assembled app is not the
+# architecture asked for.
+macos-ffi:
     #!/usr/bin/env bash
     set -euo pipefail
     # Match what SwiftPM links against. Without it cargo builds for the host's
     # OS and every link is a page of "built for newer macOS version" warnings.
     export MACOSX_DEPLOYMENT_TARGET=26.0
-    targets="{{TARGETS}}"
-    if [ -z "$targets" ]; then
-        cargo build --release -p koan-ffi
-        lib=target/release/libkoan_ffi.a
-        dylib=target/release/libkoan_ffi.dylib
-    else
-        for t in $targets; do
-            cargo build --release -p koan-ffi --target "$t"
-        done
-        mkdir -p target/universal/release
-        lipo -create $(for t in $targets; do echo "target/$t/release/libkoan_ffi.a"; done) \
-             -output target/universal/release/libkoan_ffi.a
-        lib=target/universal/release/libkoan_ffi.a
-        dylib=target/$(echo $targets | cut -d' ' -f1)/release/libkoan_ffi.dylib
-    fi
+    cargo build --release -p koan-ffi
+    lib=target/release/libkoan_ffi.a
+    dylib=target/release/libkoan_ffi.dylib
     # Stage the archive somewhere holding nothing else, and link against that.
     #
     # `-lkoan_ffi` over a directory containing both a .a and a .dylib picks the
     # .dylib, and cargo leaves one next to the archive. The release DMG shipped
     # an app that referenced
     # `/Users/runner/work/koan/koan/target/release/deps/libkoan_ffi.dylib` and
-    # could not launch anywhere, and it was arm64-only because the host dylib
-    # won over the universal archive. A directory with one file in it cannot
-    # produce either outcome.
+    # could not launch anywhere. A directory with one file in it cannot produce
+    # that outcome.
     rm -rf target/swift-link
     mkdir -p target/swift-link
     cp "$lib" target/swift-link/libkoan_ffi.a
@@ -138,16 +131,7 @@ macos-bundle: macos-build
     app="{{app_dir}}/.build/pkg/kōan.app"
     rm -rf "$app"
     mkdir -p "$app/Contents/MacOS" "$app/Contents/Resources"
-    # A multi-arch `swift build --arch a --arch b` puts its lipo'd product under
-    # .build/apple/Products, and leaves .build/release pointing at a single
-    # slice — so copying the latter shipped an arm64-only app from a build that
-    # had just compiled x86_64 as well.
-    universal={{app_dir}}/.build/apple/Products/Release/Koan
-    if [ -f "$universal" ]; then
-        cp "$universal" "$app/Contents/MacOS/koan-app"
-    else
-        cp {{app_dir}}/.build/release/Koan "$app/Contents/MacOS/koan-app"
-    fi
+    cp {{app_dir}}/.build/release/Koan "$app/Contents/MacOS/koan-app"
     echo "app binary: $(lipo -archs "$app/Contents/MacOS/koan-app")"
     [ -f {{app_dir}}/Resources/AppIcon.icns ] && cp {{app_dir}}/Resources/AppIcon.icns "$app/Contents/Resources/" || true
     # The accent colour. macOS paints list selection, focus rings and controls


### PR DESCRIPTION
v0.31.1's release ran the runner out of disk writing its disk image. It passed on a retry, so this is the why rather than a fix for a broken release.

## The job was building the app three times

From v0.31.0's timings — 1130s total:

| step | time | |
|---|---|---|
| `macos-ffi "aarch64 x86_64"` | 910s | two cross builds |
| `swift build --arch arm64 --arch x86_64` | 62s | |
| `just macos-bundle` | 61s | **re-entered `macos-ffi` with no targets — a third full koan-ffi build, for the host** |
| `just macos-verify` | 1s | |
| `just macos-dmg` | 33s | re-entered the chain again, forcing a single-arch relink |

Three optimised builds of the engine on a runner with ~14 GB free, and then `hdiutil` wanting room for a read/write image plus the compressed copy it converts that into.

**It was also a latent correctness bug.** That third build overwrote `target/swift-link/libkoan_ffi.a` — the universal archive SwiftPM links against — with an arm64-only one, then forced a single-arch `swift build` over the universal build that had just finished. The app stayed universal only because `macos-bundle` preferred `.build/apple/Products/Release/Koan`, left over from the earlier step. Lose that file and the release quietly ships the host slice as though it were the app, which is the failure the justfile comments say already happened once.

## Dropping Intel removes the reason any of it existed

Intel Macs can run macOS 26, the app's minimum — it is the last release that supports them. Not worth over half the release build.

So there is one build, one product, and nothing to choose between: `macos-ffi` loses its `*TARGETS` parameter along with the lipo, and `macos-bundle` loses the fallback it used to guess with. The release job goes from four build steps to three. `macos-verify arm64` is what keeps it honest — it fails if the assembled app is not the architecture asked for, so a runner that was not Apple silicon would break the build rather than ship the wrong binary.

**The CLI is untouched.** `koan` still builds and ships `koan-macos-x86_64`, so an Intel Mac that wants koan can run the terminal player. Only the SwiftUI app needs Apple silicon now, and the changelog says so.

## Verifying

The release job only runs on a version bump, so CI here will not exercise it. Ran the exact sequence locally instead:

```
just macos-bundle && just macos-verify arm64 && just macos-dmg
→ app binary: arm64
→ app binary: [arm64], statically linked
→ built apps/macos/.build/pkg/Koan.dmg   (9.7 MB)
```

The `macOS App` job does cover the change — `justfile` is in the changes filter and that job runs `just macos-build`.

## Worth a separate decision

The CLI release matrix still builds `x86_64-apple-darwin`, and the Homebrew formula points at it. Dropping that would break `brew upgrade` for anyone on an Intel Mac, so it is left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L2QYGXTN6dYC7MX5KNY8a5