### PR TITLE
A graphics level, ordered by what each step was measured to cost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- **A graphics level, in Settings -> Appearance.** One slider from `Plain` to `Full`, so koan can be told how much of the machine it may spend on looking like itself. `Full` is what it has always done and stays the default.
+
+  | | Wash | Indicators | Chrome |
+  |---|---|---|---|
+  | `Full` | drifts | dance | glass |
+  | `Reduced` | held still | dance | glass |
+  | `Plain` | none | held still | flat materials |
+
+  The steps are ordered by what they were measured to cost rather than by how much they look like they cost. On an M1 Pro, playing, window frontmost: `Full` is 15-18% of a core, `Reduced` around 9%, `Plain` around 6%.
+
+  `Reduced` is where it is because of what the wash's cost actually is. The blur is rasterised once at 360 points and magnified as a texture, so it is close to free -- what is expensive is the *drift*: three animations of incommensurate period running forever on scale, rotation and offset, which is the only thing making the wash's composited output differ frame to frame, so the copy mirrored out under the sidebar and toolbar and the glass sampling it are redone for as long as the music runs. Held still, the wash measures the same as no wash at all. The record's colour is free; only the breathing is billed.
+
+  Below that, `Plain` is for machines where drawing a blurred backdrop is dear at all. Most of what it saves over `Reduced` is the playing indicators standing still, which stops a 30fps timeline and the analyser poll behind it. It also swaps the glass chrome for flat materials, which measured about a point of a core on top -- close enough to the noise floor that it is there on the reasoning rather than on the evidence, for GPUs and display sizes unlike this one.
+
+  The setting lives in macOS defaults (`defaults write cc.blit.koan graphics -int 0`) rather than `config.toml`: how much this app draws is this machine's business, and the TUI has none of it to draw.
+
+- **The wash honours Reduce Motion.** It never did. The playing indicators already went still when the system asked for less motion and the room behind them kept breathing.
+
 ## v0.31.2 (2026-08-25)
 
 ### Changed

--- a/apps/macos/Sources/Koan/Support/Graphics.swift
+++ b/apps/macos/Sources/Koan/Support/Graphics.swift
@@ -1,0 +1,97 @@
+import SwiftUI
+
+/// How much koan draws.
+///
+/// One knob rather than a switch per effect, because there is only one thing to
+/// decide: how much of the machine the app may spend on looking like itself.
+///
+/// The steps are ordered by what they were measured to cost, not by how much
+/// they look like they cost. On an M1 Pro, playing, window frontmost, mean over
+/// thirty seconds:
+///
+///     full      koan-app 15-18%    the wash drifting
+///     reduced   koan-app     8%    the wash held still
+///     plain     koan-app     8%    no wash at all
+///
+/// Which is why `reduced` sits where it does. The wash's blur is rasterised
+/// once at 360 points and magnified as a texture, so holding it still costs the
+/// same as not drawing it: the record's colour is free, and only the motion is
+/// billed. Everything `full` adds over `reduced` is motion, and it is the only
+/// step of the three that shows up in a measurement on this machine.
+///
+/// `plain` is underneath that for machines where drawing a blurred backdrop is
+/// dear at all — an older GPU, or a large external display, where none of the
+/// numbers above are the ones that matter. It is the only step that stands the
+/// glass down, and it does so on that reasoning rather than on evidence from
+/// here: held still, glass costs nothing measurable on an M1 Pro.
+enum Graphics: Int, CaseIterable, Identifiable {
+    /// No wash, still indicators, flat chrome. The cheapest koan gets.
+    case plain = 0
+    /// The record's colour behind the window, held still. Everything else as it
+    /// is.
+    case reduced = 1
+    /// The wash drifts, the bars dance, the chrome is glass.
+    case full = 2
+
+    var id: Self { self }
+
+    var label: String {
+        switch self {
+        case .plain: "Plain"
+        case .reduced: "Reduced"
+        case .full: "Full"
+        }
+    }
+
+    /// What the setting says about itself, under the slider.
+    var detail: String {
+        switch self {
+        case .plain:
+            "No colour behind the window, indicators held still, flat chrome instead of glass. For a machine that would rather spend nothing on this."
+        case .reduced:
+            "The record's colour behind the window, held still — which measures the same as no colour at all. Only the drift is expensive."
+        case .full:
+            "The colour drifts while something is playing. Around a tenth of a core more than the other two, for as long as the music runs."
+        }
+    }
+
+    /// Whether the wash is drawn at all.
+    var showsWash: Bool { self != .plain }
+
+    /// Whether the wash drifts while something is playing.
+    var drifts: Bool { self == .full }
+
+    /// Whether the playing indicators dance. Off, they keep their shape and
+    /// stop asking the analyser for levels.
+    var animatesIndicators: Bool { self != .plain }
+
+    /// Whether the chrome is glass rather than a flat material.
+    var usesGlass: Bool { self != .plain }
+}
+
+/// Glass where the machine can afford it, a flat material where it cannot.
+///
+/// The fallback is per site rather than derived: `.clear` glass over artwork and
+/// `.regular` glass under a transport bar are not the same thing standing in
+/// for the same thing, and only the call site knows what the shape is holding.
+private struct AffordableGlass<S: Shape, F: ShapeStyle>: ViewModifier {
+    let glass: Glass
+    let fallback: F
+    let shape: S
+
+    @AppStorage("graphics") private var graphics = Graphics.full
+
+    func body(content: Content) -> some View {
+        if graphics.usesGlass {
+            content.glassEffect(glass, in: shape)
+        } else {
+            content.background(fallback, in: shape)
+        }
+    }
+}
+
+extension View {
+    func glass(_ glass: Glass, fallback: some ShapeStyle, in shape: some Shape) -> some View {
+        modifier(AffordableGlass(glass: glass, fallback: fallback, shape: shape))
+    }
+}

--- a/apps/macos/Sources/Koan/Views/AlbumGridCell.swift
+++ b/apps/macos/Sources/Koan/Views/AlbumGridCell.swift
@@ -33,7 +33,7 @@ struct AlbumGridCell: View {
                             // Clear glass, not a black scrim: over artwork the
                             // point is to stay readable without hiding the
                             // corner of the cover it sits on.
-                            .glassEffect(.clear, in: .capsule)
+                            .glass(.clear, fallback: .ultraThinMaterial, in: .capsule)
                             .padding(6)
                     }
                 }
@@ -51,7 +51,7 @@ struct AlbumGridCell: View {
                             library.toggleFavourite(album: album.id)
                         }
                         .padding(7)
-                        .glassEffect(.clear.interactive(), in: .circle)
+                        .glass(.clear.interactive(), fallback: .ultraThinMaterial, in: .circle)
                         .glassEffectTransition(.materialize)
                         .padding(7)
                     }

--- a/apps/macos/Sources/Koan/Views/ArtworkBleed.swift
+++ b/apps/macos/Sources/Koan/Views/ArtworkBleed.swift
@@ -19,11 +19,13 @@ struct ArtworkBleed: View {
     /// Nothing playing, or a record with no art, means no wash rather than a
     /// grey one.
     let source: AlbumArtwork.Source?
-    /// Whether the wash drifts. The room breathes while something is playing
-    /// and settles when it stops.
+    /// Whether there is anything to breathe to. The room breathes while
+    /// something is playing and settles when it stops.
     var drifts = false
 
     @Environment(CoverArtCache.self) private var cache
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @AppStorage("graphics") private var graphics = Graphics.full
     /// Held rather than drawn through `AlbumArtwork`, which shows a placeholder
     /// while it loads. Over a five second dissolve that placeholder is a long
     /// grey wipe between two records, so the old cover stays up until the new
@@ -43,16 +45,28 @@ struct ArtworkBleed: View {
     /// fraction of blurring one the width of the window.
     private static let side: CGFloat = 360
 
+    /// Whether the wash is actually moving: something to breathe to, a setting
+    /// that allows it, and a system that has not asked for less motion.
+    private var breathes: Bool { drifts && graphics.drifts && !reduceMotion }
+
     /// Three incommensurate periods, so the drift never arrives back where it
     /// started and never reads as a loop. Settling is a plain ease: playback
     /// stopping should let the room come to rest, not stop it mid-breath.
     private func drift(_ period: Double) -> Animation {
-        drifts
+        breathes
             ? .easeInOut(duration: period).repeatForever(autoreverses: true)
             : .easeInOut(duration: 2)
     }
 
     var body: some View {
+        // Below `reduced` this is nothing at all rather than a transparent
+        // wash: no cover fetched, no blur, no mirrored copy under the glass.
+        if graphics.showsWash {
+            bleed
+        }
+    }
+
+    private var bleed: some View {
         GeometryReader { geo in
             // The transforms live on this container rather than on the image,
             // so a record change swaps what is inside without interrupting the
@@ -110,8 +124,8 @@ struct ArtworkBleed: View {
         // the room has changed colour without ever catching it changing.
         .animation(.easeInOut(duration: 2), value: generation)
         .task(id: source) { await load() }
-        .onAppear { drifted = drifts }
-        .onChange(of: drifts) { _, now in drifted = now }
+        .onAppear { drifted = breathes }
+        .onChange(of: breathes) { _, now in drifted = now }
     }
 
     private func load() async {

--- a/apps/macos/Sources/Koan/Views/PickerSheet.swift
+++ b/apps/macos/Sources/Koan/Views/PickerSheet.swift
@@ -159,7 +159,7 @@ struct PickerSheet: View {
         .disabled(resolving || (picked.isEmpty && highlighted == nil))
         .padding(.horizontal, 14)
         .padding(.vertical, 10)
-        .glassEffect(.regular, in: .rect(cornerRadius: 20))
+        .glass(.regular, fallback: .regularMaterial, in: .rect(cornerRadius: 20))
         .padding(.horizontal, 12)
         .padding(.bottom, 12)
     }

--- a/apps/macos/Sources/Koan/Views/PlayingIndicator.swift
+++ b/apps/macos/Sources/Koan/Views/PlayingIndicator.swift
@@ -17,6 +17,7 @@ struct PlayingIndicator: View {
     /// off screen without ever disappearing. Off stage it stops asking the
     /// analyser for levels and its timeline stops ticking.
     @Environment(\.onStage) private var onStage
+    @AppStorage("graphics") private var graphics = Graphics.full
     @State private var watching = false
 
     private struct Bar {
@@ -42,9 +43,13 @@ struct PlayingIndicator: View {
     private static let width =
         Double(bars.count) * barWidth + Double(bars.count - 1) * spacing
 
-    /// Whether there is anything to follow. Reduce Motion keeps the still bars,
-    /// and still bars need no analyser.
-    private var live: Bool { isPlaying && !reduceMotion && onStage }
+    /// Whether the bars hold their shape instead of dancing. Reduce Motion asks
+    /// for it, and so does the bottom of the graphics ladder.
+    private var still: Bool { reduceMotion || !graphics.animatesIndicators }
+
+    /// Whether there is anything to follow. Still bars need no analyser, so
+    /// this is also what decides whether anything polls it.
+    private var live: Bool { isPlaying && !still && onStage }
 
     var body: some View {
         // At the rate the levels arrive, not the rate the display can manage.
@@ -91,7 +96,7 @@ struct PlayingIndicator: View {
     }
 
     private func height(of bar: Bar, band: Int, at now: Double) -> Double {
-        guard !reduceMotion else {
+        guard !still else {
             return Self.minHeight + bar.rest * (Self.maxHeight - Self.minHeight)
         }
         // Two frequencies with an irrational ratio: the bars never fall back

--- a/apps/macos/Sources/Koan/Views/RootView.swift
+++ b/apps/macos/Sources/Koan/Views/RootView.swift
@@ -394,7 +394,11 @@ private struct ErrorToast: View {
         .padding(.vertical, 11)
         // Tinted glass rather than a material and a border: the tint carries
         // the warning without a second colour, and glass already has an edge.
-        .glassEffect(.regular.tint(.orange.opacity(0.22)), in: .capsule)
+        .glass(
+            .regular.tint(.orange.opacity(0.22)),
+            fallback: .orange.opacity(0.22),
+            in: .capsule
+        )
         .task {
             try? await Task.sleep(for: .seconds(6))
             dismiss()

--- a/apps/macos/Sources/Koan/Views/SettingsView.swift
+++ b/apps/macos/Sources/Koan/Views/SettingsView.swift
@@ -28,6 +28,8 @@ struct SettingsView: View {
                         .tabItem { Label("Playback", systemImage: "hifispeaker") }
                     RadioSettings(model: model)
                         .tabItem { Label("Radio", systemImage: "dot.radiowaves.left.and.right") }
+                    AppearanceSettings()
+                        .tabItem { Label("Appearance", systemImage: "paintpalette") }
                 }
                 .safeAreaInset(edge: .bottom) { StatusLine(model: model) }
             } else {
@@ -375,6 +377,48 @@ private struct PlaybackSettings: View {
                 Text("Loudness")
             } footer: {
                 Text("Applies the gain written into the file's tags. Per album keeps the relative loudness within a record.")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .formStyle(.grouped)
+    }
+}
+
+// MARK: - Appearance
+
+/// Not part of `config.toml`. How much the app draws is this machine's
+/// business, and the TUI has none of it to draw, so it sits in defaults beside
+/// the other view state rather than in the file the CLI shares.
+private struct AppearanceSettings: View {
+    @AppStorage("graphics") private var graphics = Graphics.full
+
+    var body: some View {
+        Form {
+            Section {
+                Slider(
+                    value: Binding(
+                        get: { Double(graphics.rawValue) },
+                        set: { graphics = Graphics(rawValue: Int($0.rounded())) ?? .full }
+                    ),
+                    in: 0...Double(Graphics.allCases.count - 1),
+                    step: 1
+                ) {
+                    Text("Level")
+                } minimumValueLabel: {
+                    Text("Plain").font(.caption)
+                } maximumValueLabel: {
+                    Text("Full").font(.caption)
+                }
+                Text("**\(graphics.label)** — \(graphics.detail)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            } header: {
+                Text("Graphics")
+            } footer: {
+                Text("How much koan spends on looking like itself. Every step down removes something that costs while the music plays — the colour drifting behind the window first, since on this machine it is the only one that shows up in a measurement.")
                     .font(.caption)
                     .foregroundStyle(.tertiary)
             }

--- a/apps/macos/Sources/Koan/Views/ShortcutsSheet.swift
+++ b/apps/macos/Sources/Koan/Views/ShortcutsSheet.swift
@@ -86,7 +86,7 @@ struct ShortcutsSheet: View {
                         .font(.caption.monospaced())
                         .padding(.horizontal, 6)
                         .padding(.vertical, 3)
-                        .glassEffect(.regular, in: .rect(cornerRadius: 6))
+                        .glass(.regular, fallback: .quaternary, in: .rect(cornerRadius: 6))
                 }
             }
             Text(label)

--- a/apps/macos/Sources/Koan/Views/TransportBar.swift
+++ b/apps/macos/Sources/Koan/Views/TransportBar.swift
@@ -51,7 +51,7 @@ struct TransportBar: View {
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 9)
-        .glassEffect(.regular, in: .rect(cornerRadius: Self.radius))
+        .glass(.regular, fallback: .regularMaterial, in: .rect(cornerRadius: Self.radius))
         .padding(.horizontal, 16)
         .padding(.bottom, 14)
     }

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -39,6 +39,31 @@ a local copy would silently do nothing. In the other direction it drains
 machine-scoped keys out of the file you commit, which is how a `config.toml`
 polluted by an older koan cleans itself up as you use the app.
 
+## What is not in the config files
+
+The macOS app's own view state -- whether the lyrics panel is open, whether the
+queue is grouped, how much the app draws -- lives in macOS defaults
+(`defaults read cc.blit.koan`), not in `config.toml`. None of it means anything
+to the CLI or the TUI, and a setting that travels between machines in a
+committed dotfile should be one that makes sense on all of them.
+
+The graphics level is the one worth knowing about. Settings -> Appearance, or:
+
+```bash
+defaults write cc.blit.koan graphics -int 0   # 0 plain, 1 reduced, 2 full
+```
+
+| | Wash | Indicators | Chrome | Cost |
+|---|---|---|---|---|
+| `2` Full (default) | drifts | dance | glass | 15-18% of a core |
+| `1` Reduced | held still | dance | glass | ~9% |
+| `0` Plain | none | held still | flat materials | ~6% |
+
+Measured on an M1 Pro, playing, window frontmost. The wash's blur is close to
+free -- it is rasterised once and magnified as a texture -- so holding it still
+costs about what not drawing it costs. It is the drift that is expensive, which
+is why `Reduced` keeps the record's colour and only stops it moving.
+
 ## Environment variable overrides
 
 Any config field can be overridden via environment variables using the `KOAN_` prefix with `__` (double underscore) as the section separator:


### PR DESCRIPTION
One slider in Settings → Appearance, from `Plain` to `Full`, so koan can be told how much of the machine it may spend on looking like itself. `Full` is what it does today and stays the default, so nobody's app changes unless they move the slider.

|  | Wash | Indicators | Chrome |
|---|---|---|---|
| **Full** (default) | drifts | dance | glass |
| **Reduced** | held still | dance | glass |
| **Plain** | none | held still | flat materials |

## Why the steps are where they are

Measured before designing, not after. M1 Pro, playing, window frontmost, mean CPU of `koan-app` over 30s:

| | |
|---|---|
| Full | 15–18% of a core |
| Reduced | ~9% |
| Plain | ~6% |

**The wash's blur is close to free.** It is rasterised once at 360pt and magnified as a texture — that was already true before this PR. What costs is the *drift*: three `repeatForever` animations of incommensurate period (13s, 19s, 23s) on scale, rotation and offset. That motion is the only thing making the wash's composited output differ frame to frame, so the copy `backgroundExtensionEffect` mirrors out under the sidebar and toolbar, and the glass sampling it, get redone for as long as the music runs.

Held still, the wash measures the same as no wash at all. **That is the whole argument for a middle step rather than an on/off switch** — the record's colour is free, and only the breathing is billed.

**`Plain` is the least evidenced step and I want that on the record.** Most of what it saves over `Reduced` is the playing indicators standing still, which stops a 30fps `TimelineView` and the analyser poll behind it — that part is real. It also swaps glass for flat materials, and a probe build (`usesGlass` forced true, everything else at Plain) put that at about **one point of a core**, which is close enough to the noise floor that it is in on reasoning rather than evidence: for older GPUs and larger displays than the one I measured on. If you'd rather `Plain` kept its glass, that's a one-line change to `Graphics.usesGlass`.

## What to look at

- **`Support/Graphics.swift`** — the whole ladder. Three cases, four booleans, and one `glass(_:fallback:in:)` modifier every glass site now routes through.
- **The fallback is per call site, not derived.** `.clear` glass over a codec badge and `.regular` glass under the transport bar aren't standing in for the same thing, and only the call site knows what its shape is holding. Hence `fallback:` at each of the six sites — `.ultraThinMaterial` over artwork, `.regularMaterial` under chrome, and the toast keeps its orange because a warning with no colour in it says nothing.
- **`ArtworkBleed`** — `Plain` returns no view at all rather than a transparent one: no cover fetched, no blur, no mirrored copy.

## Also fixed

**The wash never honoured Reduce Motion.** `PlayingIndicator` did; the room behind it kept breathing. Both now go still.

## Confirming it works

Set the level and watch `koan-app` in Activity Monitor with something playing — the three steps are distinct and monotonic. Or:

```bash
defaults write cc.blit.koan graphics -int 0   # 0 plain, 1 reduced, 2 full
```

Not in `config.toml`, deliberately — it sits in macOS defaults beside `showLyrics` and `queueGrouped`. How much this app draws is this machine's business, and the TUI has none of it to draw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WWgTMd5afjFTgg9hjZvVsQ
