### PR TITLE
refactor(macos): the library is queried, not copied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,16 @@
 
 - **The wash honours Reduce Motion.** It never did. The playing indicators already went still when the system asked for less motion and the room behind them kept breathing.
 
+### Changed
+
+- **The macOS app queries the library instead of copying it.** It used to load every album and every artist at launch, narrow those copies in Swift and index them so search could resolve ids against them -- three shapes of the same five thousand rows, held to serve views that read none of them directly. Now each section holds only the page it is showing and asks for the next one as you scroll. Narrowing, sorting and paging all happen in SQL.
+
+  The bugs this closes are the ones that came from the copy existing: a section showing a library the database no longer has, and a cold launch showing an empty one because the load lived somewhere the second window never reached. There is no load to have forgotten to do.
+
+  `AlbumSort::Random` now takes a seed. A shuffled listing read a page at a time has to agree with itself across pages, or scrolling repeats records and drops others; the seed fixes one shuffle, and the reshuffle button asks for a new one.
+
+- **`koan-core` narrows, orders and pages albums and artists itself.** `list_albums` and `list_artists` take a search term, an order, a favourites-only flag and a limit/offset, replacing the several near-identical queries that answered one shape of the question each. Play history and favourite tracks take a search term too, and fuzzy album and artist search hands back rows rather than ids for a caller to resolve.
+
 ## v0.31.2 (2026-08-25)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,13 +24,17 @@
 
 ### Changed
 
-- **The macOS app queries the library instead of copying it.** It used to load every album and every artist at launch, narrow those copies in Swift and index them so search could resolve ids against them -- three shapes of the same five thousand rows, held to serve views that read none of them directly. Now each section holds only the page it is showing and asks for the next one as you scroll. Narrowing, sorting and paging all happen in SQL.
+- **The macOS app queries the library instead of copying it.** It used to load every album and every artist at launch, narrow those copies in Swift and index them so search could resolve ids against them -- three shapes of the same five thousand rows, held to serve views that read none of them directly. Now a section asks the engine what it should be showing and shows exactly that; narrowing and sorting happen in SQL.
+
+  Nothing is paged. This is an in-process call rather than a wire, so a listing arrives whole: the scrollbar tells the truth about how long the library is, and one flick reaches the end of it.
 
   The bugs this closes are the ones that came from the copy existing: a section showing a library the database no longer has, and a cold launch showing an empty one because the load lived somewhere the second window never reached. There is no load to have forgotten to do.
 
-  `AlbumSort::Random` now takes a seed. A shuffled listing read a page at a time has to agree with itself across pages, or scrolling repeats records and drops others; the seed fixes one shuffle, and the reshuffle button asks for a new one.
+  `AlbumSort::Random` now takes a seed, so narrowing a shuffled listing narrows the shuffle you are looking at instead of dealing a new one on every keystroke. A new seed is a new shuffle, which is what the reshuffle button asks for.
 
-- **`koan-core` narrows, orders and pages albums and artists itself.** `list_albums` and `list_artists` take a search term, an order, a favourites-only flag and a limit/offset, replacing the several near-identical queries that answered one shape of the question each. Play history and favourite tracks take a search term too, and fuzzy album and artist search hands back rows rather than ids for a caller to resolve.
+- **The engine says when the library changed.** A new `LibraryChanged` event rides the same channel as `QueueChanged` and `DownloadsChanged`, raised by anything that writes library rows -- scan, sync, import, organize, forget, rebuild -- including the automatic sync and the watched-folder scan that nothing was announcing at all. A background scan finishing now reaches the browser the same way one you asked for does, and the app no longer refreshes itself by guessing from whatever it happened to start.
+
+- **`koan-core` narrows and orders albums and artists itself.** `list_albums` and `list_artists` take a search term, an order, a favourites-only flag and an optional limit, replacing the several near-identical queries that answered one shape of the question each. Play history and favourite tracks take a search term too, and fuzzy album and artist search hands back rows rather than ids for a caller to resolve.
 
 ## v0.31.2 (2026-08-25)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,7 +165,7 @@ Swift bindings are generated, not checked in — `just macos-ffi` builds the lib
 | `Support/SettingsModel.swift` | Settings state over `config.toml`. Commits on edit, re-reads on focus |
 | `Support/PlayerModel.swift` | Polls `now_playing()` at 10 Hz; refetches the queue only when `playlistVersion` moves |
 | `Support/Navigator.swift` | Where the app is: one page, the linear history of pages visited, and a cursor. No `NavigationStack` — koan navigates like a browser, any page from any page |
-| `Support/LibraryModel.swift` | Browse state. Albums/artists loaded once and filtered in memory; tracks never loaded wholesale. Follows the navigator; never moves it |
+| `Support/LibraryModel.swift` | Browse state. Holds the page a section is showing, nothing more — narrowing, sorting and paging all happen in SQL. Follows the navigator; never moves it |
 | `Support/CoverArtCache.swift` | Album-keyed art cache: bytes once per record on disk, bitmaps per record and draw size in a bounded `NSCache`. Each miss is an HTTP round trip on remote libraries |
 | `Support/PlayingLevels.swift` | One analyser poller for every playing indicator on screen. Runs only while something is playing and something is watching |
 | `Views/QueueView.swift` | The main stage — album-grouped queue, drag reorder, multi-select. Never torn down: `StageView` keeps it mounted behind other pages, because a macOS `List` cannot be scrolled back to where it was |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,7 +165,7 @@ Swift bindings are generated, not checked in — `just macos-ffi` builds the lib
 | `Support/SettingsModel.swift` | Settings state over `config.toml`. Commits on edit, re-reads on focus |
 | `Support/PlayerModel.swift` | Polls `now_playing()` at 10 Hz; refetches the queue only when `playlistVersion` moves |
 | `Support/Navigator.swift` | Where the app is: one page, the linear history of pages visited, and a cursor. No `NavigationStack` — koan navigates like a browser, any page from any page |
-| `Support/LibraryModel.swift` | Browse state. Holds the page a section is showing, nothing more — narrowing, sorting and paging all happen in SQL. Follows the navigator; never moves it |
+| `Support/LibraryModel.swift` | Browse state. Holds what the section on screen is showing and nothing else — narrowing and sorting happen in SQL, listings arrive whole. Follows the navigator; never moves it |
 | `Support/CoverArtCache.swift` | Album-keyed art cache: bytes once per record on disk, bitmaps per record and draw size in a bounded `NSCache`. Each miss is an HTTP round trip on remote libraries |
 | `Support/PlayingLevels.swift` | One analyser poller for every playing indicator on screen. Runs only while something is playing and something is watching |
 | `Views/QueueView.swift` | The main stage — album-grouped queue, drag reorder, multi-select. Never torn down: `StageView` keeps it mounted behind other pages, because a macOS `List` cannot be scrolled back to where it was |

--- a/apps/macos/Sources/Koan/KoanApp.swift
+++ b/apps/macos/Sources/Koan/KoanApp.swift
@@ -61,6 +61,7 @@ final class AppState {
         // else would say so — the count is a database read, and the download
         // ran in the engine.
         player.onDownloadsLanded = { [weak library] in library?.loadStats() }
+        player.onLibraryChanged = { [weak library] in library?.libraryChanged() }
 
         // Control Center and the media keys ride the player's existing poll.
         let centre = NowPlayingCentre(player: player, art: art)

--- a/apps/macos/Sources/Koan/KoanApp.swift
+++ b/apps/macos/Sources/Koan/KoanApp.swift
@@ -32,7 +32,7 @@ final class AppState {
         self.library = library
         let nav = Navigator(library: library)
         self.nav = nav
-        self.search = SearchModel(engine: engine, library: library, nav: nav)
+        self.search = SearchModel(engine: engine, nav: nav)
         let art = CoverArtCache(engine: engine)
         self.art = art
         self.organize = OrganizeModel(engine: engine)

--- a/apps/macos/Sources/Koan/Support/LibraryModel.swift
+++ b/apps/macos/Sources/Koan/Support/LibraryModel.swift
@@ -2,20 +2,16 @@ import Foundation
 import KoanFFI
 import SwiftUI
 
-/// How much of a section to hold at once.
-///
-/// Enough that the first screenful is never short and scrolling always has
-/// somewhere to go; small enough that opening the browser costs the same on a
-/// library of five thousand records as on one of fifty.
-private let pageSize: UInt32 = 200
-
 /// Library browsing state.
 ///
-/// Nothing here is a copy of the library. Each section holds the page it is
-/// showing and asks for the next one when the scroll reaches the end;
-/// narrowing, sorting and paging all happen in SQL. koan-core owns the library,
-/// so the only questions this can answer without asking are the ones about
-/// where the user is.
+/// Nothing here is derived, indexed or narrowed. A section asks koan-core what
+/// it should be showing and shows exactly that; narrowing and sorting happen in
+/// SQL, because the database is the only thing that knows the answer and asking
+/// it is cheaper than keeping one.
+///
+/// Nothing is paged either. This is an in-process call, not a wire: a listing
+/// arrives whole, so the scrollbar tells the truth about how long the library
+/// is and one flick reaches the end of it.
 ///
 /// The consequence worth knowing: there is no load to have forgotten to do. A
 /// section that has never been visited shows the library the first time it is,
@@ -66,9 +62,9 @@ final class LibraryModel {
         }
     }
 
-    /// Which shuffle Random means right now. Fixed for the whole listing, so
-    /// page two belongs to the same shuffle as page one rather than reshuffling
-    /// underneath the scroll.
+    /// Which shuffle Random means right now. Held rather than dealt afresh on
+    /// every read, so typing in the filter narrows the shuffle you are looking
+    /// at instead of dealing a new one on each keystroke.
     private var shuffleSeed = Int64.random(in: .min ... .max)
 
     /// Deal again. Only visibly different under Random, which is what the
@@ -80,10 +76,10 @@ final class LibraryModel {
 
     // MARK: - What each section is showing
 
-    /// A page of rows, not a filtered copy of a catalogue. Stored rather than
-    /// computed because a `List` reads its collection far more than once per
-    /// update, and anything derived on read is derived a few hundred times a
-    /// frame.
+    /// What the section on screen is showing, as the database handed it over.
+    /// Stored rather than computed because a `List` reads its collection far
+    /// more than once per update, and anything derived on read is derived a few
+    /// hundred times a frame.
     private(set) var visibleAlbums: [Album] = []
     private(set) var visibleArtists: [Artist] = []
     private(set) var visibleFavourites: [Track] = []
@@ -135,23 +131,15 @@ final class LibraryModel {
     }
 
     private var loading: Task<Void, Never>?
-    private var paging: Task<Void, Never>?
-    /// Set once a page comes back short: there is no more to ask for, and
-    /// scrolling should stop trying.
-    private var exhausted = false
-    private var isPaging = false
 
-    /// Ask for the first page of whatever is on screen.
+    /// Ask for whatever is on screen.
     ///
     /// Cancellable, so an answer to a filter you have already typed past never
     /// lands, and debounced when a keystroke caused it, so holding a key down
     /// is one query rather than one per character.
     func reload(debounced: Bool = false) {
-        loading?.cancel()
-        paging?.cancel()
-        exhausted = false
-        isPaging = false
         isLoading = true
+        loading?.cancel()
 
         let request = self.request
         loading = Task {
@@ -159,27 +147,10 @@ final class LibraryModel {
                 try? await Task.sleep(for: Self.filterDebounce)
                 guard !Task.isCancelled else { return }
             }
-            let rows = await request.page(offset: 0)
+            let rows = await request.rows()
             guard !Task.isCancelled else { return }
-            show(rows, appending: false)
+            show(rows)
             isLoading = false
-        }
-    }
-
-    /// The scroll reached the end of what we hold. Called by the last row on
-    /// screen, which is the only thing that knows.
-    func loadMore() {
-        guard !exhausted, !isPaging, !isLoading else { return }
-        let request = self.request
-        let offset = loadedCount
-        guard offset > 0 else { return }
-        isPaging = true
-
-        paging = Task {
-            let rows = await request.page(offset: UInt32(offset))
-            guard !Task.isCancelled else { return }
-            show(rows, appending: true)
-            isPaging = false
         }
     }
 
@@ -195,8 +166,8 @@ final class LibraryModel {
 
         var search: String? { filter.isEmpty ? nil : filter }
 
-        /// One page of this section, or everything it has if it does not page.
-        func page(offset: UInt32) async -> Rows {
+        /// Everything this section is showing.
+        func rows() async -> Rows {
             switch section {
             case .queue, .searchResults, .playlist:
                 // Owned by the player, search and playlist models respectively.
@@ -204,19 +175,14 @@ final class LibraryModel {
             case .albums:
                 return .albums(
                     (try? await engine.albums(
-                        artistId: nil, sort: sort, seed: seed, search: search,
-                        limit: pageSize, offset: offset
+                        artistId: nil, sort: sort, seed: seed, search: search
                     )) ?? []
                 )
             case .artists:
-                return .artists(
-                    (try? await engine.artists(search: search, limit: pageSize, offset: offset))
-                        ?? []
-                )
+                return .artists((try? await engine.artists(search: search)) ?? [])
             case .favourites:
-                // Unpaged: a favourites list is bounded by what someone
-                // troubled themselves to press a heart on.
-                guard offset == 0 else { return .none }
+                // Three questions, asked at once — they are answers to the same
+                // one and the page shows them together.
                 async let tracks = engine.favourites(search: search)
                 async let albums = engine.favouriteAlbums(search: search)
                 async let artists = engine.favouriteArtists(search: search)
@@ -226,23 +192,8 @@ final class LibraryModel {
                     artists: (try? await artists) ?? []
                 )
             case .playHistory:
-                return .history(
-                    (try? await engine.playHistory(
-                        search: search, limit: pageSize, offset: offset
-                    )) ?? []
-                )
+                return .history((try? await engine.playHistory(search: search)) ?? [])
             }
-        }
-    }
-
-    /// How many rows the section on screen holds, which is where the next page
-    /// starts. Sections that do not page never ask.
-    private var loadedCount: Int {
-        switch section {
-        case .albums: visibleAlbums.count
-        case .artists: visibleArtists.count
-        case .playHistory: visiblePlayHistory.count
-        default: 0
         }
     }
 
@@ -260,24 +211,20 @@ final class LibraryModel {
         )
     }
 
-    private func show(_ rows: Rows, appending: Bool) {
+    private func show(_ rows: Rows) {
         switch rows {
         case .none:
-            exhausted = true
+            break
         case .albums(let rows):
-            visibleAlbums = appending ? visibleAlbums + rows : rows
-            exhausted = rows.count < pageSize
+            visibleAlbums = rows
         case .artists(let rows):
-            visibleArtists = appending ? visibleArtists + rows : rows
-            exhausted = rows.count < pageSize
+            visibleArtists = rows
         case .favourites(let tracks, let albums, let artists):
             visibleFavourites = tracks
             visibleFavouriteAlbums = albums
             visibleFavouriteArtists = artists
-            exhausted = true
         case .history(let rows):
-            visiblePlayHistory = appending ? visiblePlayHistory + rows : rows
-            exhausted = rows.count < pageSize
+            visiblePlayHistory = rows
         }
     }
 
@@ -378,8 +325,9 @@ final class LibraryModel {
         reload()
     }
 
-    /// Pull the remote library. Minutes on a large server, so it runs detached
-    /// and the page is asked for again afterwards rather than during.
+    /// Pull the remote library. Minutes on a large server, so it runs detached.
+    /// Nothing here refreshes anything: the engine announces the rows it wrote,
+    /// and `libraryChanged()` runs off that.
     func syncRemote(full: Bool = false) {
         guard !isScanning else { return }
         isScanning = true
@@ -392,7 +340,6 @@ final class LibraryModel {
             _ = try? await engine.syncRemote(full: full)
             if let job { activity?.end(job) }
             isScanning = false
-            libraryChanged()
         }
     }
 
@@ -415,14 +362,19 @@ final class LibraryModel {
             if let job { activity?.end(job) }
             scanSummary = result
             isScanning = false
-            libraryChanged()
         }
     }
 
-    /// Rows appeared or vanished underneath us. Nothing to merge or invalidate:
-    /// ask again.
+    /// Rows appeared or vanished underneath us — a scan, a sync, an import, or
+    /// a folder being forgotten. Whether this app asked for it or the engine
+    /// did it on its own makes no difference here: nothing to merge, nothing to
+    /// invalidate, just ask again.
+    ///
+    /// Favourites too, because a sync reconciles them with the server and the
+    /// hearts on screen are stale the moment it lands.
     func libraryChanged() {
         loadStats()
+        refreshFavourites()
         reload()
     }
 }

--- a/apps/macos/Sources/Koan/Support/LibraryModel.swift
+++ b/apps/macos/Sources/Koan/Support/LibraryModel.swift
@@ -2,18 +2,24 @@ import Foundation
 import KoanFFI
 import SwiftUI
 
-/// How much history to hold. Enough to scroll back through an evening's
-/// listening without paging; the whole table would be unbounded.
-private let historyPageSize: UInt32 = 500
+/// How much of a section to hold at once.
+///
+/// Enough that the first screenful is never short and scrolling always has
+/// somewhere to go; small enough that opening the browser costs the same on a
+/// library of five thousand records as on one of fifty.
+private let pageSize: UInt32 = 200
 
 /// Library browsing state.
 ///
-/// The full album and artist lists are loaded once, because search and the
-/// detail views resolve ids against them. Narrowing them is the database's job:
-/// filtering a few thousand rows in Swift cost sixteen milliseconds of main
-/// thread per keystroke, which is a filter field that visibly lags the typing.
-/// Tracks are never loaded wholesale; there are tens of thousands of them and
-/// you only ever look at one album's worth at a time.
+/// Nothing here is a copy of the library. Each section holds the page it is
+/// showing and asks for the next one when the scroll reaches the end;
+/// narrowing, sorting and paging all happen in SQL. koan-core owns the library,
+/// so the only questions this can answer without asking are the ones about
+/// where the user is.
+///
+/// The consequence worth knowing: there is no load to have forgotten to do. A
+/// section that has never been visited shows the library the first time it is,
+/// and one whose rows changed underneath it asks again rather than merging.
 @MainActor
 @Observable
 final class LibraryModel {
@@ -30,22 +36,24 @@ final class LibraryModel {
         guard section != self.section else { return }
         self.section = section
         // A filter you left behind on another view is invisible here, and an
-        // apparently empty library is the result.
+        // apparently empty library is the result. Clearing it reloads by
+        // itself; if there was nothing to clear, ask outright.
+        let hadFilter = !filter.isEmpty
         filter = ""
-        load()
+        if !hadFilter { reload() }
     }
 
-    /// Substring filter over whatever the current section is showing.
+    /// Substring filter over whatever the current section is showing. It
+    /// narrows the query, not the answer.
     var filter: String = "" {
         didSet {
             guard filter != oldValue else { return }
-            refilter()
+            reload(debounced: true)
         }
     }
 
-    /// In flight for the sections whose filter is a query. Long enough that a
-    /// burst of typing is one round trip, short enough not to read as lag.
-    private var filterQuery: Task<Void, Never>?
+    /// Long enough that a burst of typing is one round trip, short enough not
+    /// to read as lag.
     private static let filterDebounce = Duration.milliseconds(120)
 
     /// Newest first by default: the record you just added is the one you're
@@ -54,13 +62,34 @@ final class LibraryModel {
         didSet {
             guard albumSort != oldValue else { return }
             UserDefaults.standard.set(albumSort.storageKey, forKey: "albumSort")
-            reloadAlbums()
+            reload()
         }
     }
 
-    private(set) var albums: [Album] = [] { didSet { refilter() } }
-    private(set) var artists: [Artist] = [] { didSet { refilter() } }
-    private(set) var favourites: [Track] = [] { didSet { refilter() } }
+    /// Which shuffle Random means right now. Fixed for the whole listing, so
+    /// page two belongs to the same shuffle as page one rather than reshuffling
+    /// underneath the scroll.
+    private var shuffleSeed = Int64.random(in: .min ... .max)
+
+    /// Deal again. Only visibly different under Random, which is what the
+    /// button is for.
+    func reshuffleAlbums() {
+        shuffleSeed = Int64.random(in: .min ... .max)
+        reload()
+    }
+
+    // MARK: - What each section is showing
+
+    /// A page of rows, not a filtered copy of a catalogue. Stored rather than
+    /// computed because a `List` reads its collection far more than once per
+    /// update, and anything derived on read is derived a few hundred times a
+    /// frame.
+    private(set) var visibleAlbums: [Album] = []
+    private(set) var visibleArtists: [Artist] = []
+    private(set) var visibleFavourites: [Track] = []
+    private(set) var visibleFavouriteAlbums: [Album] = []
+    private(set) var visibleFavouriteArtists: [Artist] = []
+    private(set) var visiblePlayHistory: [PlayHistoryEntry] = []
 
     // Favourite state is read from here rather than from the copy baked into
     // each Track when it was fetched. A track appears in the album view, the
@@ -69,21 +98,21 @@ final class LibraryModel {
     // it left the album view showing an unfilled heart on a track that was
     // already favourited.
     private(set) var favouriteTrackIds: Set<Int64> = []
-    private(set) var favouriteAlbumIds: Set<Int64> = [] { didSet { refilter() } }
-    private(set) var favouriteArtistIds: Set<Int64> = [] { didSet { refilter() } }
+    private(set) var favouriteAlbumIds: Set<Int64> = []
+    private(set) var favouriteArtistIds: Set<Int64> = []
 
     func isFavourite(track id: Int64) -> Bool { favouriteTrackIds.contains(id) }
     func isFavourite(album id: Int64) -> Bool { favouriteAlbumIds.contains(id) }
     func isFavourite(artist id: Int64) -> Bool { favouriteArtistIds.contains(id) }
-    private(set) var playHistory: [PlayHistoryEntry] = [] { didSet { refilter() } }
+
     private(set) var stats: Stats?
     private(set) var isLoading = false
 
     private(set) var detailTracks: [Track] = []
 
-    /// Set while a scan runs so the UI can show progress and refuse a second one.
-    /// Set by `AppState`. Long tasks register here so one place can say what is
-    /// happening — see `ActivityModel`.
+    /// Set while a scan runs so the UI can show progress and refuse a second
+    /// one. Set by `AppState`. Long tasks register here so one place can say
+    /// what is happening — see `ActivityModel`.
     weak var activity: ActivityModel?
 
     private(set) var isScanning = false
@@ -98,176 +127,157 @@ final class LibraryModel {
         }
     }
 
-    /// Re-runs the current sort. Only visibly different under Random, which is
-    /// reshuffled server-side on every call — that's what the button is for.
-    func reshuffleAlbums() { reloadAlbums() }
-
-    private func reloadAlbums() {
-        let engine = self.engine
-        let sort = albumSort
-        Task {
-            albums = (try? await engine.albums(artistId: nil, sort: sort, search: nil)) ?? []
-            reindex()
-        }
-    }
-
-    // MARK: - Filtered views
-
-    /// Stored rather than computed. A `List` reads its collection far more than
-    /// once per update, and narrowing it on every read froze the artist list for
-    /// a second or two whenever the filter changed. The album grid is lazy and
-    /// never noticed, which is what made it look like a bug in the artist view
-    /// specifically.
-    private(set) var visibleAlbums: [Album] = []
-    private(set) var visibleArtists: [Artist] = []
-    private(set) var visibleFavourites: [Track] = []
-    /// Favourited records and artists, resolved out of the catalogue already in
-    /// memory — the engine hands back ids, and `prefetchCatalogue` holds the
-    /// rows. Taken in the catalogue's order rather than the set's, which has
-    /// none, so the grid does not reshuffle itself on every toggle.
-    private(set) var visibleFavouriteAlbums: [Album] = []
-    private(set) var visibleFavouriteArtists: [Artist] = []
-    private(set) var visiblePlayHistory: [PlayHistoryEntry] = []
-
-    /// Recompute what each section shows. Called whenever the filter or any of
-    /// the underlying collections change.
-    ///
-    /// Switching section clears the filter, so only the section on screen can
-    /// hold one and every other collection is handed over whole. Albums and
-    /// artists are unbounded and go to the database; favourites and a page of
-    /// history are small enough to narrow here.
-    private func refilter() {
-        visibleFavourites = section == .favourites
-            ? matching(favourites) { [$0.title, $0.artistName, $0.albumTitle] }
-            : favourites
-        // Only ever built for the page that shows them: this walks the whole
-        // catalogue, and every other section would be paying for it on each
-        // keystroke of its own filter.
-        if section == .favourites {
-            visibleFavouriteAlbums = matching(
-                albums.filter { favouriteAlbumIds.contains($0.id) }
-            ) { [$0.title, $0.artistName] }
-            visibleFavouriteArtists = matching(
-                artists.filter { favouriteArtistIds.contains($0.id) }
-            ) { [$0.name] }
-        } else {
-            visibleFavouriteAlbums = []
-            visibleFavouriteArtists = []
-        }
-        visiblePlayHistory = section == .playHistory
-            ? matching(playHistory) { [$0.track.title, $0.track.artistName, $0.track.albumTitle] }
-            : playHistory
-
-        guard section == .albums || section == .artists, !filter.isEmpty else {
-            filterQuery?.cancel()
-            visibleAlbums = albums
-            visibleArtists = artists
-            return
-        }
-        runFilterQuery()
-    }
-
-    /// Ask the database for the matches.
-    ///
-    /// Debounced and cancellable, so holding a key down is one query rather than
-    /// one per character and an answer to a filter you have already typed past
-    /// never lands.
-    private func runFilterQuery() {
-        filterQuery?.cancel()
-        let engine = self.engine
-        let wantsAlbums = section == .albums
-        let sort = albumSort
-        let query = filter
-        filterQuery = Task {
-            try? await Task.sleep(for: Self.filterDebounce)
-            guard !Task.isCancelled else { return }
-            if wantsAlbums {
-                let rows = try? await engine.albums(
-                    artistId: nil, sort: sort, search: query
-                )
-                guard !Task.isCancelled else { return }
-                visibleAlbums = rows ?? []
-            } else {
-                let rows = try? await engine.artists(search: query)
-                guard !Task.isCancelled else { return }
-                visibleArtists = rows ?? []
-            }
-        }
-    }
-
-    private func matching<T>(_ rows: [T], _ fields: (T) -> [String]) -> [T] {
-        guard !filter.isEmpty else { return rows }
-        return rows.filter { row in
-            fields(row).contains { $0.localizedCaseInsensitiveContains(filter) }
-        }
-    }
-
     // MARK: - Loading
 
     func loadInitial() {
         loadStats()
-        load()
-        // Search resolves fuzzy match ids against these, so they cannot wait
-        // until their section is first visited.
-        prefetchCatalogue()
+        reload()
     }
 
-    private var albumsById: [Int64: Album] = [:]
-    private var artistsById: [Int64: Artist] = [:]
+    private var loading: Task<Void, Never>?
+    private var paging: Task<Void, Never>?
+    /// Set once a page comes back short: there is no more to ask for, and
+    /// scrolling should stop trying.
+    private var exhausted = false
+    private var isPaging = false
 
-    func album(id: Int64) -> Album? { albumsById[id] }
-    func artist(id: Int64) -> Artist? { artistsById[id] }
+    /// Ask for the first page of whatever is on screen.
+    ///
+    /// Cancellable, so an answer to a filter you have already typed past never
+    /// lands, and debounced when a keystroke caused it, so holding a key down
+    /// is one query rather than one per character.
+    func reload(debounced: Bool = false) {
+        loading?.cancel()
+        paging?.cancel()
+        exhausted = false
+        isPaging = false
+        isLoading = true
 
-    private func prefetchCatalogue() {
-        let engine = self.engine
-        let sort = albumSort
-        Task {
-            if albums.isEmpty {
-                albums = (try? await engine.albums(artistId: nil, sort: sort, search: nil)) ?? []
+        let request = self.request
+        loading = Task {
+            if debounced {
+                try? await Task.sleep(for: Self.filterDebounce)
+                guard !Task.isCancelled else { return }
             }
-            if artists.isEmpty {
-                artists = (try? await engine.artists(search: nil)) ?? []
-            }
-            reindex()
+            let rows = await request.page(offset: 0)
+            guard !Task.isCancelled else { return }
+            show(rows, appending: false)
+            isLoading = false
         }
     }
 
-    private func reindex() {
-        albumsById = Dictionary(albums.map { ($0.id, $0) }, uniquingKeysWith: { a, _ in a })
-        artistsById = Dictionary(artists.map { ($0.id, $0) }, uniquingKeysWith: { a, _ in a })
+    /// The scroll reached the end of what we hold. Called by the last row on
+    /// screen, which is the only thing that knows.
+    func loadMore() {
+        guard !exhausted, !isPaging, !isLoading else { return }
+        let request = self.request
+        let offset = loadedCount
+        guard offset > 0 else { return }
+        isPaging = true
+
+        paging = Task {
+            let rows = await request.page(offset: UInt32(offset))
+            guard !Task.isCancelled else { return }
+            show(rows, appending: true)
+            isPaging = false
+        }
     }
 
-    /// Loads whatever the current section needs. Everything heavy happens off
-    /// the main actor; only the assignment comes back.
-    func load() {
-        let engine = self.engine
-        let section = self.section
-        let sort = albumSort
-        isLoading = true
+    /// Everything a section's query depends on, captured off the model so the
+    /// answer that lands belongs to the question that was asked. Anything that
+    /// changes one cancels the task holding it.
+    private struct Request {
+        let section: Section
+        let filter: String
+        let sort: AlbumSort
+        let seed: Int64
+        let engine: KoanEngine
 
-        Task {
+        var search: String? { filter.isEmpty ? nil : filter }
+
+        /// One page of this section, or everything it has if it does not page.
+        func page(offset: UInt32) async -> Rows {
             switch section {
-            case .queue, .searchResults:
-                break  // owned by the player and search models respectively
+            case .queue, .searchResults, .playlist:
+                // Owned by the player, search and playlist models respectively.
+                return .none
             case .albums:
-                if albums.isEmpty {
-                    albums = (try? await engine.albums(artistId: nil, sort: sort, search: nil)) ?? []
-                    reindex()
-                }
+                return .albums(
+                    (try? await engine.albums(
+                        artistId: nil, sort: sort, seed: seed, search: search,
+                        limit: pageSize, offset: offset
+                    )) ?? []
+                )
             case .artists:
-                if artists.isEmpty {
-                    artists = (try? await engine.artists(search: nil)) ?? []
-                    reindex()
-                }
+                return .artists(
+                    (try? await engine.artists(search: search, limit: pageSize, offset: offset))
+                        ?? []
+                )
             case .favourites:
-                favourites = (try? await engine.favourites()) ?? []
+                // Unpaged: a favourites list is bounded by what someone
+                // troubled themselves to press a heart on.
+                guard offset == 0 else { return .none }
+                async let tracks = engine.favourites(search: search)
+                async let albums = engine.favouriteAlbums(search: search)
+                async let artists = engine.favouriteArtists(search: search)
+                return .favourites(
+                    tracks: (try? await tracks) ?? [],
+                    albums: (try? await albums) ?? [],
+                    artists: (try? await artists) ?? []
+                )
             case .playHistory:
-                // Always refetched: it changes underneath you as you listen.
-                playHistory = (try? await engine.playHistory(limit: historyPageSize, offset: 0)) ?? []
-            case .playlist:
-                break  // owned by PlaylistsModel
+                return .history(
+                    (try? await engine.playHistory(
+                        search: search, limit: pageSize, offset: offset
+                    )) ?? []
+                )
             }
-            isLoading = false
+        }
+    }
+
+    /// How many rows the section on screen holds, which is where the next page
+    /// starts. Sections that do not page never ask.
+    private var loadedCount: Int {
+        switch section {
+        case .albums: visibleAlbums.count
+        case .artists: visibleArtists.count
+        case .playHistory: visiblePlayHistory.count
+        default: 0
+        }
+    }
+
+    private enum Rows {
+        case none
+        case albums([Album])
+        case artists([Artist])
+        case favourites(tracks: [Track], albums: [Album], artists: [Artist])
+        case history([PlayHistoryEntry])
+    }
+
+    private var request: Request {
+        Request(
+            section: section, filter: filter, sort: albumSort, seed: shuffleSeed, engine: engine
+        )
+    }
+
+    private func show(_ rows: Rows, appending: Bool) {
+        switch rows {
+        case .none:
+            exhausted = true
+        case .albums(let rows):
+            visibleAlbums = appending ? visibleAlbums + rows : rows
+            exhausted = rows.count < pageSize
+        case .artists(let rows):
+            visibleArtists = appending ? visibleArtists + rows : rows
+            exhausted = rows.count < pageSize
+        case .favourites(let tracks, let albums, let artists):
+            visibleFavourites = tracks
+            visibleFavouriteAlbums = albums
+            visibleFavouriteArtists = artists
+            exhausted = true
+        case .history(let rows):
+            visiblePlayHistory = appending ? visiblePlayHistory + rows : rows
+            exhausted = rows.count < pageSize
         }
     }
 
@@ -277,7 +287,7 @@ final class LibraryModel {
         let engine = self.engine
         let doomed = Array(ids)
         // Dropped locally first so the list does not visibly lag the keystroke.
-        playHistory.removeAll { ids.contains($0.id) }
+        visiblePlayHistory.removeAll { ids.contains($0.id) }
         Task { _ = try? await engine.deletePlays(ids: doomed) }
     }
 
@@ -286,7 +296,7 @@ final class LibraryModel {
         let engine = self.engine
         Task {
             _ = try? await engine.clearPlayHistory()
-            playHistory = []
+            visiblePlayHistory = []
         }
     }
 
@@ -321,7 +331,7 @@ final class LibraryModel {
             let now = (try? await engine.toggleFavourite(trackId: id))
             guard let now else { return }
             if now { favouriteTrackIds.insert(id) } else { favouriteTrackIds.remove(id) }
-            reloadFavouritesList()
+            reloadFavourites()
         }
     }
 
@@ -331,6 +341,7 @@ final class LibraryModel {
             let now = (try? await engine.toggleFavouriteAlbum(albumId: id))
             guard let now else { return }
             if now { favouriteAlbumIds.insert(id) } else { favouriteAlbumIds.remove(id) }
+            reloadFavourites()
         }
     }
 
@@ -340,6 +351,7 @@ final class LibraryModel {
             let now = (try? await engine.toggleFavouriteArtist(artistId: id))
             guard let now else { return }
             if now { favouriteArtistIds.insert(id) } else { favouriteArtistIds.remove(id) }
+            reloadFavourites()
         }
     }
 
@@ -356,20 +368,18 @@ final class LibraryModel {
             favouriteTrackIds = sets.0
             favouriteAlbumIds = sets.1
             favouriteArtistIds = sets.2
-            reloadFavouritesList()
+            reloadFavourites()
         }
     }
 
-    private func reloadFavouritesList() {
+    /// The favourites page lists what the hearts say, so a toggle changes it.
+    private func reloadFavourites() {
         guard section == .favourites else { return }
-        let engine = self.engine
-        Task {
-            favourites = (try? await engine.favourites()) ?? []
-        }
+        reload()
     }
 
     /// Pull the remote library. Minutes on a large server, so it runs detached
-    /// and the caches are dropped afterwards rather than during.
+    /// and the page is asked for again afterwards rather than during.
     func syncRemote(full: Bool = false) {
         guard !isScanning else { return }
         isScanning = true
@@ -382,11 +392,7 @@ final class LibraryModel {
             _ = try? await engine.syncRemote(full: full)
             if let job { activity?.end(job) }
             isScanning = false
-            albums = []
-            artists = []
-            loadStats()
-            prefetchCatalogue()
-            load()
+            libraryChanged()
         }
     }
 
@@ -413,14 +419,10 @@ final class LibraryModel {
         }
     }
 
-    /// Rows appeared or vanished underneath us. Albums and artists are loaded
-    /// once and filtered in memory, so they have to be dropped rather than
-    /// merged — anything else leaves the browser showing a library that no
-    /// longer exists.
+    /// Rows appeared or vanished underneath us. Nothing to merge or invalidate:
+    /// ask again.
     func libraryChanged() {
-        albums = []
-        artists = []
         loadStats()
-        load()
+        reload()
     }
 }

--- a/apps/macos/Sources/Koan/Support/PlayerModel.swift
+++ b/apps/macos/Sources/Koan/Support/PlayerModel.swift
@@ -109,6 +109,8 @@ final class PlayerModel {
                     self.applyPosition(positionMs)
                 case .downloadsChanged(let downloads):
                     self.applyDownloads(downloads)
+                case .libraryChanged:
+                    self.onLibraryChanged?()
                 }
             }
         }
@@ -209,6 +211,11 @@ final class PlayerModel {
     /// A download finished. Set by `AppState` — the library's cached count is
     /// the only thing that knows it moved, and it has no other way to find out.
     var onDownloadsLanded: (() -> Void)?
+
+    /// The library's rows changed. Set by `AppState`. This is how a scan or a
+    /// sync nobody asked for reaches the browser — the engine says so rather
+    /// than the app having to guess from whatever it happened to start itself.
+    var onLibraryChanged: (() -> Void)?
 
     /// The queue changed — rebuild it and refresh what depends on it.
     fileprivate func applyQueueChange() async {
@@ -518,7 +525,7 @@ final class PlayerModel {
     /// `indexed` fires once rows exist, so the library browser can pick up the
     /// artists and albums the drop just created. The player can't do that
     /// itself — it doesn't own the browse caches.
-    func importFiles(_ urls: [URL], indexed: @escaping @MainActor () -> Void) {
+    func importFiles(_ urls: [URL]) {
         let paths = urls.filter(\.isFileURL).map(\.path)
         guard !paths.isEmpty else { return }
         let engine = self.engine
@@ -538,7 +545,6 @@ final class PlayerModel {
                 lastError = first
             }
             enqueue(trackIds: summary.trackIds)
-            indexed()
         }
     }
 

--- a/apps/macos/Sources/Koan/Support/SearchModel.swift
+++ b/apps/macos/Sources/Koan/Support/SearchModel.swift
@@ -15,7 +15,6 @@ import KoanFFI
 @Observable
 final class SearchModel {
     private let engine: KoanEngine
-    private let library: LibraryModel
     private let nav: Navigator
 
     var query: String = ""
@@ -30,9 +29,8 @@ final class SearchModel {
     /// location, so a detail view you searched from is still there afterwards.
     private var locationBeforeSearch: Navigator.Page?
 
-    init(engine: KoanEngine, library: LibraryModel, nav: Navigator) {
+    init(engine: KoanEngine, nav: Navigator) {
         self.engine = engine
-        self.library = library
         self.nav = nav
     }
 
@@ -110,18 +108,18 @@ final class SearchModel {
             try? await Task.sleep(for: .milliseconds(160))
             guard !Task.isCancelled else { return }
 
+            // Rows, not ids: the engine already read them to rank them, and
+            // resolving ids would mean holding a catalogue to resolve against.
             let found = (
                 (try? await engine.search(query: text, limit: 60)) ?? [],
-                (try? await engine.fuzzySearch(query: text, kind: .album, limit: 30)) ?? [],
-                (try? await engine.fuzzySearch(query: text, kind: .artist, limit: 30)) ?? []
+                (try? await engine.fuzzyAlbums(query: text, limit: 30)) ?? [],
+                (try? await engine.fuzzyArtists(query: text, limit: 30)) ?? []
             )
 
             guard !Task.isCancelled else { return }
             tracks = found.0
-            // Fuzzy matching answers with ids; the objects come from the
-            // library caches, which are loaded once at launch.
-            albums = found.1.compactMap { library.album(id: $0.id) }
-            artists = found.2.compactMap { library.artist(id: $0.id) }
+            albums = found.1
+            artists = found.2
             isSearching = false
         }
     }

--- a/apps/macos/Sources/Koan/Support/SettingsModel.swift
+++ b/apps/macos/Sources/Koan/Support/SettingsModel.swift
@@ -17,11 +17,6 @@ final class SettingsModel {
     private let engine: KoanEngine
     private let activity: ActivityModel
 
-    /// A sync changes favourites and the library listing, and the browser is
-    /// the thing that has to show it. Weak so the settings window does not keep
-    /// the browse state alive.
-    weak var library: LibraryModel?
-
     private(set) var settings: Settings
     private(set) var lastError: String?
     private(set) var lastResult: String?
@@ -170,9 +165,6 @@ final class SettingsModel {
             }
             switch result {
             case .success(let s):
-                // A sync reconciles favourites too, so the hearts on screen are
-                // out of date the moment it finishes.
-                library?.refreshFavourites()
                 // Zero is the normal answer for an incremental sync with nothing
                 // new, and "0 tracks across 0 albums" reads as a failure.
                 lastResult = s.tracks == 0 && s.favouritesImported == 0

--- a/apps/macos/Sources/Koan/Views/AlbumBrowser.swift
+++ b/apps/macos/Sources/Koan/Views/AlbumBrowser.swift
@@ -21,6 +21,14 @@ struct AlbumBrowser: View {
                     LazyVGrid(columns: columns, spacing: 22) {
                         ForEach(library.visibleAlbums, id: \.id) { album in
                             AlbumGridCell(album: album)
+                                // The grid holds a page, not the library. The
+                                // last cell reaching the screen is the only
+                                // signal that there is more to ask for.
+                                .onAppear {
+                                    if album.id == library.visibleAlbums.last?.id {
+                                        library.loadMore()
+                                    }
+                                }
                         }
                     }
                     .padding(20)
@@ -35,7 +43,9 @@ struct AlbumDetailView: View {
     @Environment(LibraryModel.self) private var library
     @Environment(PlayerModel.self) private var player
 
-    private var album: Album? { library.album(id: albumId) }
+    /// Fetched, not looked up: the browser holds the page it is showing, and
+    /// this record may well not be on it.
+    @State private var album: Album?
 
     var body: some View {
         TrackListView(
@@ -47,6 +57,7 @@ struct AlbumDetailView: View {
             playable: album.map { Playable.album($0) }
         )
         .task(id: albumId) {
+            album = try? await library.engine.album(albumId: albumId)
             library.loadTracks(albumId: albumId)
         }
     }

--- a/apps/macos/Sources/Koan/Views/AlbumBrowser.swift
+++ b/apps/macos/Sources/Koan/Views/AlbumBrowser.swift
@@ -21,14 +21,6 @@ struct AlbumBrowser: View {
                     LazyVGrid(columns: columns, spacing: 22) {
                         ForEach(library.visibleAlbums, id: \.id) { album in
                             AlbumGridCell(album: album)
-                                // The grid holds a page, not the library. The
-                                // last cell reaching the screen is the only
-                                // signal that there is more to ask for.
-                                .onAppear {
-                                    if album.id == library.visibleAlbums.last?.id {
-                                        library.loadMore()
-                                    }
-                                }
                         }
                     }
                     .padding(20)

--- a/apps/macos/Sources/Koan/Views/ArtistBrowser.swift
+++ b/apps/macos/Sources/Koan/Views/ArtistBrowser.swift
@@ -11,12 +11,6 @@ struct ArtistBrowser: View {
     var body: some View {
         List(library.visibleArtists, id: \.id, selection: $selection) { artist in
             ArtistRow(artist: artist)
-                // The list holds a page, not the library. The last row
-                // reaching the screen is the only signal that there is more
-                // to ask for.
-                .onAppear {
-                    if artist.id == library.visibleArtists.last?.id { library.loadMore() }
-                }
         }
         .clearsSelection($selection)
         .washedGround()
@@ -174,10 +168,7 @@ struct ArtistDetailView: View {
         let engine = library.engine
         let id = artistId
         artist = try? await engine.artist(artistId: id)
-        // A discography is bounded by one artist, so it is asked for whole.
-        albums = (try? await engine.albums(
-            artistId: id, sort: .year, seed: 0, search: nil, limit: nil, offset: 0
-        )) ?? []
+        albums = (try? await engine.albums(artistId: id, sort: .year, seed: 0, search: nil)) ?? []
         similar = (try? await engine.similarArtists(artistId: id)) ?? []
     }
 

--- a/apps/macos/Sources/Koan/Views/ArtistBrowser.swift
+++ b/apps/macos/Sources/Koan/Views/ArtistBrowser.swift
@@ -11,6 +11,12 @@ struct ArtistBrowser: View {
     var body: some View {
         List(library.visibleArtists, id: \.id, selection: $selection) { artist in
             ArtistRow(artist: artist)
+                // The list holds a page, not the library. The last row
+                // reaching the screen is the only signal that there is more
+                // to ask for.
+                .onAppear {
+                    if artist.id == library.visibleArtists.last?.id { library.loadMore() }
+                }
         }
         .clearsSelection($selection)
         .washedGround()
@@ -96,12 +102,13 @@ struct ArtistDetailView: View {
     @Environment(Navigator.self) private var nav
     @Environment(PlayerModel.self) private var player
 
+    /// Fetched, not looked up: the browser holds the page it is showing, and
+    /// this artist may well not be on it.
+    @State private var artist: Artist?
     @State private var albums: [Album] = []
     @State private var similar: [SimilarArtist] = []
 
     private let columns = [GridItem(.adaptive(minimum: 150, maximum: 210), spacing: 18)]
-
-    private var artist: Artist? { library.artist(id: artistId) }
 
     var body: some View {
         ScrollView {
@@ -166,7 +173,11 @@ struct ArtistDetailView: View {
     private func load() async {
         let engine = library.engine
         let id = artistId
-        albums = (try? await engine.albums(artistId: id, sort: .year, search: nil)) ?? []
+        artist = try? await engine.artist(artistId: id)
+        // A discography is bounded by one artist, so it is asked for whole.
+        albums = (try? await engine.albums(
+            artistId: id, sort: .year, seed: 0, search: nil, limit: nil, offset: 0
+        )) ?? []
         similar = (try? await engine.similarArtists(artistId: id)) ?? []
     }
 

--- a/apps/macos/Sources/Koan/Views/HistoryView.swift
+++ b/apps/macos/Sources/Koan/Views/HistoryView.swift
@@ -42,11 +42,6 @@ struct HistoryView: View {
                             ForEach(day.entries, id: \.id) { entry in
                                 HistoryRow(entry: entry)
                                     .tag(entry.id)
-                                    // Held a page at a time; the last row on
-                                    // screen asks for the one behind it.
-                                    .onAppear {
-                                        if entry.id == entries.last?.id { library.loadMore() }
-                                    }
                             }
                         }
                     }

--- a/apps/macos/Sources/Koan/Views/HistoryView.swift
+++ b/apps/macos/Sources/Koan/Views/HistoryView.swift
@@ -42,6 +42,11 @@ struct HistoryView: View {
                             ForEach(day.entries, id: \.id) { entry in
                                 HistoryRow(entry: entry)
                                     .tag(entry.id)
+                                    // Held a page at a time; the last row on
+                                    // screen asks for the one behind it.
+                                    .onAppear {
+                                        if entry.id == entries.last?.id { library.loadMore() }
+                                    }
                             }
                         }
                     }
@@ -78,7 +83,7 @@ struct HistoryView: View {
                 .foregroundStyle(.secondary)
             Spacer(minLength: 0)
             Button("Clear…") { confirmingClear = true }
-                .disabled(library.playHistory.isEmpty)
+                .disabled(library.visiblePlayHistory.isEmpty)
         }
     }
 

--- a/apps/macos/Sources/Koan/Views/QueueView.swift
+++ b/apps/macos/Sources/Koan/Views/QueueView.swift
@@ -101,7 +101,7 @@ struct QueueView: View {
         // On the whole stage, not the List: an empty queue is exactly when you
         // want to drop a folder on it, and it has no rows to land on.
         .dropDestination(for: URL.self) { urls, _ in
-            player.importFiles(urls) { library.libraryChanged() }
+            player.importFiles(urls)
             return true
         }
     }

--- a/apps/macos/Sources/Koan/Views/SettingsView.swift
+++ b/apps/macos/Sources/Koan/Views/SettingsView.swift
@@ -39,9 +39,7 @@ struct SettingsView: View {
         .frame(width: 560, height: 460)
         .task {
             if model == nil {
-                let created = await SettingsModel(engine: library.engine, activity: activity)
-                created.library = library
-                model = created
+                model = await SettingsModel(engine: library.engine, activity: activity)
             }
         }
         // The CLI and TUI write the same file; coming back to this window is

--- a/crates/koan-core/Cargo.toml
+++ b/crates/koan-core/Cargo.toml
@@ -37,7 +37,7 @@ reqwest = { workspace = true }
 realfft = "3"
 rtrb = "0.4"
 # Database
-rusqlite = { workspace = true, features = ["collation"] }
+rusqlite = { workspace = true, features = ["collation", "functions"] }
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/koan-core/src/db/connection.rs
+++ b/crates/koan-core/src/db/connection.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use std::rc::Rc;
 
 use rusqlite::Connection;
+use rusqlite::functions::FunctionFlags;
 use thiserror::Error;
 
 use super::schema;
@@ -90,7 +91,40 @@ fn configure(conn: &Connection) -> Result<(), DbError> {
     // Here rather than with the schema: `open_existing` skips the DDL, and a
     // connection without this collation fails every ORDER BY that uses it.
     register_library_collation(conn)?;
+    register_shuffle_function(conn)?;
     Ok(())
+}
+
+/// `koan_shuffle(id, seed)` — a stable pseudo-random ordering key.
+///
+/// A shuffled listing that is read a page at a time cannot shuffle in the
+/// client: page two would be drawn from a different shuffle than page one, and
+/// records would repeat or vanish as you scrolled. Ordering by a hash of the
+/// row id and a seed gives one order that every page of the same seed agrees
+/// on, and a new seed gives a different one.
+///
+/// Registered next to the collation, and for the same reason: a connection
+/// without it fails the query outright rather than sorting some other way.
+pub(crate) fn register_shuffle_function(conn: &Connection) -> rusqlite::Result<()> {
+    conn.create_scalar_function(
+        "koan_shuffle",
+        2,
+        FunctionFlags::SQLITE_UTF8 | FunctionFlags::SQLITE_DETERMINISTIC,
+        |ctx| {
+            let id = ctx.get::<i64>(0)? as u64;
+            let seed = ctx.get::<i64>(1)? as u64;
+            Ok(splitmix64(id ^ splitmix64(seed)) as i64)
+        },
+    )
+}
+
+/// SplitMix64. Cheap, and it scatters consecutive ids — which matters, because
+/// a library's ids are consecutive in the order it was scanned.
+fn splitmix64(x: u64) -> u64 {
+    let mut z = x.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    z ^ (z >> 31)
 }
 
 /// A collation for names the way a person reads them.

--- a/crates/koan-core/src/db/queries/albums.rs
+++ b/crates/koan-core/src/db/queries/albums.rs
@@ -73,21 +73,137 @@ pub fn get_or_create_album(
     Ok(conn.last_insert_rowid())
 }
 
-/// Get albums for a specific artist, ordered chronologically.
-pub fn albums_for_artist(conn: &Connection, artist_id: i64) -> Result<Vec<AlbumRow>, DbError> {
-    let mut stmt = conn.prepare(
+/// How a listing of albums is ordered.
+///
+/// In SQL rather than over the returned rows, because a listing that is read a
+/// page at a time has to be ordered before it is cut.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum AlbumOrder {
+    /// Artist, then release date, then title — how a shelf reads.
+    #[default]
+    ArtistThenDate,
+    /// Release date, then title. A discography, in the order it happened.
+    Date,
+    /// Newest acquisition first. What a browser should open on: the record you
+    /// just added is the one you were looking for.
+    RecentlyAdded,
+    Title,
+    /// Newest release first.
+    YearDesc,
+    /// Seeded, so every page of one shuffle belongs to the same shuffle. A new
+    /// seed is a new order — that is what the reshuffle button asks for.
+    Random(i64),
+}
+
+impl AlbumOrder {
+    fn clause(self) -> &'static str {
+        match self {
+            Self::ArtistThenDate => "a.name COLLATE LIBRARY, al.date, al.title COLLATE LIBRARY",
+            Self::Date => "al.date, al.title COLLATE LIBRARY",
+            // Albums predating the added_at column sort last rather than first,
+            // which is what a NULL would do.
+            Self::RecentlyAdded => {
+                "COALESCE(al.added_at, '') DESC, a.name COLLATE LIBRARY, al.title COLLATE LIBRARY"
+            }
+            Self::Title => "al.title COLLATE LIBRARY, a.name COLLATE LIBRARY, al.date",
+            Self::YearDesc => {
+                "COALESCE(CAST(substr(al.date, 1, 4) AS INTEGER), 0) DESC, \
+                               a.name COLLATE LIBRARY, al.title COLLATE LIBRARY"
+            }
+            Self::Random(_) => "koan_shuffle(al.id, ?)",
+        }
+    }
+}
+
+/// What to list. Everything optional, so one query answers the browser, the
+/// search field, an artist's discography and the favourites page.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct AlbumQuery<'a> {
+    pub artist_id: Option<i64>,
+    /// Case-insensitive substring over the album title and the artist name.
+    pub search: Option<&'a str>,
+    pub order: AlbumOrder,
+    /// Favourited records only.
+    pub favourites_only: bool,
+    /// `None` for the whole listing. A client that scrolls should page.
+    pub limit: Option<u32>,
+    pub offset: u32,
+}
+
+/// Albums, narrowed, ordered and paged by the database.
+///
+/// The narrowing belongs here rather than in each client: every front end wants
+/// the same answer, and the ones that filtered a fully-loaded list in their own
+/// language paid for reading the whole table to throw most of it away. Matching
+/// is ASCII case-insensitive, like `find_artists` — SQLite's `NOCASE` does not
+/// fold accented letters, so `MOTLEY` finds `Motley` but `MÖTLEY` does not find
+/// `Mötley`.
+pub fn list_albums(conn: &Connection, q: &AlbumQuery) -> Result<Vec<AlbumRow>, DbError> {
+    let mut sql = String::from(
         "SELECT al.id, al.title, al.artist_id, a.name, al.date,
                 al.total_discs, al.total_tracks, al.codec, al.label, al.remote_id,
                 al.added_at
          FROM albums al
-         LEFT JOIN artists a ON al.artist_id = a.id
-         WHERE al.artist_id = ?1
-         ORDER BY al.date, al.title COLLATE LIBRARY",
-    )?;
+         LEFT JOIN artists a ON al.artist_id = a.id",
+    );
+    if q.favourites_only {
+        sql.push_str(
+            " JOIN favourite_albums f
+                ON f.artist_name = a.name AND f.album_title = al.title",
+        );
+    }
+
+    let mut params: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
+    let mut wheres: Vec<&str> = Vec::new();
+    if let Some(id) = q.artist_id {
+        params.push(Box::new(id));
+        wheres.push("al.artist_id = ?");
+    }
+    if let Some(query) = q.search {
+        let pattern = format!("%{}%", super::artists::escape_like(query));
+        // Bound twice rather than once: positional parameters are cheaper to
+        // keep straight than named ones across an assembled query.
+        params.push(Box::new(pattern.clone()));
+        params.push(Box::new(pattern));
+        wheres.push(
+            "(al.title LIKE ? COLLATE NOCASE ESCAPE '\\'
+              OR a.name LIKE ? COLLATE NOCASE ESCAPE '\\')",
+        );
+    }
+    if !wheres.is_empty() {
+        sql.push_str(" WHERE ");
+        sql.push_str(&wheres.join(" AND "));
+    }
+
+    sql.push_str(" ORDER BY ");
+    if let AlbumOrder::Random(seed) = q.order {
+        params.push(Box::new(seed));
+    }
+    sql.push_str(q.order.clause());
+
+    if let Some(limit) = q.limit {
+        params.push(Box::new(limit as i64));
+        params.push(Box::new(q.offset as i64));
+        sql.push_str(" LIMIT ? OFFSET ?");
+    }
+
+    let mut stmt = conn.prepare(&sql)?;
     let rows = stmt
-        .query_map(params![artist_id], album_row)?
+        .query_map(rusqlite::params_from_iter(params.iter()), album_row)?
         .collect::<Result<Vec<_>, _>>()?;
     Ok(rows)
+}
+
+/// Get albums for a specific artist, ordered chronologically.
+pub fn albums_for_artist(conn: &Connection, artist_id: i64) -> Result<Vec<AlbumRow>, DbError> {
+    list_albums(
+        conn,
+        &AlbumQuery {
+            artist_id: Some(artist_id),
+            order: AlbumOrder::Date,
+            ..Default::default()
+        },
+    )
 }
 
 /// Get a single album by ID.
@@ -120,47 +236,19 @@ pub fn album_date(conn: &Connection, album_id: i64) -> Result<Option<String>, Db
 }
 
 /// Albums whose title or artist matches, case-insensitive substring.
-///
-/// The narrowing belongs here rather than in each client: every front end wants
-/// the same answer, and the ones that filtered a fully-loaded list in their own
-/// language paid for reading the whole table to throw most of it away. Matching
-/// is ASCII case-insensitive, like `find_artists` — SQLite's `NOCASE` does not
-/// fold accented letters, so `MOTLEY` finds `Motley` but `MÖTLEY` does not find
-/// `Mötley`.
 pub fn find_albums(conn: &Connection, query: &str) -> Result<Vec<AlbumRow>, DbError> {
-    let pattern = format!("%{}%", super::artists::escape_like(query));
-    let mut stmt = conn.prepare(
-        "SELECT al.id, al.title, al.artist_id, a.name, al.date,
-                al.total_discs, al.total_tracks, al.codec, al.label, al.remote_id,
-                al.added_at
-         FROM albums al
-         LEFT JOIN artists a ON al.artist_id = a.id
-         WHERE al.title LIKE ?1 COLLATE NOCASE ESCAPE '\\'
-            OR a.name LIKE ?1 COLLATE NOCASE ESCAPE '\\'
-         ORDER BY a.name COLLATE LIBRARY, al.date, al.title COLLATE LIBRARY",
-    )?;
-    let rows = stmt
-        .query_map(params![pattern], album_row)?
-        .collect::<Result<Vec<_>, _>>()?;
-    Ok(rows)
+    list_albums(
+        conn,
+        &AlbumQuery {
+            search: Some(query),
+            ..Default::default()
+        },
+    )
 }
 
 /// Get all albums with their artist name, sorted.
 pub fn all_albums(conn: &Connection) -> Result<Vec<AlbumRow>, DbError> {
-    let mut stmt = conn.prepare(
-        "SELECT al.id, al.title, al.artist_id, a.name, al.date,
-                al.total_discs, al.total_tracks, al.codec, al.label, al.remote_id,
-                al.added_at
-         FROM albums al
-         LEFT JOIN artists a ON al.artist_id = a.id
-         ORDER BY a.name COLLATE LIBRARY, al.date, al.title COLLATE LIBRARY",
-    )?;
-
-    let rows = stmt
-        .query_map([], album_row)?
-        .collect::<Result<Vec<_>, _>>()?;
-
-    Ok(rows)
+    list_albums(conn, &AlbumQuery::default())
 }
 
 /// Record what the server knows about an album beyond what a track carries.
@@ -352,6 +440,121 @@ mod tests {
             label.as_deref(),
             Some("Warp"),
             "label should not be nulled by a None value"
+        );
+    }
+
+    /// Six albums across two artists, so a page is smaller than the listing.
+    fn stocked_db() -> Database {
+        use crate::db::queries::{sample_meta, upsert_track};
+        let db = test_db();
+        for (i, (artist, album)) in [
+            ("Autechre", "Amber"),
+            ("Autechre", "Tri Repetae"),
+            ("Autechre", "Confield"),
+            ("Boards of Canada", "Geogaddi"),
+            ("Boards of Canada", "Twoism"),
+            ("Coil", "Horse Rotorvator"),
+        ]
+        .iter()
+        .enumerate()
+        {
+            let mut m = sample_meta("t", artist, album);
+            m.path = Some(format!("/music/{album}/t.flac"));
+            m.date = Some(format!("199{i}"));
+            upsert_track(&db.conn, &m).unwrap();
+        }
+        db
+    }
+
+    #[test]
+    fn paging_walks_the_listing_without_repeating() {
+        let db = stocked_db();
+        let page = |offset| {
+            list_albums(
+                &db.conn,
+                &AlbumQuery {
+                    limit: Some(2),
+                    offset,
+                    ..Default::default()
+                },
+            )
+            .unwrap()
+            .into_iter()
+            .map(|a| a.title)
+            .collect::<Vec<_>>()
+        };
+        let whole = all_albums(&db.conn)
+            .unwrap()
+            .into_iter()
+            .map(|a| a.title)
+            .collect::<Vec<_>>();
+        assert_eq!([page(0), page(2), page(4)].concat(), whole);
+        assert!(
+            page(6).is_empty(),
+            "a page past the end is empty, not wrapped"
+        );
+    }
+
+    #[test]
+    fn search_narrows_on_title_or_artist() {
+        let db = stocked_db();
+        let titles = |q| {
+            find_albums(&db.conn, q)
+                .unwrap()
+                .into_iter()
+                .map(|a| a.title)
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(titles("geogaddi"), ["Geogaddi"]);
+        assert_eq!(titles("autechre").len(), 3, "matched on the artist name");
+    }
+
+    /// The reason the seed exists: page two has to belong to the same shuffle
+    /// as page one, or scrolling repeats and drops records.
+    #[test]
+    fn a_seeded_shuffle_pages_consistently() {
+        let db = stocked_db();
+        let shuffled = |seed, limit, offset| {
+            list_albums(
+                &db.conn,
+                &AlbumQuery {
+                    order: AlbumOrder::Random(seed),
+                    limit,
+                    offset,
+                    ..Default::default()
+                },
+            )
+            .unwrap()
+            .into_iter()
+            .map(|a| a.id)
+            .collect::<Vec<_>>()
+        };
+
+        let whole = shuffled(42, None, 0);
+        assert_eq!(
+            [shuffled(42, Some(4), 0), shuffled(42, Some(4), 4)].concat(),
+            whole
+        );
+        assert_ne!(shuffled(43, None, 0), whole, "a new seed is a new order");
+        assert_eq!(whole.len(), 6, "a shuffle drops nothing");
+    }
+
+    #[test]
+    fn favourites_only_lists_what_was_hearted() {
+        use crate::db::queries::toggle_favourite_album;
+        let db = stocked_db();
+        toggle_favourite_album(&db.conn, "Coil", "Horse Rotorvator").unwrap();
+        let rows = list_albums(
+            &db.conn,
+            &AlbumQuery {
+                favourites_only: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            rows.iter().map(|a| a.title.as_str()).collect::<Vec<_>>(),
+            ["Horse Rotorvator"]
         );
     }
 

--- a/crates/koan-core/src/db/queries/artists.rs
+++ b/crates/koan-core/src/db/queries/artists.rs
@@ -44,63 +44,94 @@ pub fn get_or_create_artist(
     Ok(conn.last_insert_rowid())
 }
 
-/// Find artists by name (case-insensitive substring match).
-pub fn find_artists(conn: &Connection, query: &str) -> Result<Vec<ArtistRow>, DbError> {
-    let pattern = format!("%{}%", escape_like(query));
-    let mut stmt = conn.prepare(
+/// What to list. Artists are always album artists — a track-only credit (a
+/// featured guest) appears inline in the queue, not as a shelf of its own.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ArtistQuery<'a> {
+    /// Case-insensitive substring over the name.
+    pub search: Option<&'a str>,
+    /// Favourited artists only.
+    pub favourites_only: bool,
+    /// `None` for the whole listing. A client that scrolls should page.
+    pub limit: Option<u32>,
+    pub offset: u32,
+}
+
+/// Artists with their album and track counts, narrowed and paged by the
+/// database. Ordered by sort name, falling back to the name.
+pub fn list_artists(conn: &Connection, q: &ArtistQuery) -> Result<Vec<ArtistRow>, DbError> {
+    let mut sql = String::from(
         "SELECT a.id, a.name, a.sort_name, a.remote_id,
                 COUNT(DISTINCT al.id), COUNT(t.id)
          FROM artists a
          INNER JOIN albums al ON al.artist_id = a.id
-         LEFT JOIN tracks t ON t.album_id = al.id
-         WHERE a.name LIKE ?1 COLLATE NOCASE ESCAPE '\\'
-         GROUP BY a.id
-         ORDER BY COALESCE(a.sort_name, a.name) COLLATE LIBRARY",
-    )?;
+         LEFT JOIN tracks t ON t.album_id = al.id",
+    );
+    if q.favourites_only {
+        sql.push_str(" JOIN favourite_artists f ON f.artist_name = a.name");
+    }
+
+    let mut params: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
+    if let Some(query) = q.search {
+        params.push(Box::new(format!("%{}%", escape_like(query))));
+        sql.push_str(" WHERE a.name LIKE ? COLLATE NOCASE ESCAPE '\\'");
+    }
+    sql.push_str(" GROUP BY a.id ORDER BY COALESCE(a.sort_name, a.name) COLLATE LIBRARY");
+    if let Some(limit) = q.limit {
+        params.push(Box::new(limit as i64));
+        params.push(Box::new(q.offset as i64));
+        sql.push_str(" LIMIT ? OFFSET ?");
+    }
+
+    let mut stmt = conn.prepare(&sql)?;
     let rows = stmt
-        .query_map(params![pattern], |row| {
-            Ok(ArtistRow {
-                id: row.get(0)?,
-                name: row.get(1)?,
-                sort_name: row.get(2)?,
-                remote_id: row.get(3)?,
-                album_count: row.get(4)?,
-                track_count: row.get(5)?,
-            })
-        })?
+        .query_map(rusqlite::params_from_iter(params.iter()), artist_row)?
         .collect::<Result<Vec<_>, _>>()?;
     Ok(rows)
 }
 
-/// All artists, sorted by name.
-/// Return artists that own at least one album (album artists only).
-/// Track-only artists (e.g. featured artists) are excluded from the
-/// top-level library view — they appear inline in the queue display.
+fn artist_row(row: &rusqlite::Row) -> rusqlite::Result<ArtistRow> {
+    Ok(ArtistRow {
+        id: row.get(0)?,
+        name: row.get(1)?,
+        sort_name: row.get(2)?,
+        remote_id: row.get(3)?,
+        album_count: row.get(4)?,
+        track_count: row.get(5)?,
+    })
+}
+
+/// One artist, with its counts. `None` if it owns no albums.
+pub fn get_artist(conn: &Connection, artist_id: i64) -> Result<Option<ArtistRow>, DbError> {
+    Ok(conn
+        .query_row(
+            "SELECT a.id, a.name, a.sort_name, a.remote_id,
+                    COUNT(DISTINCT al.id), COUNT(t.id)
+             FROM artists a
+             INNER JOIN albums al ON al.artist_id = a.id
+             LEFT JOIN tracks t ON t.album_id = al.id
+             WHERE a.id = ?1
+             GROUP BY a.id",
+            params![artist_id],
+            artist_row,
+        )
+        .ok())
+}
+
+/// Find artists by name (case-insensitive substring match).
+pub fn find_artists(conn: &Connection, query: &str) -> Result<Vec<ArtistRow>, DbError> {
+    list_artists(
+        conn,
+        &ArtistQuery {
+            search: Some(query),
+            ..Default::default()
+        },
+    )
+}
+
+/// Every album artist, sorted by name.
 pub fn all_artists(conn: &Connection) -> Result<Vec<ArtistRow>, DbError> {
-    let mut stmt = conn.prepare(
-        "SELECT a.id, a.name, a.sort_name, a.remote_id,
-                COUNT(DISTINCT al.id), COUNT(t.id)
-         FROM artists a
-         INNER JOIN albums al ON al.artist_id = a.id
-         LEFT JOIN tracks t ON t.album_id = al.id
-         GROUP BY a.id
-         ORDER BY COALESCE(a.sort_name, a.name) COLLATE LIBRARY",
-    )?;
-
-    let rows = stmt
-        .query_map([], |row| {
-            Ok(ArtistRow {
-                id: row.get(0)?,
-                name: row.get(1)?,
-                sort_name: row.get(2)?,
-                remote_id: row.get(3)?,
-                album_count: row.get(4)?,
-                track_count: row.get(5)?,
-            })
-        })?
-        .collect::<Result<Vec<_>, _>>()?;
-
-    Ok(rows)
+    list_artists(conn, &ArtistQuery::default())
 }
 
 /// Record what the server knows about an artist beyond its name.
@@ -134,6 +165,76 @@ mod tests {
         conn.pragma_update(None, "foreign_keys", "on").unwrap();
         crate::db::schema::create_tables(&conn).unwrap();
         Database { conn }
+    }
+
+    /// Artists only appear once they own an album, so the fixture goes in
+    /// through a track.
+    fn stocked_db() -> Database {
+        use crate::db::queries::{sample_meta, upsert_track};
+        let db = test_db();
+        for (i, artist) in ["Autechre", "Boards of Canada", "Coil", "Dopplereffekt"]
+            .iter()
+            .enumerate()
+        {
+            let mut m = sample_meta("t", artist, "Album");
+            m.path = Some(format!("/music/{i}/t.flac"));
+            upsert_track(&db.conn, &m).unwrap();
+        }
+        db
+    }
+
+    #[test]
+    fn paging_walks_the_listing_without_repeating() {
+        let db = stocked_db();
+        let page = |offset| {
+            list_artists(
+                &db.conn,
+                &ArtistQuery {
+                    limit: Some(2),
+                    offset,
+                    ..Default::default()
+                },
+            )
+            .unwrap()
+            .into_iter()
+            .map(|a| a.name)
+            .collect::<Vec<_>>()
+        };
+        assert_eq!(page(0), ["Autechre", "Boards of Canada"]);
+        assert_eq!(page(2), ["Coil", "Dopplereffekt"]);
+        assert!(page(4).is_empty());
+    }
+
+    #[test]
+    fn favourites_only_lists_what_was_hearted() {
+        use crate::db::queries::toggle_favourite_artist;
+        let db = stocked_db();
+        toggle_favourite_artist(&db.conn, "Coil").unwrap();
+        let rows = list_artists(
+            &db.conn,
+            &ArtistQuery {
+                favourites_only: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            rows.iter().map(|a| a.name.as_str()).collect::<Vec<_>>(),
+            ["Coil"]
+        );
+    }
+
+    #[test]
+    fn one_artist_carries_its_counts() {
+        let db = stocked_db();
+        let id = find_artists(&db.conn, "Coil").unwrap()[0].id;
+        let artist = get_artist(&db.conn, id)
+            .unwrap()
+            .expect("Coil owns an album");
+        assert_eq!(artist.name, "Coil");
+        assert_eq!(artist.album_count, 1);
+        assert_eq!(artist.track_count, 1);
+        assert!(get_artist(&db.conn, 9999).unwrap().is_none());
     }
 
     #[test]

--- a/crates/koan-core/src/db/queries/history.rs
+++ b/crates/koan-core/src/db/queries/history.rs
@@ -158,7 +158,8 @@ pub struct PlayHistoryRow {
 pub fn play_history_with_tracks(
     conn: &Connection,
     search: Option<&str>,
-    limit: u32,
+    // `None` for every play ever recorded.
+    limit: Option<u32>,
     offset: u32,
 ) -> Result<Vec<PlayHistoryRow>, DbError> {
     let mut sql = String::from(
@@ -185,9 +186,12 @@ pub fn play_history_with_tracks(
                  OR al.title LIKE ? COLLATE NOCASE ESCAPE '\\'",
         );
     }
-    sql.push_str(" ORDER BY h.played_at DESC, h.id DESC LIMIT ? OFFSET ?");
-    params.push(Box::new(limit as i64));
-    params.push(Box::new(offset as i64));
+    sql.push_str(" ORDER BY h.played_at DESC, h.id DESC");
+    if let Some(limit) = limit {
+        params.push(Box::new(limit as i64));
+        params.push(Box::new(offset as i64));
+        sql.push_str(" LIMIT ? OFFSET ?");
+    }
 
     let mut stmt = conn.prepare(&sql)?;
     let rows = stmt
@@ -278,7 +282,7 @@ mod tests {
         record_play_at(&db.conn, b, 200, None, SOURCE_SUBSONIC).unwrap();
         record_play_at(&db.conn, a, 300, Some(2000), SOURCE_LOCAL).unwrap();
 
-        let rows = play_history_with_tracks(&db.conn, None, 10, 0).unwrap();
+        let rows = play_history_with_tracks(&db.conn, None, Some(10), 0).unwrap();
         assert_eq!(
             rows.iter()
                 .map(|r| r.track.title.as_str())
@@ -302,13 +306,20 @@ mod tests {
         record_play_at(&db.conn, b, 200, None, SOURCE_LOCAL).unwrap();
 
         let titles = |q| {
-            play_history_with_tracks(&db.conn, Some(q), 10, 0)
+            play_history_with_tracks(&db.conn, Some(q), None, 0)
                 .unwrap()
                 .into_iter()
                 .map(|r| r.track.title)
                 .collect::<Vec<_>>()
         };
         assert_eq!(titles("autumn"), ["Autumn"]);
+        assert_eq!(
+            play_history_with_tracks(&db.conn, None, None, 0)
+                .unwrap()
+                .len(),
+            2,
+            "no limit is every play ever recorded"
+        );
         assert_eq!(titles("Artist1").len(), 2, "matched on the artist name");
         assert!(titles("nothing here").is_empty());
     }
@@ -321,19 +332,19 @@ mod tests {
             record_play_at(&db.conn, id, at, None, SOURCE_LOCAL).unwrap();
         }
         assert_eq!(
-            play_history_with_tracks(&db.conn, None, 2, 0)
+            play_history_with_tracks(&db.conn, None, Some(2), 0)
                 .unwrap()
                 .len(),
             2
         );
         assert_eq!(
-            play_history_with_tracks(&db.conn, None, 2, 4)
+            play_history_with_tracks(&db.conn, None, Some(2), 4)
                 .unwrap()
                 .len(),
             1
         );
         assert_eq!(
-            play_history_with_tracks(&db.conn, None, 10, 5)
+            play_history_with_tracks(&db.conn, None, Some(10), 5)
                 .unwrap()
                 .len(),
             0
@@ -350,7 +361,7 @@ mod tests {
         record_play_at(&db.conn, a, 42, None, SOURCE_LOCAL).unwrap();
         record_play_at(&db.conn, b, 42, None, SOURCE_LOCAL).unwrap();
 
-        let rows = play_history_with_tracks(&db.conn, None, 10, 0).unwrap();
+        let rows = play_history_with_tracks(&db.conn, None, Some(10), 0).unwrap();
         assert_eq!(
             rows.iter()
                 .map(|r| r.track.title.as_str())
@@ -371,7 +382,7 @@ mod tests {
 
         assert_eq!(play_count(&db.conn, id).unwrap(), 0);
         assert!(
-            play_history_with_tracks(&db.conn, None, 10, 0)
+            play_history_with_tracks(&db.conn, None, Some(10), 0)
                 .unwrap()
                 .is_empty()
         );
@@ -391,7 +402,7 @@ mod tests {
         // whatever entry happens to be open.
         set_listened_ms(&db.conn, first, b, 9_999).unwrap();
 
-        let rows = play_history_with_tracks(&db.conn, None, 10, 0).unwrap();
+        let rows = play_history_with_tracks(&db.conn, None, Some(10), 0).unwrap();
         let by_id: Vec<_> = rows.iter().map(|r| (r.id, r.listened_ms)).collect();
         assert!(by_id.contains(&(second, Some(4_200))));
         assert!(
@@ -410,7 +421,7 @@ mod tests {
 
         assert_eq!(delete_plays(&db.conn, &[first, third]).unwrap(), 2);
 
-        let left = play_history_with_tracks(&db.conn, None, 10, 0).unwrap();
+        let left = play_history_with_tracks(&db.conn, None, Some(10), 0).unwrap();
         assert_eq!(left.len(), 1);
         assert_eq!(left[0].id, second);
         assert_eq!(

--- a/crates/koan-core/src/db/queries/history.rs
+++ b/crates/koan-core/src/db/queries/history.rs
@@ -157,10 +157,11 @@ pub struct PlayHistoryRow {
 /// always does; the history columns follow.
 pub fn play_history_with_tracks(
     conn: &Connection,
+    search: Option<&str>,
     limit: u32,
     offset: u32,
 ) -> Result<Vec<PlayHistoryRow>, DbError> {
-    let mut stmt = conn.prepare(
+    let mut sql = String::from(
         "SELECT t.id, t.album_id, t.artist_id, a.name, aa.name, al.title,
                 t.disc, t.track_number, t.title, t.duration_ms, t.path,
                 t.codec, t.sample_rate, t.bit_depth, t.channels, t.bitrate,
@@ -170,12 +171,27 @@ pub fn play_history_with_tracks(
          JOIN tracks t ON t.id = h.track_id
          LEFT JOIN artists a ON t.artist_id = a.id
          LEFT JOIN albums al ON t.album_id = al.id
-         LEFT JOIN artists aa ON al.artist_id = aa.id
-         ORDER BY h.played_at DESC, h.id DESC
-         LIMIT ?1 OFFSET ?2",
-    )?;
+         LEFT JOIN artists aa ON al.artist_id = aa.id",
+    );
+    let mut params: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
+    if let Some(query) = search {
+        let pattern = format!("%{}%", super::artists::escape_like(query));
+        for _ in 0..3 {
+            params.push(Box::new(pattern.clone()));
+        }
+        sql.push_str(
+            " WHERE t.title LIKE ? COLLATE NOCASE ESCAPE '\\'
+                 OR a.name LIKE ? COLLATE NOCASE ESCAPE '\\'
+                 OR al.title LIKE ? COLLATE NOCASE ESCAPE '\\'",
+        );
+    }
+    sql.push_str(" ORDER BY h.played_at DESC, h.id DESC LIMIT ? OFFSET ?");
+    params.push(Box::new(limit as i64));
+    params.push(Box::new(offset as i64));
+
+    let mut stmt = conn.prepare(&sql)?;
     let rows = stmt
-        .query_map(params![limit as i64, offset as i64], |row| {
+        .query_map(rusqlite::params_from_iter(params.iter()), |row| {
             Ok(PlayHistoryRow {
                 track: super::row_to_track_row(row)?,
                 id: row.get(20)?,
@@ -262,7 +278,7 @@ mod tests {
         record_play_at(&db.conn, b, 200, None, SOURCE_SUBSONIC).unwrap();
         record_play_at(&db.conn, a, 300, Some(2000), SOURCE_LOCAL).unwrap();
 
-        let rows = play_history_with_tracks(&db.conn, 10, 0).unwrap();
+        let rows = play_history_with_tracks(&db.conn, None, 10, 0).unwrap();
         assert_eq!(
             rows.iter()
                 .map(|r| r.track.title.as_str())
@@ -278,15 +294,50 @@ mod tests {
     }
 
     #[test]
+    fn history_narrows_on_the_track_it_played() {
+        let db = test_db();
+        let a = seed_track(&db, "Autumn");
+        let b = seed_track(&db, "Winter");
+        record_play_at(&db.conn, a, 100, None, SOURCE_LOCAL).unwrap();
+        record_play_at(&db.conn, b, 200, None, SOURCE_LOCAL).unwrap();
+
+        let titles = |q| {
+            play_history_with_tracks(&db.conn, Some(q), 10, 0)
+                .unwrap()
+                .into_iter()
+                .map(|r| r.track.title)
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(titles("autumn"), ["Autumn"]);
+        assert_eq!(titles("Artist1").len(), 2, "matched on the artist name");
+        assert!(titles("nothing here").is_empty());
+    }
+
+    #[test]
     fn history_paginates() {
         let db = test_db();
         let id = seed_track(&db, "A");
         for at in 0..5 {
             record_play_at(&db.conn, id, at, None, SOURCE_LOCAL).unwrap();
         }
-        assert_eq!(play_history_with_tracks(&db.conn, 2, 0).unwrap().len(), 2);
-        assert_eq!(play_history_with_tracks(&db.conn, 2, 4).unwrap().len(), 1);
-        assert_eq!(play_history_with_tracks(&db.conn, 10, 5).unwrap().len(), 0);
+        assert_eq!(
+            play_history_with_tracks(&db.conn, None, 2, 0)
+                .unwrap()
+                .len(),
+            2
+        );
+        assert_eq!(
+            play_history_with_tracks(&db.conn, None, 2, 4)
+                .unwrap()
+                .len(),
+            1
+        );
+        assert_eq!(
+            play_history_with_tracks(&db.conn, None, 10, 5)
+                .unwrap()
+                .len(),
+            0
+        );
     }
 
     #[test]
@@ -299,7 +350,7 @@ mod tests {
         record_play_at(&db.conn, a, 42, None, SOURCE_LOCAL).unwrap();
         record_play_at(&db.conn, b, 42, None, SOURCE_LOCAL).unwrap();
 
-        let rows = play_history_with_tracks(&db.conn, 10, 0).unwrap();
+        let rows = play_history_with_tracks(&db.conn, None, 10, 0).unwrap();
         assert_eq!(
             rows.iter()
                 .map(|r| r.track.title.as_str())
@@ -320,7 +371,7 @@ mod tests {
 
         assert_eq!(play_count(&db.conn, id).unwrap(), 0);
         assert!(
-            play_history_with_tracks(&db.conn, 10, 0)
+            play_history_with_tracks(&db.conn, None, 10, 0)
                 .unwrap()
                 .is_empty()
         );
@@ -340,7 +391,7 @@ mod tests {
         // whatever entry happens to be open.
         set_listened_ms(&db.conn, first, b, 9_999).unwrap();
 
-        let rows = play_history_with_tracks(&db.conn, 10, 0).unwrap();
+        let rows = play_history_with_tracks(&db.conn, None, 10, 0).unwrap();
         let by_id: Vec<_> = rows.iter().map(|r| (r.id, r.listened_ms)).collect();
         assert!(by_id.contains(&(second, Some(4_200))));
         assert!(
@@ -359,7 +410,7 @@ mod tests {
 
         assert_eq!(delete_plays(&db.conn, &[first, third]).unwrap(), 2);
 
-        let left = play_history_with_tracks(&db.conn, 10, 0).unwrap();
+        let left = play_history_with_tracks(&db.conn, None, 10, 0).unwrap();
         assert_eq!(left.len(), 1);
         assert_eq!(left[0].id, second);
         assert_eq!(

--- a/crates/koan-core/src/db/queries/tracks.rs
+++ b/crates/koan-core/src/db/queries/tracks.rs
@@ -1268,6 +1268,48 @@ pub fn favourite_track_ids_batch(conn: &Connection) -> Result<HashSet<i64>, DbEr
     Ok(ids)
 }
 
+/// Every favourited track, narrowed by `search` and ordered as a library
+/// reads: artist, record, then running order.
+///
+/// One query rather than a favourite id list the caller resolves row by row —
+/// which is what the id set is for, and it is not for this.
+pub fn favourite_tracks(conn: &Connection, search: Option<&str>) -> Result<Vec<TrackRow>, DbError> {
+    let mut sql = String::from(
+        "SELECT DISTINCT t.id, t.album_id, t.artist_id, a.name, aa.name, al.title,
+                t.disc, t.track_number, t.title, t.duration_ms, t.path,
+                t.codec, t.sample_rate, t.bit_depth, t.channels, t.bitrate,
+                t.genre, t.source, t.remote_id, t.cached_path
+         FROM tracks t
+         JOIN favourites f ON (t.path = f.track_path
+                            OR t.cached_path = f.track_path
+                            OR t.remote_url = f.track_path)
+         LEFT JOIN artists a ON t.artist_id = a.id
+         LEFT JOIN albums al ON t.album_id = al.id
+         LEFT JOIN artists aa ON al.artist_id = aa.id",
+    );
+    let mut params: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
+    if let Some(query) = search {
+        let pattern = format!("%{}%", super::artists::escape_like(query));
+        for _ in 0..3 {
+            params.push(Box::new(pattern.clone()));
+        }
+        sql.push_str(
+            " WHERE t.title LIKE ? COLLATE NOCASE ESCAPE '\\'
+                 OR a.name LIKE ? COLLATE NOCASE ESCAPE '\\'
+                 OR al.title LIKE ? COLLATE NOCASE ESCAPE '\\'",
+        );
+    }
+    sql.push_str(
+        " ORDER BY a.name COLLATE LIBRARY, al.title COLLATE LIBRARY, t.disc, t.track_number",
+    );
+
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt
+        .query_map(rusqlite::params_from_iter(params.iter()), row_to_track_row)?
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(rows)
+}
+
 /// Get all album IDs that have at least one favourited track, in a single query.
 pub fn favourite_album_ids_batch(conn: &Connection) -> Result<HashSet<i64>, DbError> {
     let mut stmt = conn.prepare(
@@ -1294,6 +1336,33 @@ mod tests {
         conn.pragma_update(None, "foreign_keys", "on").unwrap();
         crate::db::schema::create_tables(&conn).unwrap();
         Database { conn }
+    }
+
+    #[test]
+    fn favourite_tracks_come_back_as_rows_narrowed_by_search() {
+        use crate::db::queries::toggle_favourite;
+        let db = test_db();
+        upsert_track(&db.conn, &sample_meta("Amber", "Autechre", "Amber")).unwrap();
+        upsert_track(&db.conn, &sample_meta("Foil", "Autechre", "Amber")).unwrap();
+
+        let titles = |q| {
+            favourite_tracks(&db.conn, q)
+                .unwrap()
+                .into_iter()
+                .map(|t| t.title)
+                .collect::<Vec<_>>()
+        };
+        assert!(titles(None).is_empty(), "nothing is favourite until it is");
+
+        toggle_favourite(&db.conn, Path::new("/music/Amber/Amber.flac")).unwrap();
+        toggle_favourite(&db.conn, Path::new("/music/Amber/Foil.flac")).unwrap();
+        assert_eq!(titles(None), ["Amber", "Foil"]);
+        assert_eq!(titles(Some("foil")), ["Foil"]);
+        assert_eq!(
+            titles(Some("autechre")).len(),
+            2,
+            "matched on the artist name"
+        );
     }
 
     #[test]

--- a/crates/koan-core/src/db/schema.rs
+++ b/crates/koan-core/src/db/schema.rs
@@ -9,6 +9,7 @@ pub fn create_tables(conn: &Connection) -> rusqlite::Result<()> {
     // Before any DDL: the ORDER BY clauses that use it are everywhere, and a
     // connection without it fails them rather than sorting differently.
     super::connection::register_library_collation(conn)?;
+    super::connection::register_shuffle_function(conn)?;
     let found: i64 = conn.query_row("PRAGMA user_version", [], |r| r.get(0))?;
     if found > SCHEMA_VERSION {
         return Err(rusqlite::Error::SqliteFailure(

--- a/crates/koan-ffi/src/lib.rs
+++ b/crates/koan-ffi/src/lib.rs
@@ -424,63 +424,78 @@ impl KoanEngine {
 
     // --- Library -----------------------------------------------------------
 
+    /// The library's artists, narrowed by `search` and paged by `limit`/`offset`.
+    ///
+    /// `limit` of `None` is the whole listing — for a caller that genuinely
+    /// wants all of it, not for one that is about to show the first screenful.
     pub async fn artists(
         self: Arc<Self>,
         search: Option<String>,
+        limit: Option<u32>,
+        offset: u32,
     ) -> Result<Vec<Artist>, KoanError> {
         offload::offload(move || {
             let db = self.db()?;
-            let rows = match search.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
-                Some(q) => queries::find_artists(&db.conn, q),
-                None => queries::all_artists(&db.conn),
-            }
+            let rows = queries::list_artists(
+                &db.conn,
+                &queries::ArtistQuery {
+                    search: trimmed(&search),
+                    limit,
+                    offset,
+                    ..Default::default()
+                },
+            )
             .map_err(db_err)?;
             Ok(rows.into_iter().map(Artist::from).collect())
         })
         .await
     }
 
-    /// The library's albums, narrowed by `search` if given.
+    pub async fn artist(self: Arc<Self>, artist_id: i64) -> Result<Option<Artist>, KoanError> {
+        offload::offload(move || {
+            let db = self.db()?;
+            Ok(queries::get_artist(&db.conn, artist_id)
+                .map_err(db_err)?
+                .map(Artist::from))
+        })
+        .await
+    }
+
+    /// The library's albums, narrowed by `search`, ordered by `sort` and paged
+    /// by `limit`/`offset`.
     ///
-    /// The search runs in SQL rather than over the returned list: a client that
-    /// filters what it has already been handed still pays to read and marshal
-    /// every album in the library on each keystroke.
+    /// All three run in SQL. A client that narrows or sorts what it has already
+    /// been handed still pays to read and marshal every album in the library on
+    /// each keystroke, and one that pages a listing it sorted itself gets a
+    /// page of the wrong order.
+    ///
+    /// `seed` fixes the shuffle under [`AlbumSort::Random`] and is ignored by
+    /// every other sort. Pages of one seed belong to one shuffle; a new seed is
+    /// a new shuffle, which is what a reshuffle button asks for.
     pub async fn albums(
         self: Arc<Self>,
         artist_id: Option<i64>,
         sort: AlbumSort,
+        seed: i64,
         search: Option<String>,
+        limit: Option<u32>,
+        offset: u32,
     ) -> Result<Vec<Album>, KoanError> {
         offload::offload(move || {
             let db = self.db()?;
-            let query = search.as_deref().map(str::trim).filter(|s| !s.is_empty());
-            let rows = match (artist_id, query) {
-                (Some(id), _) => queries::albums_for_artist(&db.conn, id),
-                (None, Some(q)) => queries::find_albums(&db.conn, q),
-                (None, None) => queries::all_albums(&db.conn),
-            }
+            let rows = queries::list_albums(
+                &db.conn,
+                &queries::AlbumQuery {
+                    artist_id,
+                    search: trimmed(&search),
+                    order: album_order(sort, seed),
+                    limit,
+                    offset,
+                    ..Default::default()
+                },
+            )
             .map_err(db_err)?;
-
-            let mut albums: Vec<Album> = rows.into_iter().map(Album::from).collect();
-            match sort {
-                // Albums predating the added_at column sort last rather than first,
-                // which is what an empty string would do.
-                AlbumSort::RecentlyAdded => albums.sort_by(|a, b| {
-                    b.added_at
-                        .as_deref()
-                        .unwrap_or("")
-                        .cmp(a.added_at.as_deref().unwrap_or(""))
-                }),
-                // Cached: `sort_by_key` recomputes the key on every
-                // comparison, so a plain sort lowercases each title a couple of
-                // dozen times over.
-                AlbumSort::Title => albums.sort_by_cached_key(|a| a.title.to_lowercase()),
-                AlbumSort::Artist => albums
-                    .sort_by_cached_key(|a| (a.artist_name.to_lowercase(), a.year.unwrap_or(0))),
-                AlbumSort::Year => albums.sort_by_key(|a| std::cmp::Reverse(a.year.unwrap_or(0))),
-                AlbumSort::Random => koan_core::helpers::shuffle(&mut albums),
-            }
-            Ok(albums)
+            Ok(rows.into_iter().map(Album::from).collect())
         })
         .await
     }
@@ -542,9 +557,6 @@ impl KoanEngine {
         limit: u32,
     ) -> Result<Vec<FuzzyMatch>, KoanError> {
         offload::offload(move || {
-            use nucleo::pattern::{CaseMatching, Normalization};
-            use nucleo::{Config as NucleoConfig, Nucleo};
-
             let db = self.db()?;
             let items: Vec<(i64, String)> = match kind {
                 SearchKind::Track => queries::all_tracks(&db.conn)
@@ -569,38 +581,59 @@ impl KoanEngine {
                     .collect(),
             };
 
-            let mut nucleo: Nucleo<u32> =
-                Nucleo::new(NucleoConfig::DEFAULT, Arc::new(|| {}), None, 1);
-            let injector = nucleo.injector();
-            for (i, (_, text)) in items.iter().enumerate() {
-                let text = text.clone();
-                injector.push(i as u32, |_val, cols| {
-                    cols[0] = text.into();
-                });
-            }
+            let texts: Vec<&str> = items.iter().map(|(_, t)| t.as_str()).collect();
+            Ok(fuzzy_rank(&texts, &query, limit)
+                .into_iter()
+                .map(|i| FuzzyMatch {
+                    id: items[i].0,
+                    name: items[i].1.clone(),
+                    kind,
+                })
+                .collect())
+        })
+        .await
+    }
 
-            nucleo
-                .pattern
-                .reparse(0, &query, CaseMatching::Smart, Normalization::Smart, false);
-            for _ in 0..20 {
-                nucleo.tick(10);
-            }
+    /// Fuzzy-matched albums, as rows.
+    ///
+    /// Rows rather than ids: the match already read them to build its corpus,
+    /// and a caller handed ids can only resolve them against a catalogue of its
+    /// own — which is the copy this exists to make unnecessary.
+    pub async fn fuzzy_albums(
+        self: Arc<Self>,
+        query: String,
+        limit: u32,
+    ) -> Result<Vec<Album>, KoanError> {
+        offload::offload(move || {
+            let db = self.db()?;
+            let rows = queries::all_albums(&db.conn).map_err(db_err)?;
+            let texts: Vec<String> = rows
+                .iter()
+                .map(|a| format!("{} — {}", a.artist_name, a.title))
+                .collect();
+            let texts: Vec<&str> = texts.iter().map(String::as_str).collect();
+            Ok(fuzzy_rank(&texts, &query, limit)
+                .into_iter()
+                .map(|i| Album::from(rows[i].clone()))
+                .collect())
+        })
+        .await
+    }
 
-            let snap = nucleo.snapshot();
-            let count = (snap.matched_item_count() as usize).min(limit as usize);
-            let mut out = Vec::with_capacity(count);
-            for i in 0..count as u32 {
-                if let Some(item) = snap.get_matched_item(i)
-                    && let Some((id, name)) = items.get(*item.data as usize)
-                {
-                    out.push(FuzzyMatch {
-                        id: *id,
-                        name: name.clone(),
-                        kind,
-                    });
-                }
-            }
-            Ok(out)
+    /// Fuzzy-matched artists, as rows. See [`Self::fuzzy_albums`].
+    pub async fn fuzzy_artists(
+        self: Arc<Self>,
+        query: String,
+        limit: u32,
+    ) -> Result<Vec<Artist>, KoanError> {
+        offload::offload(move || {
+            let db = self.db()?;
+            let rows = queries::all_artists(&db.conn).map_err(db_err)?;
+            let texts: Vec<&str> = rows.iter().map(|a| a.name.as_str()).collect();
+            Ok(fuzzy_rank(&texts, &query, limit)
+                .into_iter()
+                .map(|i| Artist::from(rows[i].clone()))
+                .collect())
         })
         .await
     }
@@ -797,13 +830,14 @@ impl KoanEngine {
     /// entries. Entries whose track has left the library are already gone.
     pub async fn play_history(
         self: Arc<Self>,
+        search: Option<String>,
         limit: u32,
         offset: u32,
     ) -> Result<Vec<PlayHistoryEntry>, KoanError> {
         offload::offload(move || {
             let db = self.db()?;
-            let rows =
-                queries::play_history_with_tracks(&db.conn, limit, offset).map_err(db_err)?;
+            let rows = queries::play_history_with_tracks(&db.conn, trimmed(&search), limit, offset)
+                .map_err(db_err)?;
             let (plays, tracks): (Vec<_>, Vec<_>) = rows
                 .into_iter()
                 .map(|r| ((r.id, r.played_at, r.listened_ms, r.source), r.track))
@@ -857,25 +891,57 @@ impl KoanEngine {
 
     // --- Favourites --------------------------------------------------------
 
-    pub async fn favourites(self: Arc<Self>) -> Result<Vec<Track>, KoanError> {
+    /// Favourited tracks, narrowed by `search`.
+    pub async fn favourites(
+        self: Arc<Self>,
+        search: Option<String>,
+    ) -> Result<Vec<Track>, KoanError> {
         offload::offload(move || {
             let db = self.db()?;
-            let ids = queries::favourite_track_ids_batch(&db.conn).map_err(db_err)?;
-            let mut rows = Vec::new();
-            for id in ids {
-                if let Ok(Some(row)) = queries::get_track_row(&db.conn, id) {
-                    rows.push(row);
-                }
-            }
-            rows.sort_by(|a, b| {
-                (&a.artist_name, &a.album_title, a.disc, a.track_number).cmp(&(
-                    &b.artist_name,
-                    &b.album_title,
-                    b.disc,
-                    b.track_number,
-                ))
-            });
+            let rows = queries::favourite_tracks(&db.conn, trimmed(&search)).map_err(db_err)?;
             Ok(self.decorate(&db, rows))
+        })
+        .await
+    }
+
+    /// Favourited records, as rows, narrowed by `search`.
+    pub async fn favourite_albums(
+        self: Arc<Self>,
+        search: Option<String>,
+    ) -> Result<Vec<Album>, KoanError> {
+        offload::offload(move || {
+            let db = self.db()?;
+            let rows = queries::list_albums(
+                &db.conn,
+                &queries::AlbumQuery {
+                    search: trimmed(&search),
+                    favourites_only: true,
+                    ..Default::default()
+                },
+            )
+            .map_err(db_err)?;
+            Ok(rows.into_iter().map(Album::from).collect())
+        })
+        .await
+    }
+
+    /// Favourited artists, as rows, narrowed by `search`.
+    pub async fn favourite_artists(
+        self: Arc<Self>,
+        search: Option<String>,
+    ) -> Result<Vec<Artist>, KoanError> {
+        offload::offload(move || {
+            let db = self.db()?;
+            let rows = queries::list_artists(
+                &db.conn,
+                &queries::ArtistQuery {
+                    search: trimmed(&search),
+                    favourites_only: true,
+                    ..Default::default()
+                },
+            )
+            .map_err(db_err)?;
+            Ok(rows.into_iter().map(Artist::from).collect())
         })
         .await
     }
@@ -2562,6 +2628,52 @@ fn parse_qid(s: &str) -> Result<QueueItemId, KoanError> {
 
 fn parse_qids(ids: &[String]) -> Result<Vec<QueueItemId>, KoanError> {
     ids.iter().map(|s| parse_qid(s)).collect()
+}
+
+/// A search term the user actually typed, or nothing. Whitespace is not a
+/// filter, and neither is an empty box.
+fn trimmed(search: &Option<String>) -> Option<&str> {
+    search.as_deref().map(str::trim).filter(|s| !s.is_empty())
+}
+
+/// The browser's sort as an order the database can apply.
+fn album_order(sort: AlbumSort, seed: i64) -> queries::AlbumOrder {
+    match sort {
+        AlbumSort::RecentlyAdded => queries::AlbumOrder::RecentlyAdded,
+        AlbumSort::Title => queries::AlbumOrder::Title,
+        AlbumSort::Artist => queries::AlbumOrder::ArtistThenDate,
+        AlbumSort::Year => queries::AlbumOrder::YearDesc,
+        AlbumSort::Random => queries::AlbumOrder::Random(seed),
+    }
+}
+
+/// Rank `texts` against `query`, best first, and return the indices of the top
+/// `limit`. Shared by every fuzzy listing so they rank identically.
+fn fuzzy_rank(texts: &[&str], query: &str, limit: u32) -> Vec<usize> {
+    use nucleo::pattern::{CaseMatching, Normalization};
+    use nucleo::{Config as NucleoConfig, Nucleo};
+
+    let mut nucleo: Nucleo<u32> = Nucleo::new(NucleoConfig::DEFAULT, Arc::new(|| {}), None, 1);
+    let injector = nucleo.injector();
+    for (i, text) in texts.iter().enumerate() {
+        let text = text.to_string();
+        injector.push(i as u32, |_val, cols| {
+            cols[0] = text.into();
+        });
+    }
+
+    nucleo
+        .pattern
+        .reparse(0, query, CaseMatching::Smart, Normalization::Smart, false);
+    for _ in 0..20 {
+        nucleo.tick(10);
+    }
+
+    let snap = nucleo.snapshot();
+    let count = (snap.matched_item_count() as usize).min(limit as usize);
+    (0..count as u32)
+        .filter_map(|i| snap.get_matched_item(i).map(|item| *item.data as usize))
+        .collect()
 }
 
 fn db_err(e: impl std::fmt::Display) -> KoanError {

--- a/crates/koan-ffi/src/lib.rs
+++ b/crates/koan-ffi/src/lib.rs
@@ -88,6 +88,14 @@ pub enum PlayerEvent {
     /// is in flight any more, which is also how a client learns a download
     /// finished.
     DownloadsChanged { downloads: Vec<DownloadProgress> },
+    /// The library's rows changed — a scan, a sync, an import, an organize or
+    /// a folder being forgotten. Carries a version so a client can tell one
+    /// change from a repeat of the one it already handled.
+    ///
+    /// Says nothing about what changed. A client that holds no copy of the
+    /// library only needs to know to ask again, and one that does is holding
+    /// the thing this event exists to warn it about.
+    LibraryChanged { version: u64 },
 }
 
 /// Reports how far a long task has got.
@@ -183,6 +191,10 @@ pub struct KoanEngine {
     /// one per task, because only one runs at a time — they all contend for the
     /// same single database writer.
     cancel_library_task: Arc<std::sync::atomic::AtomicBool>,
+    /// Bumped by anything that writes library rows. The watcher turns a change
+    /// here into a `LibraryChanged` event, so a background scan finishing looks
+    /// the same to a client as one it asked for itself.
+    library_version: Arc<std::sync::atomic::AtomicU64>,
 }
 
 #[uniffi::export]
@@ -424,15 +436,14 @@ impl KoanEngine {
 
     // --- Library -----------------------------------------------------------
 
-    /// The library's artists, narrowed by `search` and paged by `limit`/`offset`.
+    /// The library's artists, narrowed by `search`.
     ///
-    /// `limit` of `None` is the whole listing — for a caller that genuinely
-    /// wants all of it, not for one that is about to show the first screenful.
+    /// Whole, not paged. This is an in-process call, and a library's artists
+    /// are a bounded set — a few thousand records marshalled once beats a
+    /// client that has to know how far it has scrolled.
     pub async fn artists(
         self: Arc<Self>,
         search: Option<String>,
-        limit: Option<u32>,
-        offset: u32,
     ) -> Result<Vec<Artist>, KoanError> {
         offload::offload(move || {
             let db = self.db()?;
@@ -440,8 +451,6 @@ impl KoanEngine {
                 &db.conn,
                 &queries::ArtistQuery {
                     search: trimmed(&search),
-                    limit,
-                    offset,
                     ..Default::default()
                 },
             )
@@ -461,25 +470,24 @@ impl KoanEngine {
         .await
     }
 
-    /// The library's albums, narrowed by `search`, ordered by `sort` and paged
-    /// by `limit`/`offset`.
+    /// The library's albums, narrowed by `search` and ordered by `sort`.
     ///
-    /// All three run in SQL. A client that narrows or sorts what it has already
-    /// been handed still pays to read and marshal every album in the library on
-    /// each keystroke, and one that pages a listing it sorted itself gets a
-    /// page of the wrong order.
+    /// Both run in SQL. A client that narrows or sorts what it has already been
+    /// handed pays to read and marshal every album in the library on each
+    /// keystroke, and has to reimplement in its own language an answer the
+    /// database already knows.
+    ///
+    /// Whole, not paged, for the reason [`Self::artists`] gives.
     ///
     /// `seed` fixes the shuffle under [`AlbumSort::Random`] and is ignored by
-    /// every other sort. Pages of one seed belong to one shuffle; a new seed is
-    /// a new shuffle, which is what a reshuffle button asks for.
+    /// every other sort, so that narrowing a shuffled listing does not deal it
+    /// again. A new seed is a new shuffle, which is what a reshuffle asks for.
     pub async fn albums(
         self: Arc<Self>,
         artist_id: Option<i64>,
         sort: AlbumSort,
         seed: i64,
         search: Option<String>,
-        limit: Option<u32>,
-        offset: u32,
     ) -> Result<Vec<Album>, KoanError> {
         offload::offload(move || {
             let db = self.db()?;
@@ -489,8 +497,6 @@ impl KoanEngine {
                     artist_id,
                     search: trimmed(&search),
                     order: album_order(sort, seed),
-                    limit,
-                    offset,
                     ..Default::default()
                 },
             )
@@ -824,19 +830,19 @@ impl KoanEngine {
 
     // --- Play history ------------------------------------------------------
 
-    /// Recent plays, most recent first.
+    /// Every play, most recent first, narrowed by `search`.
     ///
     /// A list of events, not of tracks: a track played three times is three
     /// entries. Entries whose track has left the library are already gone.
+    ///
+    /// Whole, not paged, for the reason [`Self::artists`] gives.
     pub async fn play_history(
         self: Arc<Self>,
         search: Option<String>,
-        limit: u32,
-        offset: u32,
     ) -> Result<Vec<PlayHistoryEntry>, KoanError> {
         offload::offload(move || {
             let db = self.db()?;
-            let rows = queries::play_history_with_tracks(&db.conn, trimmed(&search), limit, offset)
+            let rows = queries::play_history_with_tracks(&db.conn, trimmed(&search), None, 0)
                 .map_err(db_err)?;
             let (plays, tracks): (Vec<_>, Vec<_>) = rows
                 .into_iter()
@@ -1727,7 +1733,10 @@ impl KoanEngine {
     pub async fn forget_folder(self: Arc<Self>, path: String) -> Result<u64, KoanError> {
         offload::offload(move || {
             let db = self.db()?;
-            koan_core::helpers::forget_folder(&db, Path::new(&path)).map_err(db_err)
+            let removed =
+                koan_core::helpers::forget_folder(&db, Path::new(&path)).map_err(db_err)?;
+            self.bump_library();
+            Ok(removed)
         })
         .await
     }
@@ -1738,7 +1747,9 @@ impl KoanEngine {
     pub async fn forget_remote(self: Arc<Self>) -> Result<u64, KoanError> {
         offload::offload(move || {
             let db = self.db()?;
-            koan_core::helpers::forget_remote(&db).map_err(db_err)
+            let removed = koan_core::helpers::forget_remote(&db).map_err(db_err)?;
+            self.bump_library();
+            Ok(removed)
         })
         .await
     }
@@ -1752,6 +1763,7 @@ impl KoanEngine {
         offload::offload(move || {
             let db = self.db()?;
             let summary = koan_core::helpers::rebuild_index(&db).map_err(db_err)?;
+            self.bump_library();
             Ok(RebuildSummary {
                 tracks: summary.tracks,
                 albums: summary.albums,
@@ -1812,6 +1824,7 @@ impl KoanEngine {
                 message: e.to_string(),
             })?;
 
+            self.bump_library();
             Ok(SyncSummary {
                 artists: synced.library.artists_synced as u32,
                 albums: synced.library.albums_synced as u32,
@@ -2021,6 +2034,7 @@ impl KoanEngine {
             }
             .map_err(organize_err)?;
             self.follow_moved_files(&result);
+            self.bump_library();
             Ok(OrganizePlan::build(
                 result,
                 track_ids.as_ref().map(Vec::len),
@@ -2044,6 +2058,7 @@ impl KoanEngine {
             let db = self.db()?;
             let paths: Vec<PathBuf> = paths.into_iter().map(PathBuf::from).collect();
             let result = koan_core::index::scanner::import_paths(&db, &paths);
+            self.bump_library();
             Ok(ImportSummary {
                 track_ids: result.track_ids,
                 added: result.added as u32,
@@ -2142,6 +2157,9 @@ impl KoanEngine {
                 let mut last_position = u64::MAX;
                 let mut last_signature: Option<(PlaybackState, Option<String>)> = None;
                 let mut last_downloads: Vec<DownloadProgress> = Vec::new();
+                // Starts where the engine starts, so a launch is not announced
+                // as a change to a library nobody has read yet.
+                let mut last_library = 0u64;
 
                 loop {
                     std::thread::sleep(std::time::Duration::from_millis(100));
@@ -2187,6 +2205,14 @@ impl KoanEngine {
                     if downloads != last_downloads {
                         last_downloads = downloads.clone();
                         publish(PlayerEvent::DownloadsChanged { downloads });
+                    }
+
+                    let library = engine
+                        .library_version
+                        .load(std::sync::atomic::Ordering::Relaxed);
+                    if library != last_library {
+                        last_library = library;
+                        publish(PlayerEvent::LibraryChanged { version: library });
                     }
 
                     // Only while playing: a paused position doesn't move, and
@@ -2252,6 +2278,13 @@ impl KoanEngine {
         Ok(self.decorate(&db, sort_rows(rows, sort)))
     }
 
+    /// Say that the library's rows changed. The watcher turns this into a
+    /// `LibraryChanged` event on its next tick.
+    fn bump_library(&self) {
+        self.library_version
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+
     fn scan_blocking(
         &self,
         force: bool,
@@ -2309,6 +2342,7 @@ impl KoanEngine {
                     .map(|(p, e)| format!("{}: {e}", p.display())),
             );
         }
+        self.bump_library();
         Ok(summary)
     }
 
@@ -2323,11 +2357,29 @@ impl KoanEngine {
         let (state, _timeline, viz, tx) = Player::spawn();
         koan_core::radio::spawn_autoqueue(state.clone(), tx.clone(), db_path.clone());
 
+        // Bumped by the background tasks below as well as by everything the UI
+        // asks for, so a sync nobody asked for reaches a client the same way.
+        let library_version = Arc::new(std::sync::atomic::AtomicU64::new(0));
+
+        // Finishing is the interesting edge: rows landed while it ran, and the
+        // moment it stops is the moment they are all there.
+        let finished = {
+            let version = library_version.clone();
+            move |flag: &std::sync::atomic::AtomicBool, running: bool| {
+                if !running && flag.swap(running, std::sync::atomic::Ordering::Relaxed) {
+                    version.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                } else {
+                    flag.store(running, std::sync::atomic::Ordering::Relaxed);
+                }
+            }
+        };
+
         let auto_syncing = Arc::new(std::sync::atomic::AtomicBool::new(false));
         {
             let flag = auto_syncing.clone();
+            let finished = finished.clone();
             koan_core::helpers::spawn_auto_sync(db_path.clone(), move |running| {
-                flag.store(running, std::sync::atomic::Ordering::Relaxed);
+                finished(&flag, running);
             });
         }
 
@@ -2338,7 +2390,7 @@ impl KoanEngine {
         {
             let flag = auto_scanning.clone();
             koan_core::helpers::spawn_library_watch(db_path.clone(), move |running| {
-                flag.store(running, std::sync::atomic::Ordering::Relaxed);
+                finished(&flag, running);
             });
         }
 
@@ -2354,6 +2406,7 @@ impl KoanEngine {
             auto_syncing,
             auto_scanning,
             cancel_library_task: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            library_version: library_version.clone(),
         });
         engine.spawn_watcher();
         Ok(engine)

--- a/crates/koan-ffi/src/types.rs
+++ b/crates/koan-ffi/src/types.rs
@@ -651,8 +651,8 @@ pub struct SimilarArtist {
     pub source: String,
 }
 
-/// Sort orders the library browser offers. Applied after the DB read, so it
-/// works uniformly across every listing regardless of which query produced it.
+/// Sort orders the library browser offers. Applied by the database, because a
+/// listing that is read a page at a time has to be ordered before it is cut.
 #[derive(uniffi::Enum, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AlbumSort {
     /// Newest first. What a library browser should open on — the thing you
@@ -661,8 +661,9 @@ pub enum AlbumSort {
     Title,
     Artist,
     Year,
-    /// Reshuffled on every call, so asking again gives a different order —
-    /// which is the point: it's for turning up records you'd forgotten.
+    /// Shuffled by the seed passed alongside it. The same seed is the same
+    /// order, page after page; a new seed is a new order — which is the point,
+    /// it's for turning up records you'd forgotten.
     Random,
 }
 


### PR DESCRIPTION
Closes #354

`LibraryModel` held the whole catalogue in three shapes — the rows, the narrowed copies of the rows, and dictionaries indexing the rows — to serve views that read none of the originals. A section now asks the engine what it should be showing and shows exactly that.

## Load-bearing decisions

**Narrowing and sorting go to SQL; nothing is paged.** Paging was the first instinct and it was wrong. This is an in-process FFI call, not a wire — five thousand albums is about a megabyte marshalled once, and what the browser actually paid for was the Swift-side re-derivation on every arrival, which removing the copy already took away. Paging bought a scrollbar that lied about the length of the library and a flick that stopped short of the end. Albums, artists, favourites and history all arrive whole.

**`AlbumSort.random` takes a seed.** Not for paging — because otherwise a shuffled listing is dealt again on every keystroke of the filter. The seed means narrowing narrows the shuffle you are looking at, and only the button reshuffles. `koan_shuffle(id, seed)` is a SplitMix64 scalar registered on the connection beside the `LIBRARY` collation, same contract: a connection without it fails the query rather than sorting some other way.

**The engine announces library changes.** Nothing was telling the app that the automatic sync or the watched-folder scan had written rows, so a library that grew in the background stayed invisible until you next visited the section. `PlayerEvent::LibraryChanged` rides the same channel as `QueueChanged` and `DownloadsChanged`, raised by scan, sync, import, organize, forget and rebuild as well as by the two background tasks. Every manual invalidation call in the app is gone — one event drives all of it, and a scan nobody asked for reaches the browser the same way one you did.

**One query builder per entity.** `list_albums`/`list_artists` take a search term, an order, a favourites-only flag and an optional limit. `all_albums`, `find_albums`, `albums_for_artist`, `all_artists` and `find_artists` are now one-line wrappers over them, so the ~25 call sites across koan-server, koan-tui and koan-cli are untouched and there is one place the SQL lives. The limit stays on the core query — it is a database layer and `play_history_with_tracks`/`tracks_paged` already had it — but the FFI offers no paging knob to the app, because the app does not page.

**Search hands back rows.** `fuzzy_albums`/`fuzzy_artists` return `Album`/`Artist` instead of ids. The ranking already read those rows to build its corpus; returning ids only forced the caller to keep a catalogue to resolve them against — which was the whole reason the prefetch existed.

**Favourites narrow in SQL too.** They are small enough that the old in-Swift filter cost nothing measurable; moving them removes the second code path rather than milliseconds. `favourite_albums`/`favourite_artists` return rows in the database's order, so the grid no longer reshuffles itself on every toggle (a `Set` has no order, and the old code took it from the catalogue copy).

The favourite *id sets* stay. They are how a heart knows its state anywhere it appears, and they are not a copy of the library.

## Deleted

`matching()`, `prefetchCatalogue()`, `reindex()`, `albumsById`, `artistsById`, the raw `albums`/`artists`/`favourites`/`playHistory` collections and the `didSet` cascade that rebuilt six collections whenever any of them changed. `SearchModel` no longer depends on `LibraryModel`; `SettingsModel` no longer holds it either. `importFiles` lost its completion hook. `favourites()` no longer runs one `get_track_row` per favourite.

## How to confirm it

- `just check` — 730 core / 109 server / 57 tui tests, clippy clean. New tests cover search on title *or* artist, favourites-only listings, `get_artist`'s counts, history search, unbounded history, and that a seeded shuffle is stable while a different seed reorders.
- Run it: Albums and Artists scroll to the end in one flick with a scrollbar the right length; filter narrows as you type; Random holds its order while you filter and reshuffles on the button; an album or artist opened from search shows its header (those views fetch their own row now rather than looking it up in a catalogue that may not hold it).
- The event path was exercised live — the automatic sync completing is the falling edge that publishes `LibraryChanged`, and it fires on launch with a remote configured.

## Out of scope

`PlayerModel.queue` and its indexes — a mirror of live playback state, not a copy of something the database holds. Left alone, as the issue says.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Djc5cVgFkbXoo8hUpyNinm