### PR TITLE
The wash drifts far enough to see

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@
 
   The setting lives in macOS defaults (`defaults write cc.blit.koan graphics -int 0`) rather than `config.toml`: how much this app draws is this machine's business, and the TUI has none of it to draw.
 
+### Fixed
+
+- **The wash's drift is far enough to see.** It has moved by the same amounts since it landed in #330, and those amounts were too small to register: blurred at 14 points and magnified about five times, the wash has no feature on screen narrower than eighty points, and the drift carried it about one and a half of those over twenty-three seconds. Slow movement that small does not read as movement -- it reads as a still image. The thing was running, and costing six to nine percent of a core to run, and there was nothing to see.
+
+  The excursions now reach about four of those instead: 12% of the window sideways against 4%, 10% down against 6%, and the scale swinging 1.38 to 1.58 rather than 1.19 to 1.31. The periods are untouched at 13, 19 and 23 seconds, so it is exactly as unhurried as it was -- it simply arrives somewhere.
+
+  The wider scale is not decoration. It is the floor that keeps the texture's own edge out of frame once the offset carries it 12% of the window sideways and the rotation eats another three and a half percent. The scale is also taken off the longer edge of the window now rather than its width: the texture is square, so on a window taller than it is wide the width alone never covered it.
+
 - **The wash honours Reduce Motion.** It never did. The playing indicators already went still when the system asked for less motion and the room behind them kept breathing.
 
 ## v0.31.2 (2026-08-25)

--- a/apps/macos/Sources/Koan/Views/ArtworkBleed.swift
+++ b/apps/macos/Sources/Koan/Views/ArtworkBleed.swift
@@ -45,6 +45,29 @@ struct ArtworkBleed: View {
     /// fraction of blurring one the width of the window.
     private static let side: CGFloat = 360
 
+    /// How far the drift travels, and the overscan that lets it.
+    ///
+    /// What decides whether motion is visible here is not its speed but how far
+    /// it goes against how soft the thing moving is. Blurred at 14 points and
+    /// magnified about five times, the wash has no feature narrower than eighty
+    /// points on screen — so travel has to be read in multiples of that, not in
+    /// points. The excursion this file shipped with moved it about one and a
+    /// half of those over twenty-three seconds, which is below the threshold at
+    /// which slow movement registers at all: it was running, and costing, and
+    /// nobody ever saw it.
+    ///
+    /// These reach about four. Same periods, same easing, same unhurried thing
+    /// — it simply arrives somewhere.
+    ///
+    /// `near` is a floor, not a taste: at full reach the offset carries the
+    /// texture 12% of the window sideways and the rotation eats about another
+    /// 3.5%, and the scale has to be wide enough that its edge stays out of
+    /// frame throughout.
+    private static let near: CGFloat = 1.38
+    private static let far: CGFloat = 1.58
+    private static let reach: CGFloat = 0.12
+    private static let rise: CGFloat = 0.10
+
     /// Whether the wash is actually moving: something to breathe to, a setting
     /// that allows it, and a system that has not asked for less motion.
     private var breathes: Bool { drifts && graphics.drifts && !reduceMotion }
@@ -98,13 +121,21 @@ struct ArtworkBleed: View {
             // twenty times a second was a quarter of a core with nothing
             // happening. These hand the interpolation to CoreAnimation, which
             // runs them off the main thread and smoother for it.
-            .scaleEffect(geo.size.width / Self.side * (drifted ? 1.31 : 1.19))
+            //
+            // Scaled off the longer edge rather than the width. The texture is
+            // square, so on a window taller than it is wide the width alone
+            // does not cover it, and the excursions below would swing the
+            // texture's own edge into frame.
+            .scaleEffect(
+                max(geo.size.width, geo.size.height) / Self.side
+                    * (drifted ? Self.far : Self.near)
+            )
             .animation(drift(13), value: drifted)
             .rotationEffect(.degrees(drifted ? 3 : -3))
             .animation(drift(19), value: drifted)
             .offset(
-                x: geo.size.width * (drifted ? 0.04 : -0.04),
-                y: geo.size.height * (drifted ? -0.06 : 0.06)
+                x: geo.size.width * (drifted ? Self.reach : -Self.reach),
+                y: geo.size.height * (drifted ? -Self.rise : Self.rise)
             )
             .animation(drift(23), value: drifted)
             .frame(width: geo.size.width, height: geo.size.height)


### PR DESCRIPTION
The drift has moved by exactly these amounts since it landed in #330, and I traced every version of the file to be sure: `941a8a4` had a wash with no drift, `3a71f10` added it with `1.19→1.31`, `±3°`, `±4%/±6%`, and nothing has touched a transform since. #338 added `drawingGroup()` and comments only.

So it was never a regression. It was never visible in the first place.

## Why it wasn't visible

What decides whether slow motion registers is not its speed but **how far it goes against how soft the thing moving is.**

Blurred at 14pt and magnified ~5×, the wash has no feature on screen narrower than about **80pt**. The drift carried it ~110pt — one and a half feature-widths — spread over 23 seconds. That is below the threshold where slow movement reads as movement at all; with no reference edge in a featureless gradient, it reads as a still image. Meanwhile it cost 6–9% of a core for as long as the music ran.

## What changed

| | Before | After |
|---|---|---|
| offset x | ±4% | **±12%** |
| offset y | ±6% | **±10%** |
| scale | 1.19 → 1.31 | **1.38 → 1.58** |
| rotation | ±3° | ±3° (unchanged) |
| periods | 13 / 19 / 23s | unchanged |

About four feature-widths of travel instead of one and a half. **The periods are untouched** — it is exactly as unhurried as it was, it simply arrives somewhere.

## The scale is a floor, not a taste

At full reach the offset carries the texture 12% of the window sideways and the 3° rotation eats ~3.5% more, and the scale has to be wide enough that the texture's own edge never swings into frame. The worst case is full offset at *minimum* scale — offset and scale are on 23s and 13s, so that combination does come around.

On a 1594×1058 window: 1100pt texture half-side against a 797pt half-width leaves 303pt of headroom, against 191pt offset + 58pt rotation = 249pt. **54pt of margin** horizontally, 407pt vertically. Square and tall-narrow windows check out too.

**The scale is also taken off the longer edge now rather than the width.** The texture is square, so a window taller than it is wide was never covered by the width alone — at 700×1200 the old expression put the texture's edge inside the frame before any drift at all. That was a latent bug independent of this change.

## Checking it

Only `full` drifts, so the other two levels are untouched. Play something on Full and watch the colour behind the top of the window over ~20s — the point is that you can now tell it moved without being able to catch it moving.

I could not get playback to stay up under AppleScript long enough to capture a before/after pair, so **the geometry here is verified on paper and the motion is not verified by eye.** That part wants yours — it is a taste call about how much is too much, and the constants are four lines if it overshoots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WWgTMd5afjFTgg9hjZvVsQ
