### PR TITLE
The queue keeps its place, and can be sent back to what's playing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- **The queue comes back to where you left it.** A trip to an album and back dropped you at the top of it again. The stage builds one page at a time, so leaving the queue destroyed it — and a macOS `List` cannot be put back: its scroll position belongs to AppKit's table, and every SwiftUI way of asking for one (`scrollPosition`, `scrollTo(y:)`, `scrollPosition(id:)`) is quietly inert on it. The queue is no longer torn down. It stays where it is, behind whatever you navigated to: invisible, untouchable, and off stage, which is also what stops the bars on the playing row dancing to an analyser nobody can see. The selection you left survives the trip too.
+
 ## v0.31.1 (2026-08-25)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- **A button that puts the queue back on the row that is playing.** Beside the layout picker, since both are about what you are looking at rather than what is in the queue. The row is centred rather than dropped at the top edge — what is playing is read against what comes after it. It runs the same path `g` and `G` do, and is disabled rather than hidden when nothing is playing.
+
 ### Fixed
 
 - **The queue comes back to where you left it.** A trip to an album and back dropped you at the top of it again. The stage builds one page at a time, so leaving the queue destroyed it — and a macOS `List` cannot be put back: its scroll position belongs to AppKit's table, and every SwiftUI way of asking for one (`scrollPosition`, `scrollTo(y:)`, `scrollPosition(id:)`) is quietly inert on it. The queue is no longer torn down. It stays where it is, behind whatever you navigated to: invisible, untouchable, and off stage, which is also what stops the bars on the playing row dancing to an analyser nobody can see. The selection you left survives the trip too.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,7 +171,7 @@ Swift bindings are generated, not checked in — `just macos-ffi` builds the lib
 | `Support/LibraryModel.swift` | Browse state. Albums/artists loaded once and filtered in memory; tracks never loaded wholesale. Follows the navigator; never moves it |
 | `Support/CoverArtCache.swift` | Album-keyed art cache: bytes once per record on disk, bitmaps per record and draw size in a bounded `NSCache`. Each miss is an HTTP round trip on remote libraries |
 | `Support/PlayingLevels.swift` | One analyser poller for every playing indicator on screen. Runs only while something is playing and something is watching |
-| `Views/QueueView.swift` | The main stage — album-grouped queue, drag reorder, multi-select |
+| `Views/QueueView.swift` | The main stage — album-grouped queue, drag reorder, multi-select. Never torn down: `StageView` keeps it mounted behind other pages, because a macOS `List` cannot be scrolled back to where it was |
 | `Views/PickerSheet.swift` | ⇧⌘K picker: multi-select, add / add-and-play / replace queue |
 | `Views/TransportBar.swift` | Transport, seek, format badge, output device |
 | `Views/LyricsPanel.swift` | Synced lyrics highlighted against position |

--- a/apps/macos/Sources/Koan/Support/Icons.swift
+++ b/apps/macos/Sources/Koan/Support/Icons.swift
@@ -31,6 +31,8 @@ enum Icon {
     static let album = "square.stack"
     static let artist = "music.mic"
     static let queueSection = "list.bullet"
+    /// Put the queue back on the row that is playing.
+    static let jumpToPlaying = "scope"
     static let history = "clock.arrow.circlepath"
     static let playlist = "music.note.list"
     static let search = "magnifyingglass"

--- a/apps/macos/Sources/Koan/Support/UIState.swift
+++ b/apps/macos/Sources/Koan/Support/UIState.swift
@@ -27,14 +27,15 @@ final class UIState {
     /// where the sidebar ends in order not to sit on it.
     var sidebarWidth: CGFloat = 0
 
-    enum Edge { case top, bottom }
+    /// Where the queue can be sent. Two ends and the row the music is on.
+    enum Jump { case top, bottom, playing }
 
     /// Counters, not booleans: pressing `g` twice has to jump twice, and a flag
     /// that is already true is not a change anything can observe.
     private(set) var searchFocusToken = 0
     private(set) var filterFocusToken = 0
     private(set) var queueJumpToken = 0
-    private(set) var queueJumpEdge = Edge.top
+    private(set) var queueJumpTarget = Jump.top
     /// Escape drops the selection wherever you are, so every list that has one
     /// watches this rather than each binding its own key and disagreeing about
     /// which of them the keystroke belonged to.
@@ -52,8 +53,8 @@ final class UIState {
 
     func selectAll() { selectAllToken += 1 }
 
-    func jumpQueue(to edge: Edge) {
-        queueJumpEdge = edge
+    func jumpQueue(to target: Jump) {
+        queueJumpTarget = target
         queueJumpToken += 1
     }
 

--- a/apps/macos/Sources/Koan/Support/UIState.swift
+++ b/apps/macos/Sources/Koan/Support/UIState.swift
@@ -5,10 +5,10 @@ import SwiftUI
 
 /// The bits of presentation a keystroke has to reach.
 ///
-/// Sheets, the search field and the queue's scroll position belong to views,
-/// but a hotkey arrives from outside all of them — so the flags live here,
-/// where the key monitor can set them and the view that owns the thing can
-/// watch. The menu bar drives the same flags, so both routes agree.
+/// Sheets and the search field belong to views, but a hotkey arrives from
+/// outside all of them — so the flags live here, where the key monitor can set
+/// them and the view that owns the thing can watch. The menu bar drives the
+/// same flags, so both routes agree.
 @MainActor
 @Observable
 final class UIState {
@@ -43,11 +43,6 @@ final class UIState {
     /// list knows what "everything" is. It lived on the player, so it only ever
     /// reached the queue.
     private(set) var selectAllToken = 0
-
-    /// Where the queue was left, so coming back to it is coming back rather
-    /// than starting again. The page is a `switch` in one view, so leaving the
-    /// queue destroys it and takes its scroll position with it.
-    var queueScrollY: CGFloat = 0
 
     func focusSearch() { searchFocusToken += 1 }
 

--- a/apps/macos/Sources/Koan/Views/PlayingIndicator.swift
+++ b/apps/macos/Sources/Koan/Views/PlayingIndicator.swift
@@ -13,6 +13,10 @@ struct PlayingIndicator: View {
 
     @Environment(PlayingLevels.self) private var levels
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    /// The queue stays mounted while you are elsewhere, so an indicator can be
+    /// off screen without ever disappearing. Off stage it stops asking the
+    /// analyser for levels and its timeline stops ticking.
+    @Environment(\.onStage) private var onStage
     @State private var watching = false
 
     private struct Bar {
@@ -40,7 +44,7 @@ struct PlayingIndicator: View {
 
     /// Whether there is anything to follow. Reduce Motion keeps the still bars,
     /// and still bars need no analyser.
-    private var live: Bool { isPlaying && !reduceMotion }
+    private var live: Bool { isPlaying && !reduceMotion && onStage }
 
     var body: some View {
         // At the rate the levels arrive, not the rate the display can manage.

--- a/apps/macos/Sources/Koan/Views/QueueView.swift
+++ b/apps/macos/Sources/Koan/Views/QueueView.swift
@@ -68,7 +68,7 @@ struct QueueView: View {
                     // to where you already are still has to scroll, because the
                     // list may have been moved since.
                     .onChange(of: ui.queueJumpToken) { _, _ in
-                        jump(to: ui.queueJumpEdge, using: scroll)
+                        jump(to: ui.queueJumpTarget, using: scroll)
                     }
                     // Double-click and context menu both come from the List, keyed
                     // on the rows under the pointer rather than on a gesture.
@@ -154,6 +154,16 @@ struct QueueView: View {
                 Button("Clear") { selection = [] }
                 Button("Remove", role: .destructive) { removeSelected() }
             }
+
+            // Beside the layout picker because both are about what you are
+            // looking at rather than what is in the queue. Disabled rather than
+            // hidden when nothing is playing: a control that comes and goes is
+            // one you have to look for.
+            Button { ui.jumpQueue(to: .playing) } label: {
+                Image(systemName: Icon.jumpToPlaying)
+            }
+            .disabled(player.currentItemId == nil)
+            .help("Scroll to what's playing")
 
             // Both modes shown with the active one lit, the way Finder switches
             // view. A single icon has to choose between naming the mode you are
@@ -349,10 +359,25 @@ struct QueueView: View {
     /// Scrolls only. The TUI's `g` moves a cursor because the cursor is how you
     /// look around there; here the pointer and the selection are separate things
     /// and moving the selection would throw away what you had picked.
-    private func jump(to edge: UIState.Edge, using scroll: ScrollViewProxy) {
-        guard let target = edge == .top ? rows.first?.id : rows.last?.id else { return }
+    ///
+    /// The playing row is centred rather than put at the top: what is playing
+    /// is read against what comes after it, and a row at the top edge has no
+    /// after.
+    private func jump(to target: UIState.Jump, using scroll: ScrollViewProxy) {
+        let row: String? = switch target {
+        case .top: rows.first?.id
+        case .bottom: rows.last?.id
+        // A track row's id *is* its queue item's, in either layout.
+        case .playing: player.currentItemId
+        }
+        guard let row else { return }
+        let anchor: UnitPoint = switch target {
+        case .top: .top
+        case .bottom: .bottom
+        case .playing: .center
+        }
         withAnimation(.easeOut(duration: 0.18)) {
-            scroll.scrollTo(target, anchor: edge == .top ? .top : .bottom)
+            scroll.scrollTo(row, anchor: anchor)
         }
     }
 

--- a/apps/macos/Sources/Koan/Views/QueueView.swift
+++ b/apps/macos/Sources/Koan/Views/QueueView.swift
@@ -15,6 +15,9 @@ struct QueueView: View {
     @Environment(\.openWindow) private var openWindow
     @Environment(UIState.self) private var ui
     @Environment(PlaylistsModel.self) private var playlists
+    /// The queue outlives the page you are on — see `StageView`. Anything
+    /// aimed at whatever list is in front of you has to check.
+    @Environment(\.onStage) private var onStage
 
 
     /// Grouped or one row per track. Persisted because it is a preference about
@@ -31,9 +34,6 @@ struct QueueView: View {
     /// is what made clicking here so unreliable. It is mirrored to the model on
     /// change instead: written, never read, so it stays out of the render path.
     @State private var selection: Set<String> = []
-
-    /// Bound so the list can be put back where it was left.
-    @State private var scrollPosition = ScrollPosition()
 
     /// Album headings are rows in their own right, not decoration attached to
     /// the first track. That is what lets an album be selected and dragged as a
@@ -63,19 +63,6 @@ struct QueueView: View {
                         .onMove(perform: move)
                     }
                     .listStyle(.inset)
-                    // The stage is one `switch`, so leaving the queue destroys
-                    // this view and its scroll position with it. Coming back
-                    // should be coming back, not starting again.
-                    .scrollPosition($scrollPosition)
-                    .onScrollGeometryChange(for: CGFloat.self) { geometry in
-                        geometry.contentOffset.y
-                    } action: { _, y in
-                        ui.queueScrollY = y
-                    }
-                    .onAppear {
-                        guard ui.queueScrollY > 0 else { return }
-                        scrollPosition.scrollTo(y: ui.queueScrollY)
-                    }
                     .washedGround()
                     // `g` / `G`. Watches the token rather than the edge: jumping
                     // to where you already are still has to scroll, because the
@@ -104,6 +91,7 @@ struct QueueView: View {
                         player.queueSelection = Set(itemIds(in: new))
                     }
                     .onChange(of: ui.selectAllToken) { _, _ in
+                        guard onStage else { return }
                         selection = Set(rows.map(\.id))
                     }
                     .clearsSelection($selection)

--- a/apps/macos/Sources/Koan/Views/RootView.swift
+++ b/apps/macos/Sources/Koan/Views/RootView.swift
@@ -312,10 +312,38 @@ private struct StageView: View {
     @Environment(LibraryModel.self) private var library
     @Environment(Navigator.self) private var nav
 
+    private var onQueue: Bool { nav.current == .section(.queue) }
+
+    /// The queue is never torn down; every other page is built when you arrive
+    /// and thrown away when you leave.
+    ///
+    /// That asymmetry buys the one thing a `List` cannot be given back: where it
+    /// was scrolled to. On macOS a `List` is AppKit's table, and every SwiftUI
+    /// way of asking one to go to an offset — `scrollPosition`, `scrollTo(y:)`,
+    /// `scrollPosition(id:)` — is inert on it, so a queue rebuilt on the way
+    /// back always starts at the top. Keeping it mounted means it never left.
+    ///
+    /// Off stage it is invisible, untouchable, unfocusable and told so, which
+    /// is what stops the row that is playing animating behind a page you are
+    /// actually looking at.
     var body: some View {
+        ZStack {
+            QueueView()
+                .opacity(onQueue ? 1 : 0)
+                .allowsHitTesting(onQueue)
+                .disabled(!onQueue)
+                .accessibilityHidden(!onQueue)
+                .environment(\.onStage, onQueue)
+
+            if !onQueue { page }
+        }
+    }
+
+    @ViewBuilder private var page: some View {
         switch nav.current {
         case .section(.queue):
-            QueueView()
+            // Kept alive above, and this is only reached when it is not showing.
+            EmptyView()
         case .section(.searchResults):
             SearchResultsView()
         case .section(.albums):
@@ -334,6 +362,13 @@ private struct StageView: View {
             ArtistDetailView(artistId: id)
         }
     }
+}
+
+extension EnvironmentValues {
+    /// Whether the page this view belongs to is the one on screen. False only
+    /// for the queue while you are somewhere else — see `StageView`. Anything
+    /// that animates or subscribes to keep itself current reads it.
+    @Entry var onStage = true
 }
 
 /// Engine errors are informational — a device disappearing shouldn't take a


### PR DESCRIPTION
Two things about where the queue is looking.

## The queue keeps its place

Leaving the queue for an album (or anywhere) and coming back put you at the top of it.

`QueueView` was already recording its scroll offset into `UIState` and reapplying it in `onAppear`. Neither half functioned:

- The fresh `List`'s own first layout reported offset `0` through `onScrollGeometryChange`, overwriting the saved offset before anything read it.
- More fundamentally, **a macOS `List` cannot be scrolled to an offset from SwiftUI at all.** It is AppKit's table. I checked each API in a standalone harness: `ScrollPosition.scrollTo(y:)` does nothing, `scrollPosition(id:)` reports `nil`, `onScrollTargetVisibilityChange` reports nothing. Only reading the offset and `ScrollViewReader.scrollTo(id:)` work — enough to save a position, not enough to restore one. (A plain `ScrollView` restores by offset fine; `List` does not.)

So the queue is never destroyed. `StageView` keeps it mounted behind whatever you navigated to, and there is nothing to restore because it never left. Every other page is still built on arrival and thrown away on departure.

Being mounted but off screen has to mean something, so `\.onStage` carries it: the hidden queue gets no hit testing, no keyboard, is hidden from accessibility, ignores ⌘A, and its playing indicator pauses its timeline and drops its analyser subscription. A row that is playing should not be animating behind a page you are actually looking at.

Selection survives the trip too, which is the same idea: coming back is coming back.

## A button to go to what's playing

In the header beside the layout picker — both are about what you are looking at rather than what is in the queue. It increments the same jump token `g` and `G` use rather than growing a second path to move the queue, so that token's destination gained a `.playing` case. The row is centred, not put at the top edge: what is playing is read against what comes after it.

## Verifying

- `just macos-run`, scroll down the queue, open an album, come back — you are where you were. Back/forward, the sidebar and the hotkeys are all the same path.
- While on another page, ⌘A should select that page's contents and not also the queue's; the analyser poller should be idle if nothing else on screen is watching it.
- The button: scroll away from the playing row, press it, the row lands centred. Greyed out with an empty queue or nothing playing.
- Harness result behind the claim above: a mounted list holds its offset exactly across a page change (`4994 → 4994`, one `onAppear`); the same list rebuilt comes back at `0`.

Keep-alive is the queue only, deliberately — it is the page you leave and return to constantly. Playlists and the browsers still start at the top, and the `ScrollView`-backed pages (albums grid, search results) could take offset restore later if it turns out to matter.