### PR TITLE
fix(streaming): large files, and the download state around them

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -210,7 +210,7 @@ A download that gives up sends `TrackFailed` instead, and the parked cursor adva
 | `replaygain.rs` | EBU R128 loudness scanning, gain application, tag read/write via lofty |
 | `viz.rs` | `VizBuffer` (lock-protected ring of f32 samples for analyzer), `VizSnapshot` (atomic snapshot for UI thread), `VizLevels` (spectrum reduced to low/mid/high, cloning no waveform) |
 | `analyzer.rs` | FFT analysis thread — 48-band spectrum, VU meters, peak hold, beat detection (low-band transient). Configurable fps. Writes to `VizSnapshot`. |
-| `streaming.rs` | Progressive download with `Condvar`-based ready signaling for streaming playback |
+| `streaming.rs` | `PartialFileSource` — reads a download in progress off disk, blocking at the write head |
 
 ### `player/`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,13 +18,31 @@
 
   When the transfer lands, seeking comes back on its own. Playback is not interrupted to do it — the decoder is reading a file, and a file being renamed underneath an open descriptor is not something it notices. The finished file is picked up the next time the track is seeked, which is the first moment it matters.
 
+- **A track whose downloaded copy was thrown away plays again.** Clearing downloads deleted the files but left the queue pointing at them and still saying they were ready, so afterwards nothing in the queue would play at all. Anything whose copy has gone is put back to waiting and fetched again.
+
+- **A track still downloading can be played by asking for it.** Double-clicking one opened the path the transfer will be renamed to rather than the one it is writing, and found nothing there — so it waited for the whole download rather than starting. Where a transfer is writing is now part of what says a transfer is running, so there is no longer an order for two threads to get wrong.
+
+- **The seek bar's downloaded extent moves while the download does.** The transport keeps its own copy of what is playing, refreshed when the playback state or the cursor moves — and neither moves during a download, so the mark sat wherever it had been when playback started. It follows the progress it is drawing now.
+
+- **The bar no longer darkens when a download finishes.** It lit the downloaded part rather than dimming the part that had not arrived, so completing a transfer took the highlight away and the whole bar dropped a shade. The quiet end is the one that is missing, and a track already on disk looks like the ordinary bar it is.
+
+- **The playhead is visible on a very long track.** A third of a minute into nine hours is a tenth of a percent of the bar — narrower than the bar is thick, and so drawn as nothing at all. It has a head that does not shrink with the fraction.
+
+- **Half-finished downloads are cleaned up.** koan writes a download straight through and renames it at the end, so a `.part` file still on disk is from a run that did not finish — bytes nothing knows about, since only finished downloads are tracked for eviction. An interrupted nine-hour recording was half a gigabyte that never came back. They are swept at startup, which is the run after the one that left them.
+
 ### Changed
 
 - **A download in progress is played from disk rather than copied into memory.** The decoder used to read from a growing in-memory copy that a second thread filled from the file: a 451 MB recording cost 451 MB of RAM for as long as it played. It reads the file directly now, which costs nothing, seeks backwards for free, and carries on across the rename that ends a download.
 
 ### Added
 
-- **Removing downloads, wholesale or one record at a time.** Library → Clear Downloaded Files throws away everything cached from the server; right-clicking a track, album or artist offers Remove Downloaded Files for just that. Either way the library rows stay and fetch again on demand.
+- **A Downloads section, and a store behind it.** What koan is fetching had no home: it could only be inferred from the queue, which knows about transfers for tracks that are in it and forgets each one the moment it lands — which is when you want to see that it did. There is one account of it now, kept by the downloader itself, and every surface reads it.
+
+  The page lists what is arriving with its rate, how much of how much, and where each row came from. A transfer that has stopped moving says so rather than sitting at a figure that looks like progress, which is the first thing worth knowing when something will not play.
+
+- **Where a track's bytes are, wherever a track is listed.** One mark, in one column, meaning the same thing in the queue as in a record: an empty cloud for something on the server, a ring filling as it arrives, a solid cloud once it is here. The queue drew a ring while a track was fetching and nothing at all afterwards — the one list where you watch a download happen was the one that could not say it had.
+
+- **Fetching and removing downloads, wholesale or a track at a time.** Library → Clear Downloaded Files throws away everything cached from the server. Right-clicking offers whichever of the two applies: a track already downloaded can be removed, one that is not can be fetched without queueing it — for going somewhere without a server, mostly. Either way the library rows stay and fetch again on demand.
 
 - **A graphics level, in Settings -> Appearance.** One slider from `Plain` to `Full`, so koan can be told how much of the machine it may spend on looking like itself. `Full` is what it has always done and stays the default.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 
 ### Added
 
-- **Library → Clear Downloaded Files.** Throws away everything cached from the server. The tracks stay in the library and fetch again on demand.
+- **Removing downloads, wholesale or one record at a time.** Library → Clear Downloaded Files throws away everything cached from the server; right-clicking a track, album or artist offers Remove Downloaded Files for just that. Either way the library rows stay and fetch again on demand.
 
 - **A graphics level, in Settings -> Appearance.** One slider from `Plain` to `Full`, so koan can be told how much of the machine it may spend on looking like itself. `Full` is what it has always done and stays the default.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,13 @@
 
 - **The seek bar shows how far a track can actually be reached, and stops there.** The limit was derived from the download's own byte count and quietly did nothing when a server sent no `Content-Length`, or when under five seconds had arrived — so a scrub could land somewhere the track had not got to. koan works it out once now, from bytes where a length is known and from the measured bitrate where it is not, and the bar draws the same figure the engine enforces.
 
-- **A large track no longer holds the player deaf while it opens.** Reading a container to find out what it is happened on the thread that answers play, pause and seek. Ogg states its duration in its last page, so opening one mid-download read the entire remaining transfer first — twenty-two seconds of an unresponsive player, on a fast connection. That reading now happens on its own thread and comes back as a message like anything else.
+- **A large track no longer holds the player deaf while it opens.** Reading a container to find out what it is happened on the thread that answers play, pause and seek. Ogg states its duration in its last page, so opening one mid-download waited for the entire remaining transfer first — twenty-two seconds of an unresponsive player, on a fast connection. That reading now happens on its own thread and comes back as a message like anything else.
+
+- **A long Opus starts playing straight away rather than waiting for the whole download.** It used to wait because of that last page. koan now asks the container to describe itself from the bytes that have arrived, and where it cannot — which in practice means Ogg, and so Opus — opens it without a length instead. The track starts in milliseconds and plays; what it gives up is seeking, until the download finishes. Formats that describe themselves from the front, which is everything else, are unaffected and stay seekable throughout.
+
+  The transport says which of the two it is rather than leaving you to find out: the bar fills as the file arrives, the playhead moves against the duration the library knows, and reaching for a position it cannot reach yet gets an answer instead of silence.
+
+  When the transfer lands, seeking comes back on its own. Playback is not interrupted to do it — the decoder is reading a file, and a file being renamed underneath an open descriptor is not something it notices. The finished file is picked up the next time the track is seeked, which is the first moment it matters.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,23 @@
 
 ## Unreleased
 
+### Fixed
+
+- **Long tracks streamed from a server no longer break when the download lands.** Playback of a track that started mid-download held on to the name of the temporary file it started from. Finishing a download renames that file, so from then on the track named nothing: the next seek failed to open it and stopped playback outright. A nine-hour recording made it easy to hit, because there was a lot of track left to seek in.
+
+- **Seeking a track that is still downloading stays in the stream.** It used to reopen the partial file as an ordinary file, decoding whatever bytes happened to be on disk and ending the track early. Seeking now stays inside the download and lands anywhere already fetched, forwards or back.
+
+- **The seek bar shows how far a track can actually be reached, and stops there.** The limit was derived from the download's own byte count and quietly did nothing when a server sent no `Content-Length`, or when under five seconds had arrived — so a scrub could land somewhere the track had not got to. koan works it out once now, from bytes where a length is known and from the measured bitrate where it is not, and the bar draws the same figure the engine enforces.
+
+- **A large track no longer holds the player deaf while it opens.** Reading a container to find out what it is happened on the thread that answers play, pause and seek. Ogg states its duration in its last page, so opening one mid-download read the entire remaining transfer first — twenty-two seconds of an unresponsive player, on a fast connection. That reading now happens on its own thread and comes back as a message like anything else.
+
+### Changed
+
+- **A download in progress is played from disk rather than copied into memory.** The decoder used to read from a growing in-memory copy that a second thread filled from the file: a 451 MB recording cost 451 MB of RAM for as long as it played. It reads the file directly now, which costs nothing, seeks backwards for free, and carries on across the rename that ends a download.
+
 ### Added
+
+- **Library → Clear Downloaded Files.** Throws away everything cached from the server. The tracks stay in the library and fetch again on demand.
 
 - **A graphics level, in Settings -> Appearance.** One slider from `Plain` to `Full`, so koan can be told how much of the machine it may spend on looking like itself. `Full` is what it has always done and stays the default.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,7 @@ Pre-push hook (`.claude/settings.json`) runs `cargo fmt --all` + `cargo clippy -
 | `audio/replaygain.rs` | EBU R128 loudness scanning, gain application via lofty |
 | `audio/viz.rs` | `VizBuffer` (ring of f32 samples for analyzer), `VizSnapshot` (atomic snapshot for UI), `VizLevels` (the spectrum as three bands, for callers that poll often and draw little) |
 | `audio/analyzer.rs` | FFT analysis thread — 48-band spectrum, VU meters, peak hold. Runs at configurable FPS |
-| `audio/streaming.rs` | Progressive download with `Condvar`-based ready signaling |
+| `audio/streaming.rs` | `PartialFileSource` — reads a download in progress off disk, blocking at the write head |
 | `player/mod.rs` | `Player` struct, command loop (`run()`), `start_playback()`, `update_playback_state()` |
 | `player/commands.rs` | `PlayerCommand` enum, `CommandChannel` (bounded crossbeam) |
 | `player/state.rs` | `SharedPlayerState`, `Playlist`, `PlaylistItem`, `QueueItemId`, `LoadState`, `PlaybackState`, `derive_visible_queue()` |

--- a/apps/macos/Sources/Koan/KoanApp.swift
+++ b/apps/macos/Sources/Koan/KoanApp.swift
@@ -288,6 +288,10 @@ struct KoanApp: App {
                 Button { state?.art.purge() } label: {
                     Label("Clear Artwork Cache", systemImage: Icon.clear)
                 }
+                Button { state?.library.clearDownloads() } label: {
+                    Label("Clear Downloaded Files", systemImage: Icon.clear)
+                }
+                .disabled(state?.activity.isLibraryBusy ?? false)
             }
         }
 

--- a/apps/macos/Sources/Koan/KoanApp.swift
+++ b/apps/macos/Sources/Koan/KoanApp.swift
@@ -18,6 +18,7 @@ final class AppState {
     let playlists: PlaylistsModel
     let activity: ActivityModel
     let levels: PlayingLevels
+    let downloads: DownloadsModel
     let textFocus = TextFocus()
     let ui = UIState()
     let hotkeys: Hotkeys
@@ -41,6 +42,8 @@ final class AppState {
         let activity = ActivityModel()
         self.activity = activity
         self.levels = PlayingLevels(engine: engine)
+        let downloads = DownloadsModel(engine: engine)
+        self.downloads = downloads
         library.activity = activity
         player.activity = activity
         organize.activity = activity
@@ -61,6 +64,10 @@ final class AppState {
         // else would say so — the count is a database read, and the download
         // ran in the engine.
         player.onDownloadsLanded = { [weak library] in library?.loadStats() }
+        // The list, and the figures on it, arrive on two different events at
+        // two very different rates — see `DownloadsModel`.
+        player.onDownloadStoreChanged = { [weak downloads] in downloads?.reload() }
+        player.onDownloadProgress = { [weak downloads] in downloads?.applyProgress($0) }
         player.onLibraryChanged = { [weak library] in library?.libraryChanged() }
 
         // Control Center and the media keys ride the player's existing poll.
@@ -114,6 +121,7 @@ struct KoanApp: App {
                         .environment(state.playlists)
                         .environment(state.activity)
                         .environment(state.levels)
+                        .environment(state.downloads)
                         // One accent for the whole app, from the icon. Without
                         // this everything inherits the system blue.
                         .tint(.koanAccent)

--- a/apps/macos/Sources/Koan/Support/DownloadsModel.swift
+++ b/apps/macos/Sources/Koan/Support/DownloadsModel.swift
@@ -19,10 +19,13 @@ final class DownloadsModel {
 
     private(set) var items: [DownloadEntry] = []
 
-    /// What the sidebar counts. Zero most of the time.
-    var activeCount: Int {
-        items.lazy.filter { $0.state == .queued || $0.state == .running }.count
-    }
+    /// What the sidebar counts.
+    ///
+    /// Its own property rather than a count over `items`. Reading it there
+    /// meant the sidebar re-rendered every time the list was refreshed, which
+    /// while anything is downloading is ten times a second — for a number that
+    /// changes when a transfer starts or ends and at no other time.
+    private(set) var activeCount = 0
 
     var hasSettled: Bool {
         items.contains { $0.state == .done || $0.state == .failed }
@@ -33,24 +36,57 @@ final class DownloadsModel {
     }
 
     /// The list changed shape. Refetch it.
+    ///
+    /// Called when the store's version moves, and on a timer while the
+    /// downloads page is actually on screen — see `watch()`. Not on every
+    /// progress event: assigning this array is what tells SwiftUI the list
+    /// changed, and doing that ten times a second re-rendered everything
+    /// reading it whether or not anyone was looking at a download.
     func reload() {
-        items = engine.downloads()
+        let fresh = engine.downloads()
+        if fresh.count != items.count
+            || zip(fresh, items).contains(where: { !$0.matches($1) })
+        {
+            items = fresh
+        }
+        let active = fresh.lazy.filter { $0.state == .queued || $0.state == .running }.count
+        if active != activeCount { activeCount = active }
     }
 
-    /// Byte counts moved. Re-read them from the store.
+    /// Byte counts moved.
     ///
-    /// The event carries figures of its own, derived from the queue, but taking
-    /// them would mean two accounts of one transfer that have to agree — and
-    /// the store already holds a live counter the downloader writes. So the
-    /// event is used only as a tick, and the numbers come from the one place
-    /// that has them. Half a dozen rows of small strings; the copy is nothing.
+    /// Only the count is taken. The figures behind it are read from the store,
+    /// and only while somebody is looking at them — this fires ten times a
+    /// second for as long as a transfer runs, and it is the busiest thing in
+    /// the app when one does.
     func applyProgress(_ downloads: [DownloadProgress]) {
-        guard !items.isEmpty || !downloads.isEmpty else { return }
-        reload()
+        if downloads.count != activeCount { activeCount = downloads.count }
+    }
+
+    /// Keep `items` fresh for as long as the caller is showing them. Ends when
+    /// the task is cancelled, which is when the page goes away.
+    func watch() async {
+        while !Task.isCancelled {
+            reload()
+            try? await Task.sleep(for: .milliseconds(100))
+        }
     }
 
     func clearSettled() {
         engine.clearSettledDownloads()
         reload()
+    }
+}
+
+private extension DownloadEntry {
+    /// Whether two readings of one transfer say the same thing. Compared field
+    /// by field because the generated record has no equality of its own, and
+    /// because assigning an unchanged array is still a change to SwiftUI.
+    func matches(_ other: DownloadEntry) -> Bool {
+        queueItemId == other.queueItemId
+            && state == other.state
+            && bytesWritten == other.bytesWritten
+            && bytesPerSecond == other.bytesPerSecond
+            && progress == other.progress
     }
 }

--- a/apps/macos/Sources/Koan/Support/DownloadsModel.swift
+++ b/apps/macos/Sources/Koan/Support/DownloadsModel.swift
@@ -1,0 +1,116 @@
+import KoanFFI
+import SwiftUI
+
+/// Everything koan is fetching, and what it fetched a moment ago.
+///
+/// One store rather than a listener per track. The engine broadcasts the whole
+/// in-flight set several times a second, so there is nothing to register when a
+/// download starts and nothing to unregister when it ends — and skipping
+/// between three downloading tracks and back cannot lose one, because every
+/// message carries all of them.
+///
+/// It outlives the queue's own knowledge on purpose. A queue item stops saying
+/// it is downloading the moment it lands, which is exactly when someone wants
+/// to see that it did.
+@MainActor
+@Observable
+final class DownloadsModel {
+    struct Item: Identifiable {
+        let id: String
+        var trackId: Int64?
+        var title: String
+        var artist: String
+        /// 0–1, or `nil` for a transfer whose length the server never gave.
+        var progress: Double?
+        var state: State
+
+        var isActive: Bool { state == .running }
+    }
+
+    enum State: Equatable {
+        case running
+        case finished
+        case failed(String)
+    }
+
+    /// Running first, then whatever has just settled, newest first.
+    private(set) var items: [Item] = []
+
+    /// How many transfers are going. What the sidebar counts.
+    var activeCount: Int { items.lazy.filter(\.isActive).count }
+
+    /// Kept small: this is a view of now, not an archive. Old entries are the
+    /// least interesting thing on the page and would push the live ones off it.
+    private static let settledLimit = 40
+
+    /// The whole in-flight set, as the engine last reported it, joined against
+    /// the queue for names.
+    ///
+    /// Anything previously running and now absent has settled — the queue is
+    /// asked which way, since a failure leaves a reason on the entry and a
+    /// success leaves nothing at all.
+    func apply(_ downloads: [DownloadProgress], queue: [QueueItem]) {
+        let named = Dictionary(queue.map { ($0.queueItemId, $0) }, uniquingKeysWith: { a, _ in a })
+        let running = Set(downloads.map(\.queueItemId))
+
+        for index in items.indices where items[index].state == .running {
+            guard !running.contains(items[index].id) else { continue }
+            items[index].state = settled(items[index].id, in: named)
+            items[index].progress = items[index].state == .finished ? 1 : items[index].progress
+        }
+
+        for download in downloads {
+            let entry = named[download.queueItemId]
+            if let index = items.firstIndex(where: { $0.id == download.queueItemId }) {
+                items[index].progress = download.progress
+                items[index].state = .running
+                // A name can arrive after the transfer does — the queue is
+                // fetched on its own schedule.
+                if let entry {
+                    items[index].title = entry.title
+                    items[index].artist = entry.artist
+                    items[index].trackId = entry.trackId
+                }
+            } else {
+                items.insert(
+                    Item(
+                        id: download.queueItemId,
+                        trackId: entry?.trackId,
+                        title: entry?.title ?? "Unknown track",
+                        artist: entry?.artist ?? "",
+                        progress: download.progress,
+                        state: .running
+                    ),
+                    at: 0
+                )
+            }
+        }
+
+        sortAndTrim()
+    }
+
+    /// Forget what has already settled. The running ones are not this button's
+    /// business — stopping a transfer is a different verb.
+    func clearSettled() {
+        items.removeAll { $0.state != .running }
+    }
+
+    private func settled(_ id: String, in named: [String: QueueItem]) -> State {
+        guard let entry = named[id] else { return .finished }
+        if entry.status == .failed {
+            return .failed(entry.failureReason ?? "Couldn't be fetched")
+        }
+        return .finished
+    }
+
+    private func sortAndTrim() {
+        // A stable partition: running rises, and neither half is reordered, so
+        // a list being watched does not shuffle under the pointer.
+        let running = items.filter(\.isActive)
+        var settled = items.filter { !$0.isActive }
+        if settled.count > Self.settledLimit {
+            settled = Array(settled.prefix(Self.settledLimit))
+        }
+        items = running + settled
+    }
+}

--- a/apps/macos/Sources/Koan/Support/DownloadsModel.swift
+++ b/apps/macos/Sources/Koan/Support/DownloadsModel.swift
@@ -37,20 +37,16 @@ final class DownloadsModel {
         items = engine.downloads()
     }
 
-    /// Byte counts moved. The rows are the same rows, so only the figures are
-    /// taken — replacing the array wholesale would animate every row on every
-    /// tick of a transfer.
+    /// Byte counts moved. Re-read them from the store.
+    ///
+    /// The event carries figures of its own, derived from the queue, but taking
+    /// them would mean two accounts of one transfer that have to agree — and
+    /// the store already holds a live counter the downloader writes. So the
+    /// event is used only as a tick, and the numbers come from the one place
+    /// that has them. Half a dozen rows of small strings; the copy is nothing.
     func applyProgress(_ downloads: [DownloadProgress]) {
-        guard !items.isEmpty else { return }
-        let byItem = Dictionary(
-            downloads.map { ($0.queueItemId, $0.progress) },
-            uniquingKeysWith: { first, _ in first }
-        )
-        for index in items.indices {
-            guard let progress = byItem[items[index].queueItemId] else { continue }
-            guard items[index].progress != progress else { continue }
-            items[index].progress = progress
-        }
+        guard !items.isEmpty || !downloads.isEmpty else { return }
+        reload()
     }
 
     func clearSettled() {

--- a/apps/macos/Sources/Koan/Support/DownloadsModel.swift
+++ b/apps/macos/Sources/Koan/Support/DownloadsModel.swift
@@ -3,114 +3,58 @@ import SwiftUI
 
 /// Everything koan is fetching, and what it fetched a moment ago.
 ///
-/// One store rather than a listener per track. The engine broadcasts the whole
-/// in-flight set several times a second, so there is nothing to register when a
-/// download starts and nothing to unregister when it ends — and skipping
-/// between three downloading tracks and back cannot lose one, because every
-/// message carries all of them.
+/// A mirror, not a store. The engine owns the list — it is the only thing that
+/// knows a transfer started, and it goes on knowing after one lands, which is
+/// exactly when somebody wants to see that it did. This holds the last snapshot
+/// so views have something to draw between events.
 ///
-/// It outlives the queue's own knowledge on purpose. A queue item stops saying
-/// it is downloading the moment it lands, which is exactly when someone wants
-/// to see that it did.
+/// Two events feed it, because two things move at different rates. The list
+/// changes when a transfer appears or settles, which is rare; the byte counts
+/// change hundreds of times a second. Rebuilding the list on the second would
+/// mean rebuilding it at the rate the download writes.
 @MainActor
 @Observable
 final class DownloadsModel {
-    struct Item: Identifiable {
-        let id: String
-        var trackId: Int64?
-        var title: String
-        var artist: String
-        /// 0–1, or `nil` for a transfer whose length the server never gave.
-        var progress: Double?
-        var state: State
+    private let engine: KoanEngine
 
-        var isActive: Bool { state == .running }
+    private(set) var items: [DownloadEntry] = []
+
+    /// What the sidebar counts. Zero most of the time.
+    var activeCount: Int {
+        items.lazy.filter { $0.state == .queued || $0.state == .running }.count
     }
 
-    enum State: Equatable {
-        case running
-        case finished
-        case failed(String)
+    var hasSettled: Bool {
+        items.contains { $0.state == .done || $0.state == .failed }
     }
 
-    /// Running first, then whatever has just settled, newest first.
-    private(set) var items: [Item] = []
+    init(engine: KoanEngine) {
+        self.engine = engine
+    }
 
-    /// How many transfers are going. What the sidebar counts.
-    var activeCount: Int { items.lazy.filter(\.isActive).count }
+    /// The list changed shape. Refetch it.
+    func reload() {
+        items = engine.downloads()
+    }
 
-    /// Kept small: this is a view of now, not an archive. Old entries are the
-    /// least interesting thing on the page and would push the live ones off it.
-    private static let settledLimit = 40
-
-    /// The whole in-flight set, as the engine last reported it, joined against
-    /// the queue for names.
-    ///
-    /// Anything previously running and now absent has settled — the queue is
-    /// asked which way, since a failure leaves a reason on the entry and a
-    /// success leaves nothing at all.
-    func apply(_ downloads: [DownloadProgress], queue: [QueueItem]) {
-        let named = Dictionary(queue.map { ($0.queueItemId, $0) }, uniquingKeysWith: { a, _ in a })
-        let running = Set(downloads.map(\.queueItemId))
-
-        for index in items.indices where items[index].state == .running {
-            guard !running.contains(items[index].id) else { continue }
-            items[index].state = settled(items[index].id, in: named)
-            items[index].progress = items[index].state == .finished ? 1 : items[index].progress
+    /// Byte counts moved. The rows are the same rows, so only the figures are
+    /// taken — replacing the array wholesale would animate every row on every
+    /// tick of a transfer.
+    func applyProgress(_ downloads: [DownloadProgress]) {
+        guard !items.isEmpty else { return }
+        let byItem = Dictionary(
+            downloads.map { ($0.queueItemId, $0.progress) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        for index in items.indices {
+            guard let progress = byItem[items[index].queueItemId] else { continue }
+            guard items[index].progress != progress else { continue }
+            items[index].progress = progress
         }
-
-        for download in downloads {
-            let entry = named[download.queueItemId]
-            if let index = items.firstIndex(where: { $0.id == download.queueItemId }) {
-                items[index].progress = download.progress
-                items[index].state = .running
-                // A name can arrive after the transfer does — the queue is
-                // fetched on its own schedule.
-                if let entry {
-                    items[index].title = entry.title
-                    items[index].artist = entry.artist
-                    items[index].trackId = entry.trackId
-                }
-            } else {
-                items.insert(
-                    Item(
-                        id: download.queueItemId,
-                        trackId: entry?.trackId,
-                        title: entry?.title ?? "Unknown track",
-                        artist: entry?.artist ?? "",
-                        progress: download.progress,
-                        state: .running
-                    ),
-                    at: 0
-                )
-            }
-        }
-
-        sortAndTrim()
     }
 
-    /// Forget what has already settled. The running ones are not this button's
-    /// business — stopping a transfer is a different verb.
     func clearSettled() {
-        items.removeAll { $0.state != .running }
-    }
-
-    private func settled(_ id: String, in named: [String: QueueItem]) -> State {
-        guard let entry = named[id] else { return .finished }
-        if entry.status == .failed {
-            return .failed(entry.failureReason ?? "Couldn't be fetched")
-        }
-        return .finished
-    }
-
-    private func sortAndTrim() {
-        // A stable partition: running rises, and neither half is reordered, so
-        // a list being watched does not shuffle under the pointer.
-        let running = items.filter(\.isActive)
-        var settled = items.filter { !$0.isActive }
-        if settled.count > Self.settledLimit {
-            settled = Array(settled.prefix(Self.settledLimit))
-        }
-        items = running + settled
+        engine.clearSettledDownloads()
+        reload()
     }
 }

--- a/apps/macos/Sources/Koan/Support/Icons.swift
+++ b/apps/macos/Sources/Koan/Support/Icons.swift
@@ -34,6 +34,7 @@ enum Icon {
     /// Put the queue back on the row that is playing.
     static let jumpToPlaying = "scope"
     static let history = "clock.arrow.circlepath"
+    static let downloads = "arrow.down.circle"
     static let playlist = "music.note.list"
     static let search = "magnifyingglass"
     static let add = "plus"

--- a/apps/macos/Sources/Koan/Support/LibraryModel.swift
+++ b/apps/macos/Sources/Koan/Support/LibraryModel.swift
@@ -377,6 +377,16 @@ final class LibraryModel {
         }
     }
 
+    /// Fetch these tracks into the cache without queueing them.
+    ///
+    /// Tracks already downloaded are skipped, so asking for a record you have
+    /// most of costs only the rest of it.
+    func downloadToCache(trackIds: [Int64]) {
+        guard !trackIds.isEmpty else { return }
+        let engine = self.engine
+        Task { try? await engine.downloadToCache(trackIds: trackIds) }
+    }
+
     /// Full rescan of every configured folder. Minutes on a big library, so it
     /// runs detached and the UI stays live throughout.
     func scan(force: Bool = false) {

--- a/apps/macos/Sources/Koan/Support/LibraryModel.swift
+++ b/apps/macos/Sources/Koan/Support/LibraryModel.swift
@@ -169,8 +169,9 @@ final class LibraryModel {
         /// Everything this section is showing.
         func rows() async -> Rows {
             switch section {
-            case .queue, .searchResults, .playlist:
-                // Owned by the player, search and playlist models respectively.
+            case .queue, .searchResults, .playlist, .downloads:
+                // Owned by the player, search, playlist and downloads models
+                // respectively.
                 return .none
             case .albums:
                 return .albums(

--- a/apps/macos/Sources/Koan/Support/LibraryModel.swift
+++ b/apps/macos/Sources/Koan/Support/LibraryModel.swift
@@ -390,6 +390,24 @@ final class LibraryModel {
         }
     }
 
+    /// Throw away every file cached from the server.
+    ///
+    /// The library rows stay — they are what the server said exists — so the
+    /// tracks remain playable and simply download again on demand. Exclusive
+    /// like the other library tasks: it clears the cached paths off every row.
+    func clearDownloads() {
+        guard !isScanning else { return }
+        isScanning = true
+        let engine = self.engine
+        let job = activity?.begin("Clearing downloaded files", exclusive: true)
+        Task {
+            _ = try? await engine.clearDownloadCache()
+            if let job { activity?.end(job) }
+            isScanning = false
+            loadStats()
+        }
+    }
+
     /// Full rescan of every configured folder. Minutes on a big library, so it
     /// runs detached and the UI stays live throughout.
     func scan(force: Bool = false) {

--- a/apps/macos/Sources/Koan/Support/LibraryModel.swift
+++ b/apps/macos/Sources/Koan/Support/LibraryModel.swift
@@ -408,6 +408,21 @@ final class LibraryModel {
         }
     }
 
+    /// Throw away the downloaded copies of these tracks.
+    ///
+    /// Not exclusive like the library-wide tasks: it touches only the rows
+    /// named, and someone clearing one record should not have to wait behind a
+    /// scan. Anything playing from a copy being removed keeps playing — the
+    /// decoder has the file open, and unlinking it only takes the name away.
+    func clearDownloads(trackIds: [Int64]) {
+        guard !trackIds.isEmpty else { return }
+        let engine = self.engine
+        Task {
+            _ = try? await engine.clearDownloads(trackIds: trackIds)
+            loadStats()
+        }
+    }
+
     /// Full rescan of every configured folder. Minutes on a big library, so it
     /// runs detached and the UI stays live throughout.
     func scan(force: Bool = false) {

--- a/apps/macos/Sources/Koan/Support/Navigator.swift
+++ b/apps/macos/Sources/Koan/Support/Navigator.swift
@@ -29,6 +29,7 @@ final class Navigator {
         case artists
         case favourites
         case playHistory
+        case downloads
         /// One playlist. A sidebar row like any other — which is what makes
         /// clicking it light it up, and what lets Back return to it.
         case playlist(Int64)
@@ -44,6 +45,8 @@ final class Navigator {
             case .artists: "Filter artists"
             case .favourites: "Filter favourites"
             case .playHistory: "Filter history"
+            // Short, and ordered by what is happening rather than by name.
+            case .downloads: nil
             // A playlist is a sequence someone chose, and narrowing it hides
             // part of that sequence rather than telling you anything.
             case .queue, .searchResults, .playlist: nil

--- a/apps/macos/Sources/Koan/Support/PlayerModel.swift
+++ b/apps/macos/Sources/Koan/Support/PlayerModel.swift
@@ -204,6 +204,18 @@ final class PlayerModel {
             }
         }
 
+        // The transport reads `currentEntry`, which is its own copy and not one
+        // of the rows above. Without this the seek bar's downloaded extent only
+        // moved when the state or the cursor did — so a track that spends its
+        // whole download unable to say what it is showed a figure frozen at
+        // whatever had arrived when it started, or nothing at all.
+        if let entry = currentEntry {
+            let progress = byItem[entry.queueItemId] ?? nil
+            if entry.downloadProgress != progress {
+                currentEntry?.downloadProgress = progress
+            }
+        }
+
         let active = Set(byItem.keys)
         if !downloading.subtracting(active).isEmpty {
             onDownloadsLanded?()

--- a/apps/macos/Sources/Koan/Support/PlayerModel.swift
+++ b/apps/macos/Sources/Koan/Support/PlayerModel.swift
@@ -50,6 +50,9 @@ final class PlayerModel {
     /// thumb back to the engine's position mid-gesture.
     var scrubbing: Double?
     var lastError: String?
+    /// Something the app declined to do, and why. Not a failure — the state it
+    /// describes resolves on its own.
+    var lastNotice: String?
 
     private var knownQueueVersion: UInt64 = .max
     /// Run after every state read. Now Playing hangs off this rather than
@@ -341,6 +344,13 @@ final class PlayerModel {
     /// 0–1 through the current track. Reflects the drag while scrubbing.
     var progress: Double { scrubbing ?? clock.progress }
 
+    /// Whether the track can be seeked at all yet.
+    ///
+    /// False while a download is playing that could not say what it is until
+    /// the rest of it lands — there is nothing to seek against. It becomes true
+    /// on its own when the transfer finishes.
+    var canSeek: Bool { seekableMs > 0 }
+
     /// How much of the track can be reached, as a fraction.
     ///
     /// 1 for anything on disk. Short of it while a download is still arriving —
@@ -350,6 +360,13 @@ final class PlayerModel {
         guard clock.durationMs > 0, seekableMs < clock.durationMs else { return 1 }
         return Double(seekableMs) / Double(clock.durationMs)
     }
+
+    /// How much of what is playing has arrived, while it is still arriving.
+    ///
+    /// Bytes, not reachable time: the two differ for a track that is playing
+    /// but cannot be seeked, where the point of the mark is to say the transfer
+    /// is going and roughly how far — not to offer a position.
+    var fetched: Double? { currentEntry?.downloadProgress }
 
     var upNext: [QueueItem] {
         guard let cursor = nowPlaying.queueItemId,
@@ -388,9 +405,18 @@ final class PlayerModel {
         min(seekable, min(1, max(0, fraction)))
     }
 
+    /// Why the playhead did not move. Reaching for a position in a track that
+    /// has not arrived is a reasonable thing to try, and a bar that simply
+    /// ignores the attempt teaches nothing.
+    func explainUnseekable() {
+        let progress = fetched.map { " — \(Int($0 * 100))% so far" } ?? ""
+        lastNotice = "Still downloading\(progress). This track can be seeked once it has finished."
+    }
+
     /// Nudge by a number of seconds, clamped to the track. What the arrow-key
     /// shortcuts and the TUI's `,`/`.` do.
     func seek(bySeconds delta: Int) {
+        guard canSeek else { return explainUnseekable() }
         let current = Int64(clock.positionMs)
         let target = max(0, current + Int64(delta) * 1000)
         seek(toMs: UInt64(min(target, Int64(seekableMs))))

--- a/apps/macos/Sources/Koan/Support/PlayerModel.swift
+++ b/apps/macos/Sources/Koan/Support/PlayerModel.swift
@@ -765,8 +765,14 @@ final class PlayerModel {
 extension KoanEngine {
     func events() -> AsyncStream<PlayerEvent> {
         AsyncStream { continuation in
+            // Subscribed once, for the life of the stream. Asking the engine
+            // for each message separately meant a new subscription each time,
+            // and a broadcast receiver only sees what is published after it
+            // subscribes — so everything arriving between one message and the
+            // next request was dropped on the floor.
+            let subscription = self.subscribe()
             let pump = Task {
-                while let event = await self.nextEvent() {
+                while let event = await subscription.next() {
                     continuation.yield(event)
                 }
                 continuation.finish()

--- a/apps/macos/Sources/Koan/Support/PlayerModel.swift
+++ b/apps/macos/Sources/Koan/Support/PlayerModel.swift
@@ -119,6 +119,9 @@ final class PlayerModel {
                     self.applyPosition(positionMs)
                 case .downloadsChanged(let downloads):
                     self.applyDownloads(downloads)
+                    self.onDownloadProgress?(downloads)
+                case .downloadStoreChanged:
+                    self.onDownloadStoreChanged?()
                 case .libraryChanged:
                     self.onLibraryChanged?()
                 }
@@ -238,6 +241,11 @@ final class PlayerModel {
     /// sync nobody asked for reaches the browser — the engine says so rather
     /// than the app having to guess from whatever it happened to start itself.
     var onLibraryChanged: (() -> Void)?
+    /// The set of transfers changed shape — one appeared or settled.
+    var onDownloadStoreChanged: (() -> Void)?
+    /// Byte counts moved. Fires several times a second while anything is
+    /// downloading, and not at all the rest of the time.
+    var onDownloadProgress: (([DownloadProgress]) -> Void)?
 
     /// The queue changed — rebuild it and refresh what depends on it.
     fileprivate func applyQueueChange() async {

--- a/apps/macos/Sources/Koan/Support/PlayerModel.swift
+++ b/apps/macos/Sources/Koan/Support/PlayerModel.swift
@@ -112,9 +112,9 @@ final class PlayerModel {
                 guard let self else { return }
                 switch event {
                 case .playbackChanged(let nowPlaying):
-                    await self.tick(nowPlaying)
+                    self.apply(nowPlaying)
                 case .queueChanged:
-                    await self.applyQueueChange()
+                    self.applyQueueChange()
                 case .positionChanged(let positionMs):
                     self.applyPosition(positionMs)
                 case .downloadsChanged(let downloads):
@@ -129,21 +129,56 @@ final class PlayerModel {
         }
     }
 
-    /// Apply a snapshot. Called on subscribe and whenever the engine says
-    /// something changed.
-    /// Apply a snapshot. `nil` fetches one — which only the initial seed needs,
-    /// since every event that reports a change carries the new state with it.
-    fileprivate func tick(_ snapshot: NowPlaying? = nil) async {
-        let now = if let snapshot { snapshot } else { await engine.nowPlaying() }
+    /// Seed from the engine. Only the initial subscribe needs this — every
+    /// event that reports a change carries the new state with it.
+    fileprivate func tick() async {
+        apply(await engine.nowPlaying())
+    }
+
+    /// Apply a snapshot the engine sent.
+    ///
+    /// Nothing here waits. This runs on the thread draining the event stream,
+    /// and that stream is sequential: an `await` on a database round trip here
+    /// held up every message behind it — position included — for as long as it
+    /// took. Which is why playback appeared to stall precisely when downloads
+    /// were busy bumping the queue version.
+    fileprivate func apply(_ now: NowPlaying) {
         nowPlaying = now
         updateDerived(now)
-        // The queue only gets rebuilt when the engine says it changed.
-        if nowPlaying.playlistVersion != knownQueueVersion {
-            knownQueueVersion = nowPlaying.playlistVersion
-            await rebuildQueue()
+        // The queue only gets rebuilt when the engine says it changed, and the
+        // rebuild happens somewhere this loop is not.
+        if now.playlistVersion != knownQueueVersion {
+            knownQueueVersion = now.playlistVersion
+            scheduleQueueRebuild()
         }
         settlePendingSeek()
         onTick?()
+    }
+
+    /// The rebuild in flight, if there is one.
+    @ObservationIgnored private var queueRebuild: Task<Void, Never>?
+    /// Whether the queue changed again while one was running.
+    @ObservationIgnored private var queueRebuildPending = false
+
+    /// Rebuild the queue off the event stream, and only once for any number of
+    /// changes that arrive while one is running.
+    ///
+    /// A download changing state bumps the queue version, so a handful of
+    /// transfers announce themselves several times a second. Rebuilding per
+    /// announcement meant a database round trip per announcement, in front of
+    /// every other event.
+    private func scheduleQueueRebuild() {
+        guard queueRebuild == nil else {
+            queueRebuildPending = true
+            return
+        }
+        queueRebuild = Task { @MainActor [weak self] in
+            defer { self?.queueRebuild = nil }
+            repeat {
+                self?.queueRebuildPending = false
+                await self?.rebuildQueue()
+            } while self?.queueRebuildPending == true
+        }
     }
 
     /// Where a seek asked to land, until the engine reports being near it.
@@ -248,9 +283,8 @@ final class PlayerModel {
     var onDownloadProgress: (([DownloadProgress]) -> Void)?
 
     /// The queue changed — rebuild it and refresh what depends on it.
-    fileprivate func applyQueueChange() async {
-        await rebuildQueue()
-        await tick()
+    fileprivate func applyQueueChange() {
+        scheduleQueueRebuild()
     }
 
     /// Position moved. The only genuinely periodic event, and the only thing

--- a/apps/macos/Sources/Koan/Support/PlayerModel.swift
+++ b/apps/macos/Sources/Koan/Support/PlayerModel.swift
@@ -19,6 +19,12 @@ final class PlayerModel {
 
     /// Position, on its own observable so only the transport sees the tick.
     let clock = PlaybackClock()
+    /// How far into the current track a seek can land. Equal to the duration
+    /// for anything on disk, and short of it while a download is still
+    /// arriving. Observed, unlike the snapshot it comes from, because the seek
+    /// bar draws it — and change-guarded, because it moves while a track caches
+    /// and then stops for the rest of the record.
+    private(set) var seekableMs: UInt64 = 0
     private(set) var queue: [QueueItem] = []
     /// Queue entries indexed by library track id, so a library row can show
     /// what the queue knows about it — downloading, failed, already played —
@@ -58,8 +64,9 @@ final class PlayerModel {
         // Reading the engine is a suspension now, so the first frame renders
         // against a stopped transport and `start()` fills it in.
         self.nowPlaying = NowPlaying(
-            state: .stopped, positionMs: 0, durationMs: 0, queueItemId: nil,
-            entry: nil, format: nil, playlistVersion: 0, radioEnabled: false
+            state: .stopped, positionMs: 0, durationMs: 0, seekableMs: 0,
+            queueItemId: nil, entry: nil, format: nil, playlistVersion: 0,
+            radioEnabled: false
         )
     }
 
@@ -327,11 +334,22 @@ final class PlayerModel {
         {
             currentFormat = now.format
         }
+        if now.seekableMs != seekableMs { seekableMs = now.seekableMs }
         clock.update(positionMs: now.positionMs, durationMs: now.durationMs)
     }
 
     /// 0–1 through the current track. Reflects the drag while scrubbing.
     var progress: Double { scrubbing ?? clock.progress }
+
+    /// How much of the track can be reached, as a fraction.
+    ///
+    /// 1 for anything on disk. Short of it while a download is still arriving —
+    /// the engine clamps a seek to the same extent, so a scrub past this would
+    /// land somewhere the thumb was never dragged to.
+    var seekable: Double {
+        guard clock.durationMs > 0, seekableMs < clock.durationMs else { return 1 }
+        return Double(seekableMs) / Double(clock.durationMs)
+    }
 
     var upNext: [QueueItem] {
         guard let cursor = nowPlaying.queueItemId,
@@ -351,9 +369,10 @@ final class PlayerModel {
 
     func play(itemId: String) { attempt { try await self.engine.play(queueItemId: itemId) } }
 
-    /// Commit a scrub. Position comes from the drag, not the engine.
+    /// Commit a scrub. Position comes from the drag, not the engine, and stops
+    /// at what has been downloaded.
     func seek(fraction: Double) {
-        seek(toMs: UInt64(max(0, min(1, fraction)) * Double(clock.durationMs)))
+        seek(toMs: UInt64(clamp(fraction) * Double(clock.durationMs)))
     }
 
     /// Called as the thumb is dragged. Cancels any seek still settling, since
@@ -361,7 +380,12 @@ final class PlayerModel {
     func beginScrub(fraction: Double) {
         pendingSeekMs = nil
         pendingSeekTicks = 0
-        scrubbing = min(1, max(0, fraction))
+        scrubbing = clamp(fraction)
+    }
+
+    /// A drag position held inside the track and inside what has arrived.
+    private func clamp(_ fraction: Double) -> Double {
+        min(seekable, min(1, max(0, fraction)))
     }
 
     /// Nudge by a number of seconds, clamped to the track. What the arrow-key
@@ -369,7 +393,7 @@ final class PlayerModel {
     func seek(bySeconds delta: Int) {
         let current = Int64(clock.positionMs)
         let target = max(0, current + Int64(delta) * 1000)
-        seek(toMs: UInt64(min(target, Int64(clock.durationMs))))
+        seek(toMs: UInt64(min(target, Int64(seekableMs))))
     }
 
     /// Hold the requested position until the engine agrees with it.

--- a/apps/macos/Sources/Koan/Support/PlayerModel.swift
+++ b/apps/macos/Sources/Koan/Support/PlayerModel.swift
@@ -198,8 +198,17 @@ final class PlayerModel {
         }
     }
 
+    /// Where each queue item sits, so a progress event can reach its row
+    /// without walking the queue to find it. Rebuilt with the queue, which is
+    /// the only thing that moves rows.
+    @ObservationIgnored private var queueIndex: [String: Int] = [:]
+
     private func rebuildQueue() async {
         queue = await engine.queue()
+        queueIndex = Dictionary(
+            queue.enumerated().map { ($0.element.queueItemId, $0.offset) },
+            uniquingKeysWith: { first, _ in first }
+        )
         // Here rather than at one of the callers: the queue is rebuilt from
         // two places — a queue event, and a playback event carrying a version
         // that moved — and only one of them used to say so. Which of the two
@@ -235,8 +244,14 @@ final class PlayerModel {
             downloads.map { ($0.queueItemId, $0.progress) },
             uniquingKeysWith: { first, _ in first }
         )
-        for index in queue.indices {
-            let progress = byItem[queue[index].queueItemId] ?? nil
+        // Only the rows that are fetching, and the ones that just stopped —
+        // not the whole queue. This runs ten times a second for as long as
+        // anything is downloading, and a queue is thousands of rows long: the
+        // walk cost more than everything else on this loop put together, to
+        // touch the handful of rows that had actually moved.
+        for id in downloading.union(byItem.keys) {
+            guard let index = queueIndex[id], queue.indices.contains(index) else { continue }
+            let progress = byItem[id] ?? nil
             guard queue[index].downloadProgress != progress else { continue }
             queue[index].downloadProgress = progress
             if let trackId = queue[index].trackId {

--- a/apps/macos/Sources/Koan/Views/DownloadsView.swift
+++ b/apps/macos/Sources/Koan/Views/DownloadsView.swift
@@ -8,19 +8,20 @@ import SwiftUI
 /// rather than only flashing past on the row that caused it.
 struct DownloadsView: View {
     @Environment(DownloadsModel.self) private var downloads
-    @Environment(Navigator.self) private var nav
 
     var body: some View {
         Group {
             if downloads.items.isEmpty {
                 ContentUnavailableView(
                     "Nothing downloading",
-                    systemImage: "cloud",
-                    description: Text("Tracks fetched from your server appear here while they arrive.")
+                    systemImage: Icon.downloads,
+                    description: Text(
+                        "Tracks fetched from your server appear here while they arrive."
+                    )
                 )
             } else {
                 List {
-                    ForEach(downloads.items) { item in
+                    ForEach(downloads.items, id: \.queueItemId) { item in
                         DownloadRow(item: item)
                             .listRowSeparator(.hidden)
                     }
@@ -30,71 +31,72 @@ struct DownloadsView: View {
         }
         .navigationTitle("Downloads")
         .toolbar {
-            if downloads.items.contains(where: { !$0.isActive }) {
+            if downloads.hasSettled {
                 Button { downloads.clearSettled() } label: {
                     Label("Clear Finished", systemImage: Icon.clear)
                 }
                 .help("Forget the transfers that have already settled")
             }
         }
+        .task { downloads.reload() }
     }
 }
 
 private struct DownloadRow: View {
-    let item: DownloadsModel.Item
+    let item: DownloadEntry
 
     var body: some View {
         HStack(spacing: 12) {
-            SourceBadges(
-                onServer: true,
-                onDisk: item.state == .finished,
-                downloading: badge
-            )
+            SourceBadges(onServer: true, onDisk: item.state == .done, downloading: badge)
 
             VStack(alignment: .leading, spacing: 3) {
                 Text(item.title).lineLimit(1)
                 Text(subtitle)
                     .font(.caption)
-                    .foregroundStyle(item.state.isFailure ? AnyShapeStyle(.orange) : AnyShapeStyle(.secondary))
+                    .foregroundStyle(
+                        item.state == .failed ? AnyShapeStyle(.orange) : AnyShapeStyle(.secondary)
+                    )
                     .lineLimit(1)
                 // Only while it is moving. A finished transfer's bar is a full
-                // one, which says nothing the filled cloud has not.
-                if item.isActive {
-                    ProgressView(value: item.progress ?? 0, total: 1)
+                // one, which says nothing the filled cloud has not — and a
+                // transfer with no stated length has no fraction to draw, where
+                // a bar sitting at zero would read as stalled.
+                if isRunning, let progress = item.progress {
+                    ProgressView(value: progress, total: 1)
                         .progressViewStyle(.linear)
-                        // An unknown length has no fraction to draw, and a bar
-                        // sitting at zero reads as stalled rather than unmeasured.
-                        .opacity(item.progress == nil ? 0 : 1)
                 }
             }
 
             Spacer(minLength: 8)
 
-            if let progress = item.progress, item.isActive {
-                Text("\(Int(progress * 100))%")
-                    .font(.caption.monospacedDigit())
-                    .foregroundStyle(.secondary)
-            }
+            Text(figure)
+                .font(.caption.monospacedDigit())
+                .foregroundStyle(.secondary)
         }
         .padding(.vertical, 3)
     }
 
+    private var isRunning: Bool { item.state == .running || item.state == .queued }
+
     private var badge: SourceBadges.Download? {
-        guard item.isActive else { return nil }
+        guard isRunning else { return nil }
         return item.progress.map { .fraction($0) } ?? .indeterminate
     }
 
     private var subtitle: String {
         switch item.state {
+        case .failed: item.failureReason ?? "Couldn't be fetched"
+        case .queued: item.artist.isEmpty ? "Waiting" : "\(item.artist) — waiting"
+        case .done: item.artist.isEmpty ? "Downloaded" : "\(item.artist) — downloaded"
         case .running: item.artist
-        case .finished: item.artist.isEmpty ? "Downloaded" : "\(item.artist) — downloaded"
-        case .failed(let reason): reason
         }
     }
-}
 
-private extension DownloadsModel.State {
-    var isFailure: Bool {
-        if case .failed = self { true } else { false }
+    /// A percentage where there is one, and bytes where there is not — a
+    /// transfer the server gave no length for is still visibly moving.
+    private var figure: String {
+        guard isRunning else { return "" }
+        if let progress = item.progress { return "\(Int(progress * 100))%" }
+        return Format.bytes(Int64(item.bytesWritten))
     }
 }

--- a/apps/macos/Sources/Koan/Views/DownloadsView.swift
+++ b/apps/macos/Sources/Koan/Views/DownloadsView.swift
@@ -1,0 +1,100 @@
+import KoanFFI
+import SwiftUI
+
+/// What koan is fetching from the server, and what it just finished fetching.
+///
+/// Mostly a page for when something looks wrong: a transfer that is not moving
+/// says so here, with the figure it is stuck on, and a failure keeps its reason
+/// rather than only flashing past on the row that caused it.
+struct DownloadsView: View {
+    @Environment(DownloadsModel.self) private var downloads
+    @Environment(Navigator.self) private var nav
+
+    var body: some View {
+        Group {
+            if downloads.items.isEmpty {
+                ContentUnavailableView(
+                    "Nothing downloading",
+                    systemImage: "cloud",
+                    description: Text("Tracks fetched from your server appear here while they arrive.")
+                )
+            } else {
+                List {
+                    ForEach(downloads.items) { item in
+                        DownloadRow(item: item)
+                            .listRowSeparator(.hidden)
+                    }
+                }
+                .listStyle(.inset)
+            }
+        }
+        .navigationTitle("Downloads")
+        .toolbar {
+            if downloads.items.contains(where: { !$0.isActive }) {
+                Button { downloads.clearSettled() } label: {
+                    Label("Clear Finished", systemImage: Icon.clear)
+                }
+                .help("Forget the transfers that have already settled")
+            }
+        }
+    }
+}
+
+private struct DownloadRow: View {
+    let item: DownloadsModel.Item
+
+    var body: some View {
+        HStack(spacing: 12) {
+            SourceBadges(
+                onServer: true,
+                onDisk: item.state == .finished,
+                downloading: badge
+            )
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(item.title).lineLimit(1)
+                Text(subtitle)
+                    .font(.caption)
+                    .foregroundStyle(item.state.isFailure ? AnyShapeStyle(.orange) : AnyShapeStyle(.secondary))
+                    .lineLimit(1)
+                // Only while it is moving. A finished transfer's bar is a full
+                // one, which says nothing the filled cloud has not.
+                if item.isActive {
+                    ProgressView(value: item.progress ?? 0, total: 1)
+                        .progressViewStyle(.linear)
+                        // An unknown length has no fraction to draw, and a bar
+                        // sitting at zero reads as stalled rather than unmeasured.
+                        .opacity(item.progress == nil ? 0 : 1)
+                }
+            }
+
+            Spacer(minLength: 8)
+
+            if let progress = item.progress, item.isActive {
+                Text("\(Int(progress * 100))%")
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(.vertical, 3)
+    }
+
+    private var badge: SourceBadges.Download? {
+        guard item.isActive else { return nil }
+        return item.progress.map { .fraction($0) } ?? .indeterminate
+    }
+
+    private var subtitle: String {
+        switch item.state {
+        case .running: item.artist
+        case .finished: item.artist.isEmpty ? "Downloaded" : "\(item.artist) — downloaded"
+        case .failed(let reason): reason
+        }
+    }
+}
+
+private extension DownloadsModel.State {
+    var isFailure: Bool {
+        if case .failed = self { true } else { false }
+    }
+}

--- a/apps/macos/Sources/Koan/Views/DownloadsView.swift
+++ b/apps/macos/Sources/Koan/Views/DownloadsView.swift
@@ -3,9 +3,10 @@ import SwiftUI
 
 /// What koan is fetching from the server, and what it just finished fetching.
 ///
-/// Mostly a page for when something looks wrong: a transfer that is not moving
-/// says so here, with the figure it is stuck on, and a failure keeps its reason
-/// rather than only flashing past on the row that caused it.
+/// The first place to look when something is not playing: a transfer that has
+/// stopped moving says so — its rate falls to nothing while its bar stays put —
+/// and a failure keeps its reason rather than only flashing past on the row
+/// that caused it.
 struct DownloadsView: View {
     @Environment(DownloadsModel.self) private var downloads
 
@@ -45,42 +46,82 @@ struct DownloadsView: View {
 private struct DownloadRow: View {
     let item: DownloadEntry
 
-    var body: some View {
-        HStack(spacing: 12) {
-            SourceBadges(onServer: true, onDisk: item.state == .done, downloading: badge)
+    @Environment(Navigator.self) private var nav
+    @Environment(LibraryModel.self) private var library
+    @State private var hovering = false
 
-            VStack(alignment: .leading, spacing: 3) {
-                Text(item.title).lineLimit(1)
+    var body: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text(item.title)
+                    .lineLimit(1)
+                Spacer(minLength: 8)
+                Text(figure)
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(.secondary)
+            }
+
+            // Drawn rather than a `ProgressView`: the stock linear style
+            // rendered the same full-width track whatever it was given, which
+            // made six transfers at six different percentages look identical.
+            Canvas { context, size in
+                context.fill(Self.bar(in: size, fraction: 1), with: .style(.quaternary))
+                context.fill(Self.bar(in: size, fraction: fraction), with: .style(.tint))
+            }
+            .frame(height: 3)
+            .opacity(isRunning ? 1 : 0.35)
+
+            HStack(spacing: 6) {
                 Text(subtitle)
-                    .font(.caption)
+                    .lineLimit(1)
                     .foregroundStyle(
                         item.state == .failed ? AnyShapeStyle(.orange) : AnyShapeStyle(.secondary)
                     )
-                    .lineLimit(1)
-                // Only while it is moving. A finished transfer's bar is a full
-                // one, which says nothing the filled cloud has not — and a
-                // transfer with no stated length has no fraction to draw, where
-                // a bar sitting at zero would read as stalled.
-                if isRunning, let progress = item.progress {
-                    ProgressView(value: progress, total: 1)
-                        .progressViewStyle(.linear)
+                Spacer(minLength: 8)
+                if hovering {
+                    Button("Show in Library") { showInLibrary() }
+                        .buttonStyle(.link)
+                        .font(.caption)
                 }
             }
-
-            Spacer(minLength: 8)
-
-            Text(figure)
-                .font(.caption.monospacedDigit())
-                .foregroundStyle(.secondary)
+            .font(.caption)
         }
-        .padding(.vertical, 3)
+        .padding(.vertical, 4)
+        .contentShape(Rectangle())
+        .onHover { hovering = $0 }
+        .contextMenu {
+            Button { showInLibrary() } label: {
+                Label("Show in Library", systemImage: Icon.album)
+            }
+            if item.state == .done {
+                Button { library.clearDownloads(trackIds: [item.trackId]) } label: {
+                    Label("Remove Downloaded File", systemImage: Icon.clear)
+                }
+            }
+        }
+    }
+
+    /// The record it came off, which is where you go to find it. Resolved when
+    /// asked rather than carried on every row — the store holds transfers, not
+    /// library rows, and most rows are never clicked.
+    private func showInLibrary() {
+        let engine = library.engine
+        let trackId = item.trackId
+        Task {
+            guard let albumId = (try? await engine.track(trackId: trackId))??.albumId else {
+                return
+            }
+            nav.open(album: albumId, highlighting: trackId)
+        }
     }
 
     private var isRunning: Bool { item.state == .running || item.state == .queued }
 
-    private var badge: SourceBadges.Download? {
-        guard isRunning else { return nil }
-        return item.progress.map { .fraction($0) } ?? .indeterminate
+    /// What has arrived. A transfer with no stated length has no fraction, and
+    /// draws an empty bar rather than a full one — it is going, not finished.
+    private var fraction: Double {
+        if item.state == .done { return 1 }
+        return item.progress ?? 0
     }
 
     private var subtitle: String {
@@ -88,15 +129,42 @@ private struct DownloadRow: View {
         case .failed: item.failureReason ?? "Couldn't be fetched"
         case .queued: item.artist.isEmpty ? "Waiting" : "\(item.artist) — waiting"
         case .done: item.artist.isEmpty ? "Downloaded" : "\(item.artist) — downloaded"
-        case .running: item.artist
+        case .running: rateAndSize
         }
     }
 
-    /// A percentage where there is one, and bytes where there is not — a
-    /// transfer the server gave no length for is still visibly moving.
+    /// "Artist · 4.2 MB/s · 210 MB of 451 MB", dropping whatever is not known.
+    /// A rate of nothing is a stall, and saying so is the point of the row.
+    private var rateAndSize: String {
+        var parts: [String] = []
+        if !item.artist.isEmpty { parts.append(item.artist) }
+        parts.append(
+            item.bytesPerSecond > 0
+                ? "\(Format.bytes(Int64(item.bytesPerSecond)))/s"
+                : "stalled"
+        )
+        if item.totalBytes > 0 {
+            parts.append(
+                "\(Format.bytes(Int64(item.bytesWritten))) of \(Format.bytes(Int64(item.totalBytes)))"
+            )
+        } else if item.bytesWritten > 0 {
+            parts.append(Format.bytes(Int64(item.bytesWritten)))
+        }
+        return parts.joined(separator: " · ")
+    }
+
     private var figure: String {
-        guard isRunning else { return "" }
-        if let progress = item.progress { return "\(Int(progress * 100))%" }
-        return Format.bytes(Int64(item.bytesWritten))
+        switch item.state {
+        case .done: "Done"
+        case .failed: "Failed"
+        case .queued: "Queued"
+        case .running: item.progress.map { "\(Int($0 * 100))%" } ?? ""
+        }
+    }
+
+    private static func bar(in size: CGSize, fraction: Double) -> Path {
+        let width = size.width * min(1, max(0, fraction))
+        guard width > 0 else { return Path() }
+        return Capsule().path(in: CGRect(x: 0, y: 0, width: width, height: size.height))
     }
 }

--- a/apps/macos/Sources/Koan/Views/DownloadsView.swift
+++ b/apps/macos/Sources/Koan/Views/DownloadsView.swift
@@ -38,7 +38,9 @@ struct DownloadsView: View {
                 .help("Forget the transfers that have already settled")
             }
         }
-        .task { downloads.reload() }
+        // Only while this page is up. The figures move ten times a second and
+        // nothing else in the app needs them at that rate.
+        .task { await downloads.watch() }
     }
 }
 

--- a/apps/macos/Sources/Koan/Views/DownloadsView.swift
+++ b/apps/macos/Sources/Koan/Views/DownloadsView.swift
@@ -87,11 +87,15 @@ private struct DownloadRow: View {
             // Drawn rather than a `ProgressView`: the stock linear style
             // rendered the same full-width track whatever it was given, which
             // made six transfers at six different percentages look identical.
+            //
+            // A named colour rather than `.tint`, which a `Canvas` resolves
+            // against its own environment and not the view's — hierarchical
+            // styles come through, that one comes out invisible.
             Canvas { context, size in
                 context.fill(Self.bar(in: size, fraction: 1), with: .style(.quaternary))
-                context.fill(Self.bar(in: size, fraction: fraction), with: .style(.tint))
+                context.fill(Self.bar(in: size, fraction: fraction), with: .color(.koanAccent))
             }
-            .frame(height: 3)
+            .frame(height: 4)
             .opacity(isRunning ? 1 : 0.35)
 
             HStack(spacing: 6) {

--- a/apps/macos/Sources/Koan/Views/DownloadsView.swift
+++ b/apps/macos/Sources/Koan/Views/DownloadsView.swift
@@ -24,7 +24,6 @@ struct DownloadsView: View {
                 List {
                     ForEach(downloads.items, id: \.queueItemId) { item in
                         DownloadRow(item: item)
-                            .listRowSeparator(.hidden)
                     }
                 }
                 .listStyle(.inset)
@@ -51,6 +50,30 @@ private struct DownloadRow: View {
     @State private var hovering = false
 
     var body: some View {
+        HStack(spacing: 10) {
+            // A record is what you recognise a download by, and this is a list
+            // of things you are waiting for.
+            AlbumArtwork(source: .track(item.trackId), size: .thumb, cornerRadius: 3)
+                .frame(width: 34, height: 34)
+
+            rows
+        }
+        .padding(.vertical, 4)
+        .contentShape(Rectangle())
+        .onHover { hovering = $0 }
+        .contextMenu {
+            Button { showInLibrary() } label: {
+                Label("Show in Library", systemImage: Icon.album)
+            }
+            if item.state == .done {
+                Button { library.clearDownloads(trackIds: [item.trackId]) } label: {
+                    Label("Remove Downloaded File", systemImage: Icon.clear)
+                }
+            }
+        }
+    }
+
+    private var rows: some View {
         VStack(alignment: .leading, spacing: 5) {
             HStack(alignment: .firstTextBaseline, spacing: 8) {
                 Text(item.title)
@@ -85,19 +108,6 @@ private struct DownloadRow: View {
                 }
             }
             .font(.caption)
-        }
-        .padding(.vertical, 4)
-        .contentShape(Rectangle())
-        .onHover { hovering = $0 }
-        .contextMenu {
-            Button { showInLibrary() } label: {
-                Label("Show in Library", systemImage: Icon.album)
-            }
-            if item.state == .done {
-                Button { library.clearDownloads(trackIds: [item.trackId]) } label: {
-                    Label("Remove Downloaded File", systemImage: Icon.clear)
-                }
-            }
         }
     }
 

--- a/apps/macos/Sources/Koan/Views/PlayableMenu.swift
+++ b/apps/macos/Sources/Koan/Views/PlayableMenu.swift
@@ -106,12 +106,7 @@ struct PlayableMenu: View {
             } label: {
                 Label("Organize Files…", systemImage: Icon.organize)
             }
-            // Acts on whatever of this is cached and says nothing when none of
-            // it is — resolving an artist to find out would be a query per
-            // menu drawn, for a line that is usually greyed out anyway.
-            Button { act { library.clearDownloads(trackIds: $0) } } label: {
-                Label("Remove Downloaded Files", systemImage: Icon.clear)
-            }
+            cacheActions
         }
 
         if case .track(let track) = playable, let albumId = track.albumId {
@@ -132,6 +127,34 @@ struct PlayableMenu: View {
             }
             Button { nav.open(artist: album.artistId) } label: {
                 Label("Go to Artist", systemImage: Icon.artist)
+            }
+        }
+    }
+
+    /// Fetching and throwing away, offered according to what is actually here.
+    ///
+    /// A single track knows whether its bytes are on the machine, so it is
+    /// offered one verb rather than two with one of them inert. A record or an
+    /// artist is usually part of the way there, and both apply: fetching skips
+    /// what is already down, and removing skips what is not.
+    @ViewBuilder
+    private var cacheActions: some View {
+        if case .track(let track) = playable {
+            if track.onDisk {
+                Button { act { library.clearDownloads(trackIds: $0) } } label: {
+                    Label("Remove Downloaded File", systemImage: Icon.clear)
+                }
+            } else {
+                Button { act { library.downloadToCache(trackIds: $0) } } label: {
+                    Label("Download to Cache", systemImage: Icon.downloads)
+                }
+            }
+        } else {
+            Button { act { library.downloadToCache(trackIds: $0) } } label: {
+                Label("Download All to Cache", systemImage: Icon.downloads)
+            }
+            Button { act { library.clearDownloads(trackIds: $0) } } label: {
+                Label("Remove Downloaded Files", systemImage: Icon.clear)
             }
         }
     }
@@ -206,6 +229,11 @@ struct QueueActions: View {
             Label("Add to Queue", systemImage: Icon.queue)
         }
         Divider()
+        // A selection is usually mixed, so both apply: fetching skips what is
+        // already down and removing skips what is not.
+        Button { library.downloadToCache(trackIds: trackIds) } label: {
+            Label("Download to Cache", systemImage: Icon.downloads)
+        }
         Button { library.clearDownloads(trackIds: trackIds) } label: {
             Label("Remove Downloaded Files", systemImage: Icon.clear)
         }

--- a/apps/macos/Sources/Koan/Views/PlayableMenu.swift
+++ b/apps/macos/Sources/Koan/Views/PlayableMenu.swift
@@ -106,6 +106,12 @@ struct PlayableMenu: View {
             } label: {
                 Label("Organize Files…", systemImage: Icon.organize)
             }
+            // Acts on whatever of this is cached and says nothing when none of
+            // it is — resolving an artist to find out would be a query per
+            // menu drawn, for a line that is usually greyed out anyway.
+            Button { act { library.clearDownloads(trackIds: $0) } } label: {
+                Label("Remove Downloaded Files", systemImage: Icon.clear)
+            }
         }
 
         if case .track(let track) = playable, let albumId = track.albumId {

--- a/apps/macos/Sources/Koan/Views/PlayableMenu.swift
+++ b/apps/macos/Sources/Koan/Views/PlayableMenu.swift
@@ -193,6 +193,7 @@ struct QueueActions: View {
     let trackIds: [Int64]
 
     @Environment(PlayerModel.self) private var player
+    @Environment(LibraryModel.self) private var library
 
     var body: some View {
         Button { player.playNow(trackIds: trackIds) } label: {
@@ -203,6 +204,10 @@ struct QueueActions: View {
         }
         Button { player.enqueue(trackIds: trackIds) } label: {
             Label("Add to Queue", systemImage: Icon.queue)
+        }
+        Divider()
+        Button { library.clearDownloads(trackIds: trackIds) } label: {
+            Label("Remove Downloaded Files", systemImage: Icon.clear)
         }
     }
 }

--- a/apps/macos/Sources/Koan/Views/QueueRow.swift
+++ b/apps/macos/Sources/Koan/Views/QueueRow.swift
@@ -30,6 +30,10 @@ struct QueueRowContent {
     var status: EntryStatus?
     var downloadProgress: Double?
     var failureReason: String?
+    /// Where this track's bytes are. Both false for an item with no library
+    /// row behind it, which draws no mark rather than a guessed one.
+    var onServer = false
+    var onDisk = false
     init(item: QueueItem) {
         trackId = item.trackId
         title = item.title
@@ -42,6 +46,8 @@ struct QueueRowContent {
         status = item.status
         downloadProgress = item.downloadProgress
         failureReason = item.failureReason
+        onServer = item.onServer
+        onDisk = item.onDisk
     }
 
     /// A playlist row, wearing whatever the queue currently thinks of it.
@@ -67,6 +73,8 @@ struct QueueRowContent {
         sleeve = track.albumId.map { .album($0) } ?? .track(track.id)
         downloadProgress = queued?.downloadProgress
         failureReason = queued?.failureReason
+        onServer = track.onServer
+        onDisk = track.onDisk
         status =
             if isCurrent { .playing }
             else if let live = queued?.status, live == .downloading || live == .priorityPending
@@ -161,10 +169,11 @@ struct QueueRow: View {
             // album view uses. Its own slot rather than the status column's:
             // a track can be playing and still arriving at once, and one slot
             // could only ever show whichever of the two it was told to.
-            // Only the ring, for now: a queue item does not carry where its
-            // bytes live the way a library row does, and a cloud guessed from
-            // the load state would be wrong for a local file.
-            SourceBadges(onServer: false, onDisk: false, downloading: downloading)
+            SourceBadges(
+                onServer: item.onServer,
+                onDisk: item.onDisk,
+                downloading: downloading
+            )
 
             if let codec = item.codec {
                 Text(codec.uppercased())

--- a/apps/macos/Sources/Koan/Views/QueueRow.swift
+++ b/apps/macos/Sources/Koan/Views/QueueRow.swift
@@ -30,7 +30,6 @@ struct QueueRowContent {
     var status: EntryStatus?
     var downloadProgress: Double?
     var failureReason: String?
-
     init(item: QueueItem) {
         trackId = item.trackId
         title = item.title
@@ -158,6 +157,15 @@ struct QueueRow: View {
                 Color.clear.frame(width: 16, height: 1)
             }
 
+            // Where the bytes are, in the same mark and the same column the
+            // album view uses. Its own slot rather than the status column's:
+            // a track can be playing and still arriving at once, and one slot
+            // could only ever show whichever of the two it was told to.
+            // Only the ring, for now: a queue item does not carry where its
+            // bytes live the way a library row does, and a cloud guessed from
+            // the load state would be wrong for a local file.
+            SourceBadges(onServer: false, onDisk: false, downloading: downloading)
+
             if let codec = item.codec {
                 Text(codec.uppercased())
                     .font(.caption2.monospaced())
@@ -187,6 +195,13 @@ struct QueueRow: View {
         // clicks landing there select nothing.
         .contentShape(Rectangle())
         .onHover { hovering = $0 }
+    }
+
+    /// The ring, when this row is fetching. Read off the row's own status so a
+    /// playlist row and a queue row answer the same way.
+    private var downloading: SourceBadges.Download? {
+        guard item.status == .downloading else { return nil }
+        return item.downloadProgress.map { .fraction($0) } ?? .indeterminate
     }
 
     /// A played row steps back rather than disappears — and it does it in
@@ -221,21 +236,9 @@ struct QueueRow: View {
         case .playing:
             PlayingIndicator(isPlaying: player.isPlaying)
         case .downloading:
-            // The ring is the whole indicator — a static arrow beside a
-            // separate bar said the same thing twice, in two places, and the
-            // column the eye already reads for state was the mute one.
-            if let progress = item.downloadProgress {
-                ProgressView(value: progress)
-                    .progressViewStyle(.circular)
-                    .controlSize(.mini)
-                    .frame(width: 14, height: 14)
-                    .help("Downloading — \(Int(progress * 100))%")
-            } else {
-                ProgressView()
-                    .progressViewStyle(.circular)
-                    .controlSize(.mini)
-                    .help("Downloading")
-            }
+            // Said by the badge in its own column, which can show it at the
+            // same time as this column shows the track playing.
+            Color.clear
         case .priorityPending:
             Image(systemName: "arrow.down.circle")
                 .foregroundStyle(.tint)

--- a/apps/macos/Sources/Koan/Views/QueueView.swift
+++ b/apps/macos/Sources/Koan/Views/QueueView.swift
@@ -317,8 +317,14 @@ struct QueueView: View {
             Button { showInLibrary(trackId: trackId, highlight: true) } label: {
                 Label("Go to Album", systemImage: Icon.album)
             }
-            Button { library.clearDownloads(trackIds: [trackId]) } label: {
-                Label("Remove Downloaded File", systemImage: Icon.clear)
+            if item.onDisk {
+                Button { library.clearDownloads(trackIds: [trackId]) } label: {
+                    Label("Remove Downloaded File", systemImage: Icon.clear)
+                }
+            } else {
+                Button { library.downloadToCache(trackIds: [trackId]) } label: {
+                    Label("Download to Cache", systemImage: Icon.downloads)
+                }
             }
             Button {
                 Share.link(
@@ -401,6 +407,9 @@ struct QueueView: View {
             AddToPlaylistMenu { $0(trackIds(in: ids)) }
             Divider()
             organizeButton(trackIds: trackIds(in: ids), title: nil)
+            Button { library.downloadToCache(trackIds: trackIds(in: ids)) } label: {
+                Label("Download to Cache", systemImage: Icon.downloads)
+            }
             Button { library.clearDownloads(trackIds: trackIds(in: ids)) } label: {
                 Label("Remove Downloaded Files", systemImage: Icon.clear)
             }

--- a/apps/macos/Sources/Koan/Views/QueueView.swift
+++ b/apps/macos/Sources/Koan/Views/QueueView.swift
@@ -317,6 +317,9 @@ struct QueueView: View {
             Button { showInLibrary(trackId: trackId, highlight: true) } label: {
                 Label("Go to Album", systemImage: Icon.album)
             }
+            Button { library.clearDownloads(trackIds: [trackId]) } label: {
+                Label("Remove Downloaded File", systemImage: Icon.clear)
+            }
             Button {
                 Share.link(
                     trackIds: [trackId],
@@ -398,6 +401,9 @@ struct QueueView: View {
             AddToPlaylistMenu { $0(trackIds(in: ids)) }
             Divider()
             organizeButton(trackIds: trackIds(in: ids), title: nil)
+            Button { library.clearDownloads(trackIds: trackIds(in: ids)) } label: {
+                Label("Remove Downloaded Files", systemImage: Icon.clear)
+            }
         }
     }
 

--- a/apps/macos/Sources/Koan/Views/RootView.swift
+++ b/apps/macos/Sources/Koan/Views/RootView.swift
@@ -359,6 +359,8 @@ private struct StageView: View {
             FavouritesView()
         case .section(.playHistory):
             HistoryView()
+        case .section(.downloads):
+            DownloadsView()
         case .section(.playlist(let id)):
             PlaylistView(playlistId: id)
         case .album(let id):

--- a/apps/macos/Sources/Koan/Views/RootView.swift
+++ b/apps/macos/Sources/Koan/Views/RootView.swift
@@ -271,9 +271,14 @@ struct RootView: View {
             ShortcutsSheet(hotkeys: hotkeys.all)
         }
         .overlay(alignment: .bottom) {
+            // One slot, and a failure outranks a remark about something that
+            // has not finished yet.
             if let error = player.lastError {
                 ErrorToast(message: error) { player.lastError = nil }
                     // Above the transport, not behind it.
+                    .padding(.bottom, transportHeight + 10)
+            } else if let notice = player.lastNotice {
+                ErrorToast(message: notice, kind: .notice) { player.lastNotice = nil }
                     .padding(.bottom, transportHeight + 10)
             }
         }
@@ -374,13 +379,36 @@ extension EnvironmentValues {
 /// Engine errors are informational — a device disappearing shouldn't take a
 /// modal to dismiss.
 private struct ErrorToast: View {
+    /// Whether something went wrong, or something is merely not available yet.
+    /// The second is not a warning and does not get the colour of one — a
+    /// track that is still downloading is working exactly as intended.
+    enum Kind {
+        case warning
+        case notice
+
+        var symbol: String {
+            switch self {
+            case .warning: "exclamationmark.circle.fill"
+            case .notice: "arrow.down.circle.fill"
+            }
+        }
+
+        var tint: Color {
+            switch self {
+            case .warning: .orange
+            case .notice: .secondary
+            }
+        }
+    }
+
     let message: String
+    var kind: Kind = .warning
     let dismiss: () -> Void
 
     var body: some View {
         HStack(spacing: 10) {
-            Image(systemName: "exclamationmark.circle.fill")
-                .foregroundStyle(.orange)
+            Image(systemName: kind.symbol)
+                .foregroundStyle(kind.tint)
             Text(message)
                 .font(.callout)
                 .lineLimit(2)
@@ -395,8 +423,8 @@ private struct ErrorToast: View {
         // Tinted glass rather than a material and a border: the tint carries
         // the warning without a second colour, and glass already has an edge.
         .glass(
-            .regular.tint(.orange.opacity(0.22)),
-            fallback: .orange.opacity(0.22),
+            .regular.tint(kind.tint.opacity(0.22)),
+            fallback: kind.tint.opacity(0.22),
             in: .capsule
         )
         .task {

--- a/apps/macos/Sources/Koan/Views/SearchResultsView.swift
+++ b/apps/macos/Sources/Koan/Views/SearchResultsView.swift
@@ -99,6 +99,7 @@ private struct SearchTrackRow: View {
     let track: Track
 
     @Environment(LibraryModel.self) private var library
+    @Environment(PlayerModel.self) private var player
     @Environment(Navigator.self) private var nav
     @State private var hovering = false
 
@@ -123,7 +124,7 @@ private struct SearchTrackRow: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
-                SourceBadges(track: track)
+                SourceBadges(track: track, queued: player.queuedByTrack[track.id])
             }
 
             Spacer(minLength: 8)

--- a/apps/macos/Sources/Koan/Views/SidebarView.swift
+++ b/apps/macos/Sources/Koan/Views/SidebarView.swift
@@ -10,6 +10,7 @@ struct SidebarView: View {
     @Environment(SearchModel.self) private var search
     @Environment(UIState.self) private var ui
     @Environment(PlaylistsModel.self) private var playlists
+    @Environment(DownloadsModel.self) private var downloads
     @FocusState private var searchFocused: Bool
     /// Highlights the Queue row while something is held over it — without it a
     /// drop is a guess.
@@ -71,6 +72,18 @@ struct SidebarView: View {
                     .tag(Navigator.Section.favourites)
                 Label("History", systemImage: Icon.history)
                     .tag(Navigator.Section.playHistory)
+                HStack {
+                    Label("Downloads", systemImage: Icon.downloads)
+                    // Only while something is happening. A zero sitting there
+                    // permanently is a number nobody reads.
+                    if downloads.activeCount > 0 {
+                        Spacer()
+                        Text("\(downloads.activeCount)")
+                            .font(.caption.monospacedDigit())
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .tag(Navigator.Section.downloads)
             }
 
             playlistSection

--- a/apps/macos/Sources/Koan/Views/SourceBadges.swift
+++ b/apps/macos/Sources/Koan/Views/SourceBadges.swift
@@ -1,39 +1,93 @@
 import KoanFFI
 import SwiftUI
 
-/// Where a track's bytes are: on the server, on this machine, or both.
+/// Where a track's bytes are, in one mark.
 ///
-/// Both, because they are not exclusive. A record that exists as local files
-/// *and* on the server is one row that is genuinely both, and the old single
-/// "source" reading meant the cloud vanished the moment anything was
-/// downloaded — which read as the track having left the server.
+/// A cloud that fills as the track comes down: empty means the server has it
+/// and this machine does not, a ring means it is arriving, filled means it is
+/// here. One slot rather than two, and the progress lives in it rather than
+/// beside it — the eye already goes to this column to ask "have I got this?",
+/// and a transfer is the same question mid-answer.
+///
+/// A local file is not a cloud at all and keeps its own mark. A row that is
+/// both — local files that also exist on the server — reads as downloaded,
+/// which is what it is.
 ///
 /// Shared by every view that lists tracks so the vocabulary is the same
 /// wherever you meet it.
 struct SourceBadges: View {
     let onServer: Bool
     let onDisk: Bool
+    /// 0–1 while this track is being fetched, `nil` when it is not. A transfer
+    /// whose length the server never gave has no fraction to show and spins.
+    var downloading: Download?
+
+    enum Download {
+        case indeterminate
+        case fraction(Double)
+    }
 
     var body: some View {
-        HStack(spacing: 3) {
-            if onServer {
-                Image(systemName: "cloud")
-                    .foregroundStyle(.quaternary)
+        Group {
+            if let downloading {
+                ring(downloading)
+            } else if onServer {
+                Image(systemName: onDisk ? "cloud.fill" : "cloud")
+                    .foregroundStyle(onDisk ? AnyShapeStyle(.tertiary) : AnyShapeStyle(.quaternary))
                     .help(onDisk ? "On your server, downloaded" : "On your server — downloads on play")
-            }
-            if onDisk {
+            } else if onDisk {
                 Image(systemName: "internaldrive")
                     .foregroundStyle(.tertiary)
-                    .help(onServer ? "Downloaded to this machine" : "Local file")
+                    .help("Local file")
             }
         }
         .font(.caption2)
         .imageScale(.small)
+        // Fixed, so a row does not shift as the mark changes under it — every
+        // state has to occupy the same space as every other.
+        .frame(width: 14, height: 14)
+    }
+
+    @ViewBuilder
+    private func ring(_ download: Download) -> some View {
+        switch download {
+        case .fraction(let value):
+            ProgressView(value: value)
+                .progressViewStyle(.circular)
+                .controlSize(.mini)
+                .help("Downloading — \(Int(value * 100))%")
+        case .indeterminate:
+            ProgressView()
+                .progressViewStyle(.circular)
+                .controlSize(.mini)
+                .help("Downloading")
+        }
     }
 }
 
 extension SourceBadges {
-    init(track: Track) {
-        self.init(onServer: track.onServer, onDisk: track.onDisk)
+    /// A library row, plus whatever the queue knows about fetching it. The
+    /// queue is the only thing that knows a transfer is running; the library
+    /// row only ever learns it finished.
+    init(track: Track, queued: QueueItem? = nil) {
+        self.init(
+            onServer: track.onServer,
+            onDisk: track.onDisk,
+            downloading: SourceBadges.download(of: queued)
+        )
+    }
+
+    /// A queue row, which knows where its bytes came from by its own status.
+    init(queued: QueueItem, onServer: Bool, onDisk: Bool) {
+        self.init(
+            onServer: onServer,
+            onDisk: onDisk,
+            downloading: SourceBadges.download(of: queued)
+        )
+    }
+
+    static func download(of item: QueueItem?) -> Download? {
+        guard let item, item.status == .downloading else { return nil }
+        return item.downloadProgress.map { .fraction($0) } ?? .indeterminate
     }
 }

--- a/apps/macos/Sources/Koan/Views/SourceBadges.swift
+++ b/apps/macos/Sources/Koan/Views/SourceBadges.swift
@@ -32,12 +32,15 @@ struct SourceBadges: View {
             if let downloading {
                 ring(downloading)
             } else if onServer {
+                // Visible enough to be read at a glance down a list. At
+                // `.quaternary` this was there and effectively invisible, which
+                // is the same as not drawing it.
                 Image(systemName: onDisk ? "cloud.fill" : "cloud")
-                    .foregroundStyle(onDisk ? AnyShapeStyle(.tertiary) : AnyShapeStyle(.quaternary))
+                    .foregroundStyle(onDisk ? AnyShapeStyle(.secondary) : AnyShapeStyle(.tertiary))
                     .help(onDisk ? "On your server, downloaded" : "On your server — downloads on play")
             } else if onDisk {
                 Image(systemName: "internaldrive")
-                    .foregroundStyle(.tertiary)
+                    .foregroundStyle(.secondary)
                     .help("Local file")
             }
         }

--- a/apps/macos/Sources/Koan/Views/TrackListView.swift
+++ b/apps/macos/Sources/Koan/Views/TrackListView.swift
@@ -290,36 +290,27 @@ private struct TrackAvailability: View {
 
     var body: some View {
         Group {
-            if let queued = player.queuedByTrack[track.id], isLive(queued.status) {
+            // Only the states the badge cannot say itself. Downloading is one
+            // it can — the ring belongs in the same slot as the cloud it is
+            // filling, not in a column of its own.
+            if let queued = player.queuedByTrack[track.id], isBlocking(queued.status) {
                 queueState(queued)
             } else {
-                SourceBadges(track: track)
+                SourceBadges(track: track, queued: player.queuedByTrack[track.id])
             }
         }
         .font(.caption)
         .frame(width: 30, height: 16, alignment: .trailing)
     }
 
-    /// Only these say something the library row doesn't already know.
-    private func isLive(_ status: EntryStatus) -> Bool {
-        status == .downloading || status == .priorityPending || status == .failed
+    /// Only these say something neither the library row nor the badge can.
+    private func isBlocking(_ status: EntryStatus) -> Bool {
+        status == .priorityPending || status == .failed
     }
 
     @ViewBuilder
     private func queueState(_ item: QueueItem) -> some View {
         switch item.status {
-        case .downloading:
-            if let progress = item.downloadProgress {
-                ProgressView(value: progress)
-                    .progressViewStyle(.circular)
-                    .controlSize(.mini)
-                    .frame(width: 14, height: 14)
-                    .help("Downloading — \(Int(progress * 100))%")
-            } else {
-                ProgressView()
-                    .progressViewStyle(.circular)
-                    .controlSize(.mini)
-            }
         case .priorityPending:
             Image(systemName: "arrow.down.circle")
                 .foregroundStyle(.tint)

--- a/apps/macos/Sources/Koan/Views/TransportBar.swift
+++ b/apps/macos/Sources/Koan/Views/TransportBar.swift
@@ -234,33 +234,26 @@ private struct SeekBar: View {
                 // and AppKit answered each one with a full window Auto Layout
                 // pass. Same bar, same marks; only the pixels change now.
                 ZStack {
+                    // What has not arrived, drawn quieter than the rest.
+                    //
+                    // The dimming is on the tail rather than the head on
+                    // purpose: a track on disk is the ordinary case and should
+                    // look like the ordinary bar, so a download finishing
+                    // changes nothing about what is drawn. Lighting the
+                    // downloaded part instead meant the bar went *dark* the
+                    // moment a transfer completed, which is exactly backwards.
                     Canvas { context, size in
                         context.fill(Self.mark(in: size, fraction: 1), with: .style(.quaternary))
                     }
-                    // How much of a streaming track has arrived. Where the
-                    // track can also be seeked, the engine stops a scrub at
-                    // this same extent, so the bar never offers a position
-                    // playback would refuse. Where it cannot be seeked yet,
-                    // this is the whole message: the transfer is going, and
-                    // this is how far.
-                    //
-                    // Held well back, because it is context rather than the
-                    // reading. At full weight it was the brightest thing on the
-                    // bar and got taken for the playhead — which on a long
-                    // track is a sliver a fraction of a pixel wide, and so lost
-                    // under it entirely.
+                    .opacity(0.4)
+                    // What can be played: the whole bar for anything already
+                    // here, and as far as the bytes reach for anything still
+                    // arriving. Where the track can also be seeked, the engine
+                    // stops a scrub at this same extent, so the bar never
+                    // offers a position playback would refuse.
                     Canvas { context, size in
-                        context.fill(Self.mark(in: size, fraction: fetched ?? 0), with: .style(.secondary))
+                        context.fill(Self.mark(in: size, fraction: fetched ?? 1), with: .style(.quaternary))
                     }
-                    // On whether there is a mark at all, not on how long it is:
-                    // the fetched extent moves several times a second and a
-                    // quarter of a second of easing on every one of those would
-                    // leave both it and the playhead beside it perpetually
-                    // behind. Opacity rather than a transition, because this
-                    // layer is always present — and opacity is one of the few
-                    // things CoreAnimation can carry without touching layout.
-                    .opacity(fetched == nil ? 0 : 0.4)
-                    .animation(.easeOut(duration: 0.25), value: fetched == nil)
                     // Not the tint. The tint is the colour of the record now,
                     // and a muted sleeve puts the played portion at the same
                     // value as the track behind it — this is a bar you read a

--- a/apps/macos/Sources/Koan/Views/TransportBar.swift
+++ b/apps/macos/Sources/Koan/Views/TransportBar.swift
@@ -237,11 +237,13 @@ private struct SeekBar: View {
                     Canvas { context, size in
                         context.fill(Self.mark(in: size, fraction: 1), with: .style(.quaternary))
                     }
-                    // How much of a streaming track can be reached. The engine
-                    // clamps a seek to this same extent, so it is a boundary
-                    // rather than an illustration — the bar cannot offer a
-                    // position playback would then refuse. Its own layer so it
-                    // sits under the played extent and is covered by it.
+                    // How much of a streaming track has arrived. Where the
+                    // track can also be seeked, the engine stops a scrub at
+                    // this same extent, so the bar never offers a position
+                    // playback would refuse. Where it cannot be seeked yet,
+                    // this is the whole message: the transfer is going, and
+                    // this is how far. Its own layer so it sits under the
+                    // played extent and is covered by it.
                     Canvas { context, size in
                         context.fill(Self.mark(in: size, fraction: fetched ?? 0), with: .style(.secondary))
                     }
@@ -254,7 +256,6 @@ private struct SeekBar: View {
                     // things CoreAnimation can carry without touching layout.
                     .opacity(fetched == nil ? 0 : 1)
                     .animation(.easeOut(duration: 0.25), value: fetched == nil)
-                    .help(fetched.map { "Downloaded as far as \(Int($0 * 100))% — seeking stops here" } ?? "")
                     // Not the tint. The tint is the colour of the record now,
                     // and a muted sleeve puts the played portion at the same
                     // value as the track behind it — this is a bar you read a
@@ -264,15 +265,23 @@ private struct SeekBar: View {
                     }
                 }
                 .contentShape(.rect)
+                // Always attached, even where there is nowhere to drag to. The
+                // thumb does not follow the pointer then — a head that moves
+                // and springs back is a worse answer than one that stays put —
+                // but the attempt is still worth answering, so releasing says
+                // why nothing happened.
                 .gesture(
                     DragGesture(minimumDistance: 0)
                         .onChanged { value in
+                            guard player.canSeek else { return }
                             player.beginScrub(fraction: (value.location.x / geo.size.width).clamped())
                         }
                         .onEnded { value in
+                            guard player.canSeek else { return player.explainUnseekable() }
                             player.seek(fraction: (value.location.x / geo.size.width).clamped())
                         }
                 )
+                .help(help)
             }
             .frame(height: 14)
 
@@ -300,12 +309,18 @@ private struct SeekBar: View {
         UInt64(player.progress * Double(player.clock.durationMs))
     }
 
-    /// How much of what is playing can be seeked into, while that is less than
-    /// all of it. `nil` for anything on disk, which is every track most of the
-    /// time — there is no boundary worth drawing then.
-    private var fetched: Double? {
-        let seekable = player.seekable
-        return seekable < 1 ? seekable : nil
+    /// How much of what is playing has arrived, while it is still arriving.
+    /// `nil` for anything on disk, which is every track most of the time.
+    private var fetched: Double? { player.fetched }
+
+    /// Says which of the three states the bar is in, because a bar that stops
+    /// short or stops responding without saying why reads as broken.
+    private var help: String {
+        guard let fetched else { return "" }
+        let percent = Int(fetched * 100)
+        return player.canSeek
+            ? "Downloaded to \(percent)% — seeking stops there until the rest arrives"
+            : "Downloading, \(percent)% — seeking becomes available when it finishes"
     }
 }
 

--- a/apps/macos/Sources/Koan/Views/TransportBar.swift
+++ b/apps/macos/Sources/Koan/Views/TransportBar.swift
@@ -242,8 +242,13 @@ private struct SeekBar: View {
                     // this same extent, so the bar never offers a position
                     // playback would refuse. Where it cannot be seeked yet,
                     // this is the whole message: the transfer is going, and
-                    // this is how far. Its own layer so it sits under the
-                    // played extent and is covered by it.
+                    // this is how far.
+                    //
+                    // Held well back, because it is context rather than the
+                    // reading. At full weight it was the brightest thing on the
+                    // bar and got taken for the playhead — which on a long
+                    // track is a sliver a fraction of a pixel wide, and so lost
+                    // under it entirely.
                     Canvas { context, size in
                         context.fill(Self.mark(in: size, fraction: fetched ?? 0), with: .style(.secondary))
                     }
@@ -254,7 +259,7 @@ private struct SeekBar: View {
                     // behind. Opacity rather than a transition, because this
                     // layer is always present — and opacity is one of the few
                     // things CoreAnimation can carry without touching layout.
-                    .opacity(fetched == nil ? 0 : 1)
+                    .opacity(fetched == nil ? 0 : 0.4)
                     .animation(.easeOut(duration: 0.25), value: fetched == nil)
                     // Not the tint. The tint is the colour of the record now,
                     // and a muted sleeve puts the played portion at the same
@@ -262,6 +267,15 @@ private struct SeekBar: View {
                     // position off, not a thing that needs to say whose it is.
                     Canvas { context, size in
                         context.fill(Self.mark(in: size, fraction: player.progress), with: .style(.primary))
+                    }
+                    // The head itself, which the played extent cannot show on
+                    // its own: a third of a minute into nine hours is a tenth
+                    // of a percent of the bar, narrower than the bar is thick,
+                    // and a capsule that short is not drawn at all. A mark that
+                    // does not shrink with the fraction is the only thing that
+                    // says where playback is on a track this long.
+                    Canvas { context, size in
+                        context.fill(Self.head(in: size, fraction: player.progress), with: .style(.primary))
                     }
                 }
                 .contentShape(.rect)
@@ -297,6 +311,23 @@ private struct SeekBar: View {
 
     /// A capsule covering `fraction` of the bar, centred vertically. Shorter
     /// than its own thickness it would draw as a squashed dot, so it doesn't.
+    /// A round head centred on `fraction`, kept inside the bar at both ends so
+    /// it never hangs off the track it is marking.
+    private static func head(in size: CGSize, fraction: Double) -> Path {
+        let diameter = thickness * 2
+        let travel = size.width - diameter
+        guard travel > 0 else { return Path() }
+        let x = travel * fraction.clamped()
+        return Path(
+            ellipseIn: CGRect(
+                x: x,
+                y: (size.height - diameter) / 2,
+                width: diameter,
+                height: diameter
+            )
+        )
+    }
+
     private static func mark(in size: CGSize, fraction: Double) -> Path {
         let width = size.width * fraction.clamped()
         guard width >= thickness else { return Path() }

--- a/apps/macos/Sources/Koan/Views/TransportBar.swift
+++ b/apps/macos/Sources/Koan/Views/TransportBar.swift
@@ -237,14 +237,11 @@ private struct SeekBar: View {
                     Canvas { context, size in
                         context.fill(Self.mark(in: size, fraction: 1), with: .style(.quaternary))
                     }
-                    // How much of a streaming track has arrived. A fraction of
-                    // bytes drawn on an axis of time: right for lossless and
-                    // CBR, out by however far the bitrate wanders on VBR. Hence
-                    // the weaker mark and the word "roughly" — what it answers
-                    // is whether playback is about to run out of track, not
-                    // where in the track anything is. Its own layer so it sits
-                    // under the played extent: an approximation that lands
-                    // behind the playhead is covered rather than drawn wrong.
+                    // How much of a streaming track can be reached. The engine
+                    // clamps a seek to this same extent, so it is a boundary
+                    // rather than an illustration — the bar cannot offer a
+                    // position playback would then refuse. Its own layer so it
+                    // sits under the played extent and is covered by it.
                     Canvas { context, size in
                         context.fill(Self.mark(in: size, fraction: fetched ?? 0), with: .style(.secondary))
                     }
@@ -257,7 +254,7 @@ private struct SeekBar: View {
                     // things CoreAnimation can carry without touching layout.
                     .opacity(fetched == nil ? 0 : 1)
                     .animation(.easeOut(duration: 0.25), value: fetched == nil)
-                    .help(fetched.map { "Roughly \(Int($0 * 100))% downloaded" } ?? "")
+                    .help(fetched.map { "Downloaded as far as \(Int($0 * 100))% — seeking stops here" } ?? "")
                     // Not the tint. The tint is the colour of the record now,
                     // and a muted sleeve puts the played portion at the same
                     // value as the track behind it — this is a bar you read a
@@ -303,10 +300,13 @@ private struct SeekBar: View {
         UInt64(player.progress * Double(player.clock.durationMs))
     }
 
-    /// How much of what is playing has been fetched, while it is still being
-    /// fetched. `nil` for anything already on disk, and for a transfer the
-    /// server gave no length for — there is nothing to draw a fraction of.
-    private var fetched: Double? { player.currentEntry?.downloadProgress }
+    /// How much of what is playing can be seeked into, while that is less than
+    /// all of it. `nil` for anything on disk, which is every track most of the
+    /// time — there is no boundary worth drawing then.
+    private var fetched: Double? {
+        let seekable = player.seekable
+        return seekable < 1 ? seekable : nil
+    }
 }
 
 private struct DeviceMenu: View {

--- a/crates/koan-core/src/audio/buffer.rs
+++ b/crates/koan-core/src/audio/buffer.rs
@@ -353,7 +353,13 @@ fn probe_mss(mss: MediaSourceStream<'_>, hint: &Hint) -> Result<StreamInfo, Deco
             FormatOptions::default(),
             MetadataOptions::default(),
         )
-        .map_err(|e| DecodeError::Decode(e.to_string()))?;
+        .map_err(|e| match e {
+            // Kept whole rather than flattened to a string: a probe against a
+            // partial file fails by running out of bytes, and the caller has to
+            // tell that apart from a file it cannot make sense of.
+            symphonia::core::errors::Error::IoError(io) => DecodeError::Io(io),
+            other => DecodeError::Decode(other.to_string()),
+        })?;
 
     let track = reader
         .default_track(TrackType::Audio)

--- a/crates/koan-core/src/audio/streaming.rs
+++ b/crates/koan-core/src/audio/streaming.rs
@@ -1,306 +1,341 @@
-//! StreamingSource — a Read+Seek adapter over a shared, incrementally-filled byte buffer.
+//! `PartialFileSource` — a Read+Seek adapter over a file that is still downloading.
 //!
-//! The download thread writes chunks into a `StreamBuffer` while the Symphonia decoder
-//! reads from a `StreamingSource` backed by the same buffer. The source blocks briefly
-//! when the read position catches up to the write head, enabling true streaming decode
-//! without waiting for the full download to complete.
+//! The download thread writes the track to a `.part` file and publishes how far
+//! it has got in an `AtomicU64`; the Symphonia decoder reads the same file
+//! through a `PartialFileSource`, which blocks when the read position catches
+//! up to the write head. Playback starts long before the transfer finishes and
+//! seeking anywhere below the write head costs a `lseek`.
+//!
+//! Nothing is copied. An earlier design pumped the file into a shared `Vec<u8>`
+//! so the decoder could read from memory, which cost as much RAM as the track
+//! was long — half a gigabyte for a nine-hour recording, held for as long as it
+//! played. The bytes are already on disk; the page cache is better at this.
+//!
+//! The open descriptor survives the download's final rename from `.part` to its
+//! cache path, so a transfer landing mid-playback changes nothing for a reader.
 
+use std::fs::File;
 use std::io::{self, Read, Seek, SeekFrom};
-use std::sync::{Arc, Condvar, Mutex};
-use std::time::Duration;
+use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
 
-/// Longest a read may block waiting for bytes before the stream counts as dead.
-/// A download that stops advancing must surface as an error, not park the decode
-/// thread forever holding the ring buffer producer and the whole buffered track.
-const READ_TIMEOUT: Duration = Duration::from_secs(30);
+/// Longest a read may block waiting for bytes before the transfer counts as
+/// dead. A download that stops advancing must surface as an error, not park the
+/// decode thread forever holding the ring buffer producer.
+const STALL_LIMIT: Duration = Duration::from_secs(30);
 
-/// State shared between the download writer and the decoder reader.
-struct Inner {
-    data: Vec<u8>,
-    /// Total expected byte length. `None` if not yet known (no Content-Length).
-    total_len: Option<u64>,
-    /// Set to true when the download thread has finished cleanly — the buffer
-    /// holds the whole source and readers see EOF past its end.
-    done: bool,
-    /// Set to true when the download died before delivering everything.
-    /// Reads past the buffered bytes fail rather than reporting EOF.
-    failed: bool,
-    /// How long a read blocks for new bytes before giving up.
-    read_timeout: Duration,
+/// How long to wait between checks for bytes that have not landed yet.
+const POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+/// Where a download has got to, as the source needs to know it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StreamStatus {
+    /// Bytes are still arriving.
+    Downloading,
+    /// Every byte landed. Reads past the end are a clean EOF.
+    Complete,
+    /// The transfer died before delivering everything. Reads past the written
+    /// bytes fail rather than reporting EOF, which would silently truncate the
+    /// track and look like a short file.
+    Failed,
 }
 
-/// A shared, growable byte buffer that the download thread writes into.
-///
-/// Clone it to get additional handles; all clones share the same underlying data.
-#[derive(Clone)]
-pub struct StreamBuffer {
-    inner: Arc<(Mutex<Inner>, Condvar)>,
-}
-
-impl StreamBuffer {
-    /// Create a new empty buffer. `total_len` may be provided once Content-Length is known.
-    pub fn new(total_len: Option<u64>) -> Self {
-        Self::with_read_timeout(total_len, READ_TIMEOUT)
-    }
-
-    fn with_read_timeout(total_len: Option<u64>, read_timeout: Duration) -> Self {
-        Self {
-            inner: Arc::new((
-                Mutex::new(Inner {
-                    data: Vec::new(),
-                    total_len,
-                    done: false,
-                    failed: false,
-                    read_timeout,
-                }),
-                Condvar::new(),
-            )),
-        }
-    }
-
-    /// Append downloaded bytes. Called by the download thread.
-    pub fn push(&self, chunk: &[u8]) {
-        let (lock, cvar) = &*self.inner;
-        let mut inner = lock.lock().unwrap();
-        inner.data.extend_from_slice(chunk);
-        cvar.notify_all();
-    }
-
-    /// Signal that the download delivered everything. Readers see EOF past the
-    /// buffered bytes.
-    pub fn finish(&self) {
-        let (lock, cvar) = &*self.inner;
-        let mut inner = lock.lock().unwrap();
-        inner.done = true;
-        cvar.notify_all();
-    }
-
-    /// Signal that the download died. Readers past the buffered bytes get a
-    /// broken-pipe error — reporting EOF here would silently truncate the track.
-    pub fn fail(&self) {
-        let (lock, cvar) = &*self.inner;
-        let mut inner = lock.lock().unwrap();
-        inner.failed = true;
-        cvar.notify_all();
-    }
-
-    /// True when this is the last handle: nothing can read what is written from
-    /// here on, so a writer holding it has no reason to keep going.
-    pub fn is_abandoned(&self) -> bool {
-        Arc::strong_count(&self.inner) == 1
-    }
-
-    /// Total bytes received so far.
-    pub fn bytes_downloaded(&self) -> u64 {
-        let (lock, _) = &*self.inner;
-        lock.lock().unwrap().data.len() as u64
-    }
-
-    /// Total expected length (from Content-Length), if known.
-    pub fn total_len(&self) -> Option<u64> {
-        let (lock, _) = &*self.inner;
-        lock.lock().unwrap().total_len
-    }
-
-    /// Create a `StreamingSource` that reads from this buffer starting at offset 0.
-    pub fn reader(&self) -> StreamingSource {
-        StreamingSource {
-            inner: self.inner.clone(),
-            pos: 0,
-        }
-    }
-}
-
-/// A `Read + Seek` view into a `StreamBuffer`.
-///
-/// Blocks on `read` when the read position is at or beyond the write head,
-/// until more bytes arrive or the download finishes.
-pub struct StreamingSource {
-    inner: Arc<(Mutex<Inner>, Condvar)>,
+/// A `Read + Seek` view of a file that is still being written.
+pub struct PartialFileSource {
+    file: File,
     pos: u64,
+    /// How many bytes the download has committed to disk so far.
+    bytes_written: Arc<AtomicU64>,
+    /// Total expected length, or 0 when the server sent no Content-Length.
+    total: u64,
+    status: Arc<dyn Fn() -> StreamStatus + Send + Sync>,
+    stall_limit: Duration,
 }
 
-impl Read for StreamingSource {
+impl PartialFileSource {
+    /// Open `path` for streaming. `bytes_written` is the download's own counter
+    /// and `total` its advertised length, 0 when it sent none.
+    pub fn open(
+        path: &Path,
+        bytes_written: Arc<AtomicU64>,
+        total: u64,
+        status: Arc<dyn Fn() -> StreamStatus + Send + Sync>,
+    ) -> io::Result<Self> {
+        Self::with_stall_limit(path, bytes_written, total, status, STALL_LIMIT)
+    }
+
+    fn with_stall_limit(
+        path: &Path,
+        bytes_written: Arc<AtomicU64>,
+        total: u64,
+        status: Arc<dyn Fn() -> StreamStatus + Send + Sync>,
+        stall_limit: Duration,
+    ) -> io::Result<Self> {
+        Ok(Self {
+            file: File::open(path)?,
+            pos: 0,
+            bytes_written,
+            total,
+            status,
+            stall_limit,
+        })
+    }
+
+    /// Bytes known to be readable — what the download has written, or the whole
+    /// file once it has landed.
+    fn available(&self) -> u64 {
+        let written = self.bytes_written.load(Ordering::Acquire);
+        match (self.status)() {
+            StreamStatus::Complete => self.file.metadata().map(|m| m.len()).unwrap_or(written),
+            _ => written,
+        }
+    }
+
+    /// Read straight from the file, tolerating a short read at the write head:
+    /// `bytes_written` is published by the downloader as it goes and the data
+    /// behind it can lag by a moment.
+    fn read_available(&mut self, buf: &mut [u8], limit: u64) -> io::Result<usize> {
+        let to_read = (limit as usize).min(buf.len());
+        self.file.read(&mut buf[..to_read]).inspect(|n| {
+            self.pos += *n as u64;
+        })
+    }
+}
+
+impl Read for PartialFileSource {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         if buf.is_empty() {
             return Ok(0);
         }
 
-        let (lock, cvar) = &*self.inner;
-
-        // Wait until there is data at `pos`, or the download ends one way or another.
-        let guard = lock.lock().unwrap();
-        let timeout = guard.read_timeout;
-        let (inner, wait) = cvar
-            .wait_timeout_while(guard, timeout, |s| {
-                s.data.len() as u64 <= self.pos && !s.done && !s.failed
-            })
-            .unwrap();
-
-        let available = inner.data.len() as u64;
-        if available <= self.pos {
-            if inner.failed {
-                return Err(io::Error::new(
-                    io::ErrorKind::BrokenPipe,
-                    "stream download failed before delivering the whole track",
-                ));
+        let deadline = Instant::now() + self.stall_limit;
+        loop {
+            let available = self.available();
+            if available > self.pos {
+                let n = self.read_available(buf, available - self.pos)?;
+                if n > 0 {
+                    return Ok(n);
+                }
+                // The counter ran ahead of what is visible on disk. Fall
+                // through and wait rather than reporting a false EOF.
             }
-            if wait.timed_out() {
+
+            match (self.status)() {
+                StreamStatus::Failed => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::BrokenPipe,
+                        "stream download failed before delivering the whole track",
+                    ));
+                }
+                // Everything landed and there is nothing past `pos`: real EOF.
+                StreamStatus::Complete if available <= self.pos => return Ok(0),
+                StreamStatus::Complete => {}
+                StreamStatus::Downloading => {
+                    // A server that sent a Content-Length has delivered it all.
+                    if self.total > 0 && available >= self.total && self.pos >= self.total {
+                        return Ok(0);
+                    }
+                }
+            }
+
+            if Instant::now() >= deadline {
                 return Err(io::Error::new(
                     io::ErrorKind::TimedOut,
                     "stream download stalled",
                 ));
             }
-            // Done and no more data — EOF.
-            return Ok(0);
+            std::thread::sleep(POLL_INTERVAL);
         }
-
-        let start = self.pos as usize;
-        let end = (start + buf.len()).min(inner.data.len());
-        let n = end - start;
-        buf[..n].copy_from_slice(&inner.data[start..end]);
-        self.pos += n as u64;
-        Ok(n)
     }
 }
 
-impl Seek for StreamingSource {
+impl Seek for PartialFileSource {
     fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
-        let (lock, _) = &*self.inner;
-        let inner = lock.lock().unwrap();
-
-        let new_pos: i64 = match pos {
+        let target: i64 = match pos {
             SeekFrom::Start(n) => n as i64,
             SeekFrom::Current(n) => self.pos as i64 + n,
+            // Seeking relative to an end the download has not reached yet is
+            // guesswork; the advertised length is the best answer there is.
             SeekFrom::End(n) => {
-                // For End seeks we need total_len. If not known yet, use current data len.
-                let len = inner.total_len.unwrap_or(inner.data.len() as u64) as i64;
-                len + n
+                let len = if self.total > 0 {
+                    self.total
+                } else {
+                    self.available()
+                };
+                len as i64 + n
             }
         };
 
-        if new_pos < 0 {
+        if target < 0 {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
                 "seek before beginning of stream",
             ));
         }
 
-        self.pos = new_pos as u64;
+        self.pos = self.file.seek(SeekFrom::Start(target as u64))?;
         Ok(self.pos)
     }
 }
 
 // Symphonia requires MediaSource: Read + Seek + Send + Any
-impl symphonia::core::io::MediaSource for StreamingSource {
+impl symphonia::core::io::MediaSource for PartialFileSource {
     fn is_seekable(&self) -> bool {
-        // Seekable only if the total length is known (needed for seek-to-end math).
-        // Forward seeks always work; backward seeks require buffered data already present.
-        // We advertise seekable=true and handle backward seeks via the buffered Vec.
+        // Backward seeks and forward seeks below the write head are a `lseek`
+        // on a file that is already there. A forward seek past it lands on a
+        // read that blocks until the bytes arrive, which is the honest
+        // behaviour — callers clamp to `seekable_ms` to avoid asking.
         true
     }
 
     fn byte_len(&self) -> Option<u64> {
-        let (lock, _) = &*self.inner;
-        lock.lock().unwrap().total_len
+        (self.total > 0).then_some(self.total)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::io::{self, Read, Seek, SeekFrom};
+    use std::io::Write;
+    use std::sync::atomic::AtomicU8;
+
+    use symphonia::core::io::MediaSource;
 
     use super::*;
 
-    fn filled_buffer(data: &[u8]) -> StreamBuffer {
-        let buf = StreamBuffer::new(Some(data.len() as u64));
-        buf.push(data);
-        buf.finish();
-        buf
+    /// A file plus the counter and status a download would publish, so a test
+    /// can advance either independently.
+    struct Fixture {
+        _dir: tempfile::TempDir,
+        path: std::path::PathBuf,
+        written: Arc<AtomicU64>,
+        status: Arc<AtomicU8>,
+    }
+
+    const DOWNLOADING: u8 = 0;
+    const COMPLETE: u8 = 1;
+    const FAILED: u8 = 2;
+
+    impl Fixture {
+        fn new() -> Self {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("track.opus.part");
+            File::create(&path).unwrap();
+            Self {
+                _dir: dir,
+                path,
+                written: Arc::new(AtomicU64::new(0)),
+                status: Arc::new(AtomicU8::new(DOWNLOADING)),
+            }
+        }
+
+        /// Append bytes and publish them, as the downloader does per chunk.
+        fn push(&self, chunk: &[u8]) {
+            let mut f = std::fs::OpenOptions::new()
+                .append(true)
+                .open(&self.path)
+                .unwrap();
+            f.write_all(chunk).unwrap();
+            f.flush().unwrap();
+            self.written
+                .fetch_add(chunk.len() as u64, Ordering::Release);
+        }
+
+        fn set(&self, status: u8) {
+            self.status.store(status, Ordering::Release);
+        }
+
+        fn source(&self, total: u64) -> PartialFileSource {
+            self.source_with_stall(total, STALL_LIMIT)
+        }
+
+        fn source_with_stall(&self, total: u64, stall: Duration) -> PartialFileSource {
+            let status = self.status.clone();
+            PartialFileSource::with_stall_limit(
+                &self.path,
+                self.written.clone(),
+                total,
+                Arc::new(move || match status.load(Ordering::Acquire) {
+                    COMPLETE => StreamStatus::Complete,
+                    FAILED => StreamStatus::Failed,
+                    _ => StreamStatus::Downloading,
+                }),
+                stall,
+            )
+            .unwrap()
+        }
     }
 
     #[test]
-    fn new_buffer_starts_empty() {
-        let buf = StreamBuffer::new(Some(1024));
-        assert_eq!(buf.bytes_downloaded(), 0);
-        assert_eq!(buf.total_len(), Some(1024));
-    }
-
-    #[test]
-    fn new_buffer_unknown_total() {
-        let buf = StreamBuffer::new(None);
-        assert_eq!(buf.total_len(), None);
-    }
-
-    #[test]
-    fn read_all_data_available() {
-        let data = b"hello streaming world";
-        let buf = filled_buffer(data);
-        let mut src = buf.reader();
+    fn reads_what_has_landed() {
+        let fx = Fixture::new();
+        fx.push(b"hello streaming world");
+        fx.set(COMPLETE);
 
         let mut out = Vec::new();
-        src.read_to_end(&mut out).unwrap();
-        assert_eq!(out, data);
+        fx.source(21).read_to_end(&mut out).unwrap();
+        assert_eq!(out, b"hello streaming world");
     }
 
     #[test]
-    fn read_partial_then_rest() {
-        let data = b"abcdefghij";
-        let buf = filled_buffer(data);
-        let mut src = buf.reader();
+    fn read_stops_at_the_write_head_then_resumes() {
+        let fx = Fixture::new();
+        fx.push(b"abcd");
+        let mut src = fx.source(10);
 
-        let mut first = [0u8; 4];
-        let n = src.read(&mut first).unwrap();
-        assert_eq!(n, 4);
-        assert_eq!(&first, b"abcd");
+        let mut first = [0u8; 8];
+        assert_eq!(src.read(&mut first).unwrap(), 4);
+        assert_eq!(&first[..4], b"abcd");
 
-        let mut rest = Vec::new();
-        src.read_to_end(&mut rest).unwrap();
-        assert_eq!(rest, b"efghij");
+        // The rest arrives while the reader is blocked on it.
+        std::thread::spawn({
+            let path = fx.path.clone();
+            let written = fx.written.clone();
+            move || {
+                std::thread::sleep(Duration::from_millis(20));
+                let mut f = std::fs::OpenOptions::new()
+                    .append(true)
+                    .open(&path)
+                    .unwrap();
+                f.write_all(b"efghij").unwrap();
+                f.flush().unwrap();
+                written.fetch_add(6, Ordering::Release);
+            }
+        });
+
+        let mut rest = [0u8; 8];
+        let n = src.read(&mut rest).unwrap();
+        assert_eq!(&rest[..n], b"efghij");
     }
 
     #[test]
-    fn seek_from_start() {
-        let data = b"0123456789";
-        let buf = filled_buffer(data);
-        let mut src = buf.reader();
+    fn seeks_freely_below_the_write_head() {
+        let fx = Fixture::new();
+        fx.push(b"0123456789");
+        let mut src = fx.source(1_000_000);
 
-        let pos = src.seek(SeekFrom::Start(5)).unwrap();
-        assert_eq!(pos, 5);
-
+        assert_eq!(src.seek(SeekFrom::Start(5)).unwrap(), 5);
         let mut out = [0u8; 3];
         src.read_exact(&mut out).unwrap();
         assert_eq!(&out, b"567");
-    }
 
-    #[test]
-    fn seek_from_current() {
-        let data = b"0123456789";
-        let buf = filled_buffer(data);
-        let mut src = buf.reader();
-
-        src.seek(SeekFrom::Start(2)).unwrap();
-        let pos = src.seek(SeekFrom::Current(3)).unwrap();
-        assert_eq!(pos, 5);
-
-        let mut out = [0u8; 2];
+        // Backwards, into bytes already read — no re-download, no buffer.
+        assert_eq!(src.seek(SeekFrom::Start(1)).unwrap(), 1);
         src.read_exact(&mut out).unwrap();
-        assert_eq!(&out, b"56");
+        assert_eq!(&out, b"123");
+
+        assert_eq!(src.seek(SeekFrom::Current(-2)).unwrap(), 2);
     }
 
     #[test]
-    fn seek_from_end() {
-        let data = b"0123456789";
-        let buf = filled_buffer(data);
-        let mut src = buf.reader();
+    fn seek_from_end_uses_the_advertised_length() {
+        let fx = Fixture::new();
+        fx.push(b"0123456789");
+        let mut src = fx.source(10);
 
-        // SeekFrom::End(0) should position at total_len (EOF).
-        let pos = src.seek(SeekFrom::End(0)).unwrap();
-        assert_eq!(pos, 10);
-
-        // SeekFrom::End(-3) should position at offset 7.
-        let pos = src.seek(SeekFrom::End(-3)).unwrap();
-        assert_eq!(pos, 7);
+        assert_eq!(src.seek(SeekFrom::End(0)).unwrap(), 10);
+        assert_eq!(src.seek(SeekFrom::End(-3)).unwrap(), 7);
 
         let mut out = [0u8; 3];
         src.read_exact(&mut out).unwrap();
@@ -309,150 +344,106 @@ mod tests {
 
     #[test]
     fn seek_before_start_errors() {
-        let data = b"hello";
-        let buf = filled_buffer(data);
-        let mut src = buf.reader();
-
-        let result = src.seek(SeekFrom::Current(-1));
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn is_complete_when_done() {
-        let buf = StreamBuffer::new(Some(5));
-        buf.push(b"hello");
-        // Not yet finished.
-        assert!(buf.bytes_downloaded() != 0); // just check bytes_downloaded works
-        buf.finish();
-        // After finish, a reader should see EOF immediately.
-        let mut src = buf.reader();
-        let mut out = Vec::new();
-        src.read_to_end(&mut out).unwrap();
-        assert_eq!(out, b"hello");
-    }
-
-    #[test]
-    fn byte_len_returns_total() {
-        use symphonia::core::io::MediaSource;
-        let buf = StreamBuffer::new(Some(42));
-        let src = buf.reader();
-        assert_eq!(src.byte_len(), Some(42));
-    }
-
-    #[test]
-    fn is_seekable_true() {
-        use symphonia::core::io::MediaSource;
-        let buf = StreamBuffer::new(None);
-        let src = buf.reader();
-        assert!(src.is_seekable());
-    }
-
-    #[test]
-    fn push_increments_bytes_downloaded() {
-        let buf = StreamBuffer::new(Some(10));
-        buf.push(b"hello");
-        assert_eq!(buf.bytes_downloaded(), 5);
-        buf.push(b"world");
-        assert_eq!(buf.bytes_downloaded(), 10);
-    }
-
-    #[test]
-    fn multiple_readers_independent_positions() {
-        let data = b"0123456789";
-        let buf = filled_buffer(data);
-
-        let mut r1 = buf.reader();
-        let mut r2 = buf.reader();
-
-        r1.seek(SeekFrom::Start(7)).unwrap();
-
-        let mut out1 = [0u8; 3];
-        r1.read_exact(&mut out1).unwrap();
-        assert_eq!(&out1, b"789");
-
-        let mut out2 = [0u8; 3];
-        r2.read_exact(&mut out2).unwrap();
-        assert_eq!(&out2, b"012");
+        let fx = Fixture::new();
+        fx.push(b"hello");
+        assert!(fx.source(5).seek(SeekFrom::Current(-1)).is_err());
     }
 
     #[test]
     fn failed_download_errors_instead_of_reporting_eof() {
-        let buf = StreamBuffer::new(Some(1000));
-        buf.push(b"partial");
-        buf.fail();
+        let fx = Fixture::new();
+        fx.push(b"partial");
+        fx.set(FAILED);
+        let mut src = fx.source(1000);
 
-        let mut src = buf.reader();
         let mut out = [0u8; 7];
         src.read_exact(&mut out).unwrap();
         assert_eq!(&out, b"partial");
 
-        // Past the buffered bytes: an error, never a clean EOF — Ok(0) here
+        // Past the written bytes: an error, never a clean EOF — Ok(0) here
         // would end the track early and look like a short file.
-        let err = src.read(&mut out).unwrap_err();
-        assert_eq!(err.kind(), io::ErrorKind::BrokenPipe);
+        assert_eq!(
+            src.read(&mut out).unwrap_err().kind(),
+            io::ErrorKind::BrokenPipe
+        );
     }
 
     #[test]
-    fn failed_download_wakes_a_blocked_reader() {
-        let buf = StreamBuffer::new(Some(1000));
-        let mut src = buf.reader();
+    fn failure_wakes_a_blocked_reader() {
+        let fx = Fixture::new();
+        let mut src = fx.source(1000);
 
-        let writer = buf.clone();
-        let waiter = std::thread::spawn(move || {
-            let mut out = [0u8; 8];
-            src.read(&mut out).map(|_| ()).map_err(|e| e.kind())
+        let status = fx.status.clone();
+        std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(20));
+            status.store(FAILED, Ordering::Release);
         });
 
-        std::thread::sleep(std::time::Duration::from_millis(20));
-        writer.fail();
-
-        assert_eq!(waiter.join().unwrap(), Err(io::ErrorKind::BrokenPipe));
+        let mut out = [0u8; 8];
+        assert_eq!(
+            src.read(&mut out).unwrap_err().kind(),
+            io::ErrorKind::BrokenPipe
+        );
     }
 
     #[test]
     fn stalled_download_times_out() {
         // A download with a Content-Length that never arrives: the read must
         // give up rather than park the decode thread forever.
-        let buf = StreamBuffer::with_read_timeout(Some(1000), std::time::Duration::from_millis(20));
-        let mut src = buf.reader();
+        let fx = Fixture::new();
+        let mut src = fx.source_with_stall(1000, Duration::from_millis(20));
         let mut out = [0u8; 8];
-        let err = src.read(&mut out).unwrap_err();
-        assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+        assert_eq!(
+            src.read(&mut out).unwrap_err().kind(),
+            io::ErrorKind::TimedOut
+        );
     }
 
     #[test]
-    fn abandoned_when_no_other_handles_remain() {
-        let buf = StreamBuffer::new(None);
-        assert!(buf.is_abandoned());
+    fn completion_ends_the_read_at_the_true_length() {
+        // A chunked transfer reports no total; completion is what says the file
+        // is whole, and its length on disk is what is readable.
+        let fx = Fixture::new();
+        fx.push(b"chunked");
+        fx.set(COMPLETE);
 
-        let reader = buf.reader();
-        assert!(!buf.is_abandoned());
-
-        drop(reader);
-        assert!(buf.is_abandoned());
-    }
-
-    #[test]
-    fn test_partial_availability() {
-        // Push only 500 bytes without finish() — simulates in-progress download.
-        let data: Vec<u8> = (0u8..=255).cycle().take(1000).collect();
-        let buf = StreamBuffer::new(Some(1000));
-        buf.push(&data[..500]);
-
-        assert_eq!(buf.bytes_downloaded(), 500);
-        assert_eq!(buf.total_len(), Some(1000));
-
-        // Spawn thread to call finish() after brief delay so reader doesn't block forever.
-        let buf2 = buf.clone();
-        std::thread::spawn(move || {
-            std::thread::sleep(std::time::Duration::from_millis(10));
-            buf2.finish();
-        });
-
-        let mut src = buf.reader();
         let mut out = Vec::new();
-        src.read_to_end(&mut out).unwrap();
-        assert_eq!(out.len(), 500);
-        assert_eq!(out, &data[..500]);
+        fx.source(0).read_to_end(&mut out).unwrap();
+        assert_eq!(out, b"chunked");
+    }
+
+    #[test]
+    fn survives_the_part_file_being_renamed() {
+        // The download's final act is a rename. A reader that already has the
+        // file open must not notice.
+        let fx = Fixture::new();
+        fx.push(b"0123456789");
+        let mut src = fx.source(10);
+
+        let mut out = [0u8; 4];
+        src.read_exact(&mut out).unwrap();
+        assert_eq!(&out, b"0123");
+
+        std::fs::rename(&fx.path, fx.path.with_extension("")).unwrap();
+        fx.set(COMPLETE);
+
+        let mut rest = Vec::new();
+        src.read_to_end(&mut rest).unwrap();
+        assert_eq!(rest, b"456789");
+    }
+
+    #[test]
+    fn byte_len_is_the_advertised_length_only() {
+        let fx = Fixture::new();
+        assert_eq!(fx.source(42).byte_len(), Some(42));
+        // No Content-Length: the length is genuinely unknown, and claiming one
+        // would have Symphonia compute a duration from it.
+        assert_eq!(fx.source(0).byte_len(), None);
+    }
+
+    #[test]
+    fn is_seekable_true() {
+        let fx = Fixture::new();
+        assert!(fx.source(0).is_seekable());
     }
 }

--- a/crates/koan-core/src/audio/streaming.rs
+++ b/crates/koan-core/src/audio/streaming.rs
@@ -52,6 +52,34 @@ pub struct PartialFileSource {
     total: u64,
     status: Arc<dyn Fn() -> StreamStatus + Send + Sync>,
     stall_limit: Duration,
+    /// Whether a read may wait at the write head for more of the download.
+    ///
+    /// Playback waits; probing does not. A container asked to describe itself
+    /// reads whatever it needs to, and Ogg needs its last page — so a probe
+    /// that waits waits for the whole transfer. Refusing instead turns that
+    /// into an immediate answer of "not from what has arrived", which is
+    /// something the caller can act on.
+    wait_for_bytes: bool,
+    /// Whether to state the advertised length.
+    ///
+    /// Saying nothing is what stops a container going looking for its tail:
+    /// Ogg reads its final page only when the source claims both a length and
+    /// seekability. The cost is that it then cannot seek at all, so this is for
+    /// the second attempt at opening a partial file, once the first has shown
+    /// the container will not describe itself from the front.
+    advertise_len: bool,
+}
+
+/// How much a probe may claim, and how far it may read.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProbeMode {
+    /// State the length. A container that can describe itself from the bytes
+    /// already downloaded does, and the result is fully seekable.
+    Full,
+    /// State no length, so a container that would go looking for its tail
+    /// settles for what it can read from the front. Opens immediately at the
+    /// cost of seeking, and of any duration only the tail could give.
+    Lengthless,
 }
 
 impl PartialFileSource {
@@ -64,6 +92,21 @@ impl PartialFileSource {
         status: Arc<dyn Fn() -> StreamStatus + Send + Sync>,
     ) -> io::Result<Self> {
         Self::with_stall_limit(path, bytes_written, total, status, STALL_LIMIT)
+    }
+
+    /// Open for a probe: never waits at the write head, so a container that
+    /// cannot describe itself from what has arrived says so at once.
+    pub fn open_for_probe(
+        path: &Path,
+        bytes_written: Arc<AtomicU64>,
+        total: u64,
+        status: Arc<dyn Fn() -> StreamStatus + Send + Sync>,
+        mode: ProbeMode,
+    ) -> io::Result<Self> {
+        let mut source = Self::with_stall_limit(path, bytes_written, total, status, STALL_LIMIT)?;
+        source.wait_for_bytes = false;
+        source.advertise_len = mode == ProbeMode::Full;
+        Ok(source)
     }
 
     fn with_stall_limit(
@@ -80,6 +123,8 @@ impl PartialFileSource {
             total,
             status,
             stall_limit,
+            wait_for_bytes: true,
+            advertise_len: true,
         })
     }
 
@@ -140,6 +185,12 @@ impl Read for PartialFileSource {
                 }
             }
 
+            if !self.wait_for_bytes {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "past what the download has delivered",
+                ));
+            }
             if Instant::now() >= deadline {
                 return Err(io::Error::new(
                     io::ErrorKind::TimedOut,
@@ -191,7 +242,7 @@ impl symphonia::core::io::MediaSource for PartialFileSource {
     }
 
     fn byte_len(&self) -> Option<u64> {
-        (self.total > 0).then_some(self.total)
+        (self.advertise_len && self.total > 0).then_some(self.total)
     }
 }
 

--- a/crates/koan-core/src/audio/streaming.rs
+++ b/crates/koan-core/src/audio/streaming.rs
@@ -83,15 +83,24 @@ pub enum ProbeMode {
 }
 
 impl PartialFileSource {
-    /// Open `path` for streaming. `bytes_written` is the download's own counter
-    /// and `total` its advertised length, 0 when it sent none.
+    /// Open `path` for playback: reads wait at the write head for the download
+    /// to catch up. `bytes_written` is the download's own counter and `total`
+    /// its advertised length, 0 when it sent none.
+    ///
+    /// `mode` must be whatever the probe settled on. A container opened without
+    /// a length to describe itself has to be decoded without one too — given a
+    /// length it goes looking for its tail all over again, and this time on the
+    /// decode thread, where the cost is silence rather than a busy player.
     pub fn open(
         path: &Path,
         bytes_written: Arc<AtomicU64>,
         total: u64,
         status: Arc<dyn Fn() -> StreamStatus + Send + Sync>,
+        mode: ProbeMode,
     ) -> io::Result<Self> {
-        Self::with_stall_limit(path, bytes_written, total, status, STALL_LIMIT)
+        let mut source = Self::with_stall_limit(path, bytes_written, total, status, STALL_LIMIT)?;
+        source.advertise_len = mode == ProbeMode::Full;
+        Ok(source)
     }
 
     /// Open for a probe: never waits at the write head, so a container that

--- a/crates/koan-core/src/db/connection.rs
+++ b/crates/koan-core/src/db/connection.rs
@@ -88,6 +88,17 @@ fn configure(conn: &Connection) -> Result<(), DbError> {
     conn.pragma_update(None, "busy_timeout", 30000)?;
     // Slightly faster at the cost of durability on power loss (acceptable for a media DB).
     conn.pragma_update(None, "synchronous", "normal")?;
+    // Map the whole library. A library this size fits well inside this, so
+    // reads become dereferences into a mapped region rather than syscalls —
+    // which is the useful sense in which a database can be "in memory". The
+    // page cache was already holding it; this stops copying it out per read.
+    conn.pragma_update(None, "mmap_size", 268_435_456i64)?;
+    // 32 MiB of pages, per connection. Negative means KiB rather than pages,
+    // so the figure does not change meaning with the page size.
+    conn.pragma_update(None, "cache_size", -32_000i64)?;
+    // Sorts and intermediate tables in memory. FTS and the ORDER BYs behind
+    // every library listing make temporary tables constantly.
+    conn.pragma_update(None, "temp_store", "memory")?;
     // Here rather than with the schema: `open_existing` skips the DDL, and a
     // connection without this collation fails every ORDER BY that uses it.
     register_library_collation(conn)?;

--- a/crates/koan-core/src/db/mod.rs
+++ b/crates/koan-core/src/db/mod.rs
@@ -1,3 +1,4 @@
 pub mod connection;
+pub mod pool;
 pub mod queries;
 pub mod schema;

--- a/crates/koan-core/src/db/pool.rs
+++ b/crates/koan-core/src/db/pool.rs
@@ -1,0 +1,182 @@
+//! Database connections, opened once and kept.
+//!
+//! Every read used to open its own: a connection, a permissions syscall, the
+//! whole schema DDL and a WAL checkpoint, before a single row came back.
+//! Clicking an album paid all of it, and while downloads were writing, the
+//! checkpoint contended with them and it took seconds.
+//!
+//! A pool rather than one shared connection, because rusqlite's `Connection` is
+//! `Send` but not `Sync`: sharing one means a mutex, and a mutex means every
+//! read waits for every other. SQLite in WAL mode reads concurrently across
+//! connections, so the way to keep that is to have several and hand them out.
+//!
+//! A connection is opened only when every existing one is busy, so the pool
+//! grows to whatever concurrency actually happens. What it *keeps* is capped:
+//! queueing a thousand tracks runs as many transfers at once as
+//! `download_workers` allows and no more, but a burst wider than the cap should
+//! not leave a thousand connections parked for the rest of the session, each
+//! holding its own page cache. Past the cap a returned connection is closed
+//! rather than kept.
+
+use std::ops::Deref;
+use std::path::{Path, PathBuf};
+
+use super::connection::{Database, DbError};
+
+pub struct Pool {
+    path: PathBuf,
+    idle: parking_lot::Mutex<Vec<Database>>,
+    keep: usize,
+}
+
+/// How many idle connections to hold on to.
+///
+/// Comfortably more than the concurrency anything here actually reaches — a
+/// handful of front-end reads alongside the configured download workers — so
+/// the steady state never opens one, while a burst still cannot park hundreds.
+const KEEP_IDLE: usize = 32;
+
+/// The process's pool for the default library.
+///
+/// One database, opened once, shared by everything that reads it: the front
+/// ends, the downloader, the background tasks. Callers with their own path —
+/// tests, mostly — build their own.
+pub fn shared() -> &'static Pool {
+    static POOL: std::sync::OnceLock<Pool> = std::sync::OnceLock::new();
+    POOL.get_or_init(|| Pool::new(crate::config::db_path()))
+}
+
+impl Pool {
+    /// The schema must already be applied — see [`Pool::get`].
+    pub fn new(path: PathBuf) -> Self {
+        Self {
+            path,
+            idle: parking_lot::Mutex::new(Vec::new()),
+            keep: KEEP_IDLE,
+        }
+    }
+
+    /// Borrow a connection, opening one only if none are free.
+    ///
+    /// `open_existing`, so this never re-runs the DDL or checkpoints: the
+    /// schema is applied once at startup, before any pool exists.
+    pub fn get(&self) -> Result<Handle<'_>, DbError> {
+        let pooled = self.idle.lock().pop();
+        let db = match pooled {
+            Some(db) => db,
+            None => Database::open_existing(&self.path)?,
+        };
+        Ok(Handle {
+            db: Some(db),
+            pool: self,
+        })
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn put_back(&self, db: Database) {
+        let mut idle = self.idle.lock();
+        if idle.len() < self.keep {
+            idle.push(db);
+        }
+        // Otherwise it closes here, which is the point of the cap.
+    }
+}
+
+/// A borrowed connection, returned to the pool when it goes out of scope.
+///
+/// Derefs to `Database` so callers reach `.conn` exactly as they did when this
+/// was an owned connection they had opened themselves.
+pub struct Handle<'a> {
+    db: Option<Database>,
+    pool: &'a Pool,
+}
+
+impl Deref for Handle<'_> {
+    type Target = Database;
+
+    fn deref(&self) -> &Database {
+        self.db.as_ref().expect("a handle holds its connection")
+    }
+}
+
+impl Drop for Handle<'_> {
+    fn drop(&mut self) {
+        if let Some(db) = self.db.take() {
+            self.pool.put_back(db);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pool() -> (tempfile::TempDir, Pool) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("koan.db");
+        // What startup does, once.
+        Database::open(&path).unwrap();
+        (dir, Pool::new(path))
+    }
+
+    #[test]
+    fn a_connection_comes_back_and_is_reused() {
+        let (_dir, pool) = pool();
+        {
+            let db = pool.get().unwrap();
+            db.conn.execute_batch("SELECT 1").unwrap();
+        }
+        assert_eq!(pool.idle.lock().len(), 1, "returned on drop");
+        {
+            let _db = pool.get().unwrap();
+            assert_eq!(pool.idle.lock().len(), 0, "handed back out");
+        }
+        assert_eq!(pool.idle.lock().len(), 1);
+    }
+
+    #[test]
+    fn concurrent_borrowers_get_their_own() {
+        let (_dir, pool) = pool();
+        let first = pool.get().unwrap();
+        let second = pool.get().unwrap();
+        first.conn.execute_batch("SELECT 1").unwrap();
+        second.conn.execute_batch("SELECT 1").unwrap();
+        drop(first);
+        drop(second);
+        assert_eq!(pool.idle.lock().len(), 2, "both kept for next time");
+    }
+
+    #[test]
+    fn idle_connections_are_capped() {
+        // A burst wider than the cap must not park connections for the rest of
+        // the session.
+        let (_dir, mut pool) = pool();
+        pool.keep = 2;
+        let handles: Vec<_> = (0..6).map(|_| pool.get().unwrap()).collect();
+        assert_eq!(pool.idle.lock().len(), 0, "all of them are out");
+        drop(handles);
+        assert_eq!(pool.idle.lock().len(), 2, "the rest closed on return");
+    }
+
+    #[test]
+    fn a_pooled_connection_sees_what_another_wrote() {
+        // WAL readers are per-connection snapshots; a stale one would serve a
+        // library that is missing whatever just landed.
+        let (_dir, pool) = pool();
+        {
+            let db = pool.get().unwrap();
+            db.conn
+                .execute_batch("CREATE TABLE probe (v INTEGER); INSERT INTO probe VALUES (7)")
+                .unwrap();
+        }
+        let db = pool.get().unwrap();
+        let v: i64 = db
+            .conn
+            .query_row("SELECT v FROM probe", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(v, 7);
+    }
+}

--- a/crates/koan-core/src/db/queries/batch.rs
+++ b/crates/koan-core/src/db/queries/batch.rs
@@ -299,6 +299,35 @@ pub fn album_ids_for_tracks(
         .map_err(Into::into)
 }
 
+/// Where each track's bytes are: on the server, on this machine, or both.
+///
+/// One query for a whole queue. The same reading `Track` gives, so a row in the
+/// queue and the same row in an album agree about what they are — asked here
+/// per queue rather than per row, which is what a list of a thousand would
+/// otherwise cost.
+pub fn sources_for_tracks(
+    conn: &Connection,
+    track_ids: &[i64],
+) -> Result<HashMap<i64, (bool, bool)>, DbError> {
+    if track_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+    let sql = format!(
+        "SELECT id, remote_id IS NOT NULL, COALESCE(cached_path, path) IS NOT NULL \
+         FROM tracks WHERE id IN {}",
+        placeholders(track_ids.len())
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(params_from_iter(track_ids), |row| {
+        Ok((
+            row.get::<_, i64>(0)?,
+            (row.get::<_, bool>(1)?, row.get::<_, bool>(2)?),
+        ))
+    })?;
+    rows.collect::<Result<HashMap<_, _>, _>>()
+        .map_err(Into::into)
+}
+
 // ---------------------------------------------------------------------------
 // SQL-side track filtering
 // ---------------------------------------------------------------------------

--- a/crates/koan-core/src/db/queries/tracks.rs
+++ b/crates/koan-core/src/db/queries/tracks.rs
@@ -917,6 +917,37 @@ pub fn clear_cached_paths(conn: &Connection) -> Result<(), DbError> {
     Ok(())
 }
 
+/// Where the named tracks were downloaded to, for the ones that were.
+pub fn cached_paths_for(conn: &Connection, track_ids: &[i64]) -> Result<Vec<String>, DbError> {
+    if track_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    let placeholders = vec!["?"; track_ids.len()].join(",");
+    let sql = format!(
+        "SELECT cached_path FROM tracks WHERE id IN ({placeholders}) AND cached_path IS NOT NULL"
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(rusqlite::params_from_iter(track_ids), |row| row.get(0))?;
+    Ok(rows.filter_map(Result::ok).collect())
+}
+
+/// Forget where the named tracks were downloaded to. The rows stay: a remote
+/// track is still in the library, it just has to be fetched again to play.
+pub fn clear_cached_paths_for(conn: &Connection, track_ids: &[i64]) -> Result<(), DbError> {
+    if track_ids.is_empty() {
+        return Ok(());
+    }
+    let placeholders = vec!["?"; track_ids.len()].join(",");
+    conn.execute(
+        &format!(
+            "UPDATE tracks SET cached_path = NULL, cache_size_bytes = NULL, \
+             cache_download_date = NULL WHERE id IN ({placeholders})"
+        ),
+        rusqlite::params_from_iter(track_ids),
+    )?;
+    Ok(())
+}
+
 /// Update the cached_path for a track after downloading, recording size and timestamp.
 pub fn set_cached_path(conn: &Connection, track_id: i64, path: &str) -> Result<(), DbError> {
     let size_bytes: Option<i64> = std::fs::metadata(path).ok().map(|m| m.len() as i64);

--- a/crates/koan-core/src/db/queries/tracks.rs
+++ b/crates/koan-core/src/db/queries/tracks.rs
@@ -931,6 +931,19 @@ pub fn cached_paths_for(conn: &Connection, track_ids: &[i64]) -> Result<Vec<Stri
     Ok(rows.filter_map(Result::ok).collect())
 }
 
+/// Which of the named tracks have a downloaded copy.
+pub fn downloaded_of(conn: &Connection, track_ids: &[i64]) -> Result<Vec<i64>, DbError> {
+    if track_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    let placeholders = vec!["?"; track_ids.len()].join(",");
+    let sql =
+        format!("SELECT id FROM tracks WHERE id IN ({placeholders}) AND cached_path IS NOT NULL");
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(rusqlite::params_from_iter(track_ids), |row| row.get(0))?;
+    Ok(rows.filter_map(Result::ok).collect())
+}
+
 /// Forget where the named tracks were downloaded to. The rows stay: a remote
 /// track is still in the library, it just has to be fetched again to play.
 pub fn clear_cached_paths_for(conn: &Connection, track_ids: &[i64]) -> Result<(), DbError> {

--- a/crates/koan-core/src/helpers.rs
+++ b/crates/koan-core/src/helpers.rs
@@ -425,6 +425,45 @@ pub fn clear_downloads_for(db: &Database, track_ids: &[i64]) -> CacheCleared {
     cleared
 }
 
+/// Throw away half-finished downloads left behind by a previous run.
+///
+/// A `.part` file only means something to the transfer writing it. koan does
+/// not resume — the file is written straight through and renamed at the end —
+/// so one still on disk at startup is from a run that did not finish, and it
+/// will be truncated and rewritten the next time that track is wanted anyway.
+/// Until then it is bytes nothing knows about: cache eviction only tracks what
+/// finished, so an interrupted download of a nine-hour recording is half a
+/// gigabyte that never gets reclaimed.
+///
+/// At startup rather than at exit, because a run that ends without getting to
+/// its own cleanup is exactly the run that leaves these behind.
+pub fn sweep_partial_downloads(cfg: &Config) -> CacheCleared {
+    let mut swept = CacheCleared::default();
+    for entry in walkdir::WalkDir::new(cfg.cache_dir())
+        .into_iter()
+        .filter_map(Result::ok)
+        .filter(|e| e.file_type().is_file())
+        .filter(|e| e.path().extension().is_some_and(|ext| ext == "part"))
+    {
+        let size = entry.metadata().map(|m| m.len()).unwrap_or(0);
+        match std::fs::remove_file(entry.path()) {
+            Ok(()) => {
+                swept.files += 1;
+                swept.bytes += size;
+            }
+            Err(e) => log::warn!("could not remove {}: {e}", entry.path().display()),
+        }
+    }
+    if swept.files > 0 {
+        log::info!(
+            "swept {} unfinished download(s), {} bytes",
+            swept.files,
+            swept.bytes
+        );
+    }
+    swept
+}
+
 /// Fetch again anything in the queue whose downloaded copy has just been
 /// removed.
 ///
@@ -1404,6 +1443,45 @@ mod rebuild_tests {
                 .unwrap()
                 .is_empty()
         );
+    }
+
+    #[test]
+    fn sweeping_removes_half_finished_downloads_and_nothing_else() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = dir.path().join("cache");
+        std::fs::create_dir_all(cache.join("Artist")).unwrap();
+
+        let finished = cache.join("Artist/whole.opus");
+        let half = cache.join("Artist/half.opus.part");
+        std::fs::write(&finished, vec![0u8; 1024]).unwrap();
+        std::fs::write(&half, vec![0u8; 4096]).unwrap();
+
+        let cfg = Config {
+            remote: crate::config::RemoteConfig {
+                cache_dir: Some(cache.clone()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let swept = sweep_partial_downloads(&cfg);
+        assert_eq!(swept.files, 1);
+        assert_eq!(swept.bytes, 4096);
+        assert!(!half.exists(), "the unfinished one is gone");
+        assert!(finished.exists(), "a downloaded track is not touched");
+    }
+
+    #[test]
+    fn sweeping_an_empty_cache_is_not_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = Config {
+            remote: crate::config::RemoteConfig {
+                cache_dir: Some(dir.path().join("nothing-here")),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        assert_eq!(sweep_partial_downloads(&cfg).files, 0);
     }
 
     #[test]

--- a/crates/koan-core/src/helpers.rs
+++ b/crates/koan-core/src/helpers.rs
@@ -1189,6 +1189,21 @@ pub fn download_track(
 
     let bytes_written: Arc<AtomicU64> = Arc::new(AtomicU64::new(0));
 
+    // Announce it before a byte moves, so a queue of six shows six rows rather
+    // than one row and five tracks that look like nothing is happening to them.
+    let store = crate::remote::downloads::store();
+    store.queued(crate::remote::downloads::Download {
+        id: queue_id,
+        track_id: db_id,
+        title: track.title.clone(),
+        artist: track.artist_name.clone(),
+        source: crate::remote::download::part_path(&dest),
+        dest: dest.clone(),
+        total: 0,
+        written: bytes_written.clone(),
+        state: crate::remote::downloads::DownloadState::Queued,
+    });
+
     let progress_state = state.clone();
     let progress_qid = queue_id;
     let bytes_written_progress = bytes_written.clone();
@@ -1207,6 +1222,7 @@ pub fn download_track(
     let result = client.download_with_progress(&remote_id, &dest, move |downloaded, total| {
         bytes_written_progress.store(downloaded, Ordering::Release);
         if announced_total.swap(total, Ordering::Relaxed) != total {
+            store.started(progress_qid, total, bytes_written_progress.clone());
             progress_state.update_load_state(
                 progress_qid,
                 LoadState::Downloading {
@@ -1227,10 +1243,12 @@ pub fn download_track(
     });
 
     if let Err(e) = result {
+        store.failed(queue_id, e.to_string());
         fail_track(state, tx, queue_id, e.to_string());
         push_log(log_buf, format!("x {} — {}", track.title, e));
         return;
     }
+    store.finished(queue_id);
 
     // Download succeeded.
     state.update_paths(&[(queue_id, dest.clone())]);

--- a/crates/koan-core/src/helpers.rs
+++ b/crates/koan-core/src/helpers.rs
@@ -1203,12 +1203,14 @@ pub fn download_track(
     //
     // A retry restarts the byte count from zero, so a changed total re-announces.
     let announced_total = AtomicU64::new(u64::MAX);
+    let in_progress = crate::remote::download::part_path(&dest);
     let result = client.download_with_progress(&remote_id, &dest, move |downloaded, total| {
         bytes_written_progress.store(downloaded, Ordering::Release);
         if announced_total.swap(total, Ordering::Relaxed) != total {
             progress_state.update_load_state(
                 progress_qid,
                 LoadState::Downloading {
+                    path: in_progress.clone(),
                     total,
                     bytes_written: bytes_written_progress.clone(),
                 },

--- a/crates/koan-core/src/helpers.rs
+++ b/crates/koan-core/src/helpers.rs
@@ -1130,7 +1130,7 @@ pub fn download_track(
     }
 
     // 3. Download from remote. The queue item points at the in-progress file so
-    // the streaming pump reads bytes as they land; it flips to `dest` on success.
+    // the decoder reads bytes as they land; it flips to `dest` on success.
     state.update_paths(&[(queue_id, crate::remote::download::part_path(&dest))]);
 
     let bytes_written: Arc<AtomicU64> = Arc::new(AtomicU64::new(0));

--- a/crates/koan-core/src/helpers.rs
+++ b/crates/koan-core/src/helpers.rs
@@ -1141,7 +1141,11 @@ pub fn download_track(
     cfg: &Config,
     client: &SubsonicClient,
 ) {
-    let db = match Database::open_default() {
+    // From the pool. This runs once per track fetched, and opening a
+    // connection here re-ran the schema DDL and attempted a WAL checkpoint —
+    // with several transfers going, several init cycles contending with each
+    // other and with whatever the library was trying to read.
+    let db = match crate::db::pool::shared().get() {
         Ok(db) => db,
         Err(e) => {
             fail_track(state, tx, queue_id, format!("db error: {}", e));

--- a/crates/koan-core/src/helpers.rs
+++ b/crates/koan-core/src/helpers.rs
@@ -392,6 +392,39 @@ pub fn clear_download_cache(db: &Database, cfg: &Config) -> CacheCleared {
     cleared
 }
 
+/// Delete the downloaded copies of just these tracks.
+///
+/// The per-track counterpart of `clear_download_cache`, for throwing away one
+/// record rather than the lot. A track playing from a copy being removed keeps
+/// playing — the decoder holds the file open, and unlinking it only takes the
+/// name away — but the next play fetches it again.
+pub fn clear_downloads_for(db: &Database, track_ids: &[i64]) -> CacheCleared {
+    let mut cleared = CacheCleared::default();
+    let paths = match queries::cached_paths_for(&db.conn, track_ids) {
+        Ok(paths) => paths,
+        Err(e) => {
+            log::warn!("could not read cached paths: {e}");
+            return cleared;
+        }
+    };
+    for path in &paths {
+        let size = std::fs::metadata(path).map(|m| m.len()).unwrap_or(0);
+        match std::fs::remove_file(path) {
+            Ok(()) => {
+                cleared.files += 1;
+                cleared.bytes += size;
+            }
+            // Already gone is the outcome asked for, so it is not a failure.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => log::warn!("could not remove {path}: {e}"),
+        }
+    }
+    if let Err(e) = queries::clear_cached_paths_for(&db.conn, track_ids) {
+        log::warn!("removed downloads but failed to forget them ({e})");
+    }
+    cleared
+}
+
 /// Push a favourite to the remote server, if this track came from one.
 ///
 /// Fire and forget on its own thread: starring is a courtesy to the server, and
@@ -1274,6 +1307,67 @@ mod rebuild_tests {
         conn.pragma_update(None, "foreign_keys", "on").unwrap();
         crate::db::schema::create_tables(&conn).unwrap();
         Database { conn }
+    }
+
+    #[test]
+    fn clearing_one_download_leaves_the_others_and_the_library_alone() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = test_db();
+
+        let mut cached = Vec::new();
+        for name in ["one", "two"] {
+            let mut meta = sample_meta(name, "Artist", "Album");
+            meta.source = "remote".into();
+            meta.path = None;
+            meta.remote_id = Some(name.into());
+            let id = queries::upsert_track(&db.conn, &meta).unwrap();
+            let file = dir.path().join(format!("{name}.opus"));
+            std::fs::write(&file, vec![0u8; 2048]).unwrap();
+            queries::set_cached_path(&db.conn, id, &file.to_string_lossy()).unwrap();
+            cached.push((id, file));
+        }
+
+        let cleared = clear_downloads_for(&db, &[cached[0].0]);
+        assert_eq!(cleared.files, 1);
+        assert_eq!(cleared.bytes, 2048);
+        assert!(!cached[0].1.exists(), "the copy asked for is gone");
+        assert!(cached[1].1.exists(), "the other one is untouched");
+
+        // The row survives — a remote track is still in the library, it just
+        // has to be fetched again.
+        assert_eq!(queries::library_stats(&db.conn).unwrap().remote_tracks, 2);
+        assert_eq!(queries::library_stats(&db.conn).unwrap().cached_tracks, 1);
+        assert!(
+            queries::cached_paths_for(&db.conn, &[cached[0].0])
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn clearing_a_download_that_is_already_gone_is_not_a_failure() {
+        let db = test_db();
+        let mut meta = sample_meta("ghost", "Artist", "Album");
+        meta.source = "remote".into();
+        meta.path = None;
+        meta.remote_id = Some("ghost".into());
+        let id = queries::upsert_track(&db.conn, &meta).unwrap();
+        queries::set_cached_path(&db.conn, id, "/nowhere/at/all.opus").unwrap();
+
+        let cleared = clear_downloads_for(&db, &[id]);
+        assert_eq!(cleared.files, 0, "nothing was there to remove");
+        // Forgotten regardless: the row claimed a copy that does not exist.
+        assert!(
+            queries::cached_paths_for(&db.conn, &[id])
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn clearing_no_tracks_does_nothing() {
+        let db = test_db();
+        assert_eq!(clear_downloads_for(&db, &[]).files, 0);
     }
 
     #[test]

--- a/crates/koan-core/src/helpers.rs
+++ b/crates/koan-core/src/helpers.rs
@@ -425,6 +425,27 @@ pub fn clear_downloads_for(db: &Database, track_ids: &[i64]) -> CacheCleared {
     cleared
 }
 
+/// Fetch again anything in the queue whose downloaded copy has just been
+/// removed.
+///
+/// Clearing downloads deletes files the queue is still pointing at, and an item
+/// that goes on claiming to be ready plays nothing at all. Call this after
+/// either clearing function, from anywhere with a player attached.
+pub fn requeue_cleared_downloads(
+    state: &Arc<SharedPlayerState>,
+    tx: &crossbeam_channel::Sender<PlayerCommand>,
+) {
+    let stale = state.reset_items_with_missing_files();
+    if stale.is_empty() {
+        return;
+    }
+    log::info!(
+        "{} queued tracks lost their copy — fetching again",
+        stale.len()
+    );
+    spawn_downloads(stale, tx.clone(), state.clone());
+}
+
 /// Push a favourite to the remote server, if this track came from one.
 ///
 /// Fire and forget on its own thread: starring is a courtesy to the server, and

--- a/crates/koan-core/src/helpers.rs
+++ b/crates/koan-core/src/helpers.rs
@@ -1202,6 +1202,7 @@ pub fn download_track(
         total: 0,
         written: bytes_written.clone(),
         state: crate::remote::downloads::DownloadState::Queued,
+        bytes_per_second: 0,
     });
 
     let progress_state = state.clone();

--- a/crates/koan-core/src/player/commands.rs
+++ b/crates/koan-core/src/player/commands.rs
@@ -64,6 +64,17 @@ pub enum PlayerCommand {
     TrackReady(QueueItemId),
     /// Enough data buffered for streaming playback — check if cursor is waiting.
     TrackStreamReady(QueueItemId),
+    /// A partial file has been probed off-thread and can be started.
+    ///
+    /// Probing reads as much of the container as it takes to describe itself,
+    /// which for Ogg means its last page — the whole remaining download. That
+    /// cannot happen on this loop, so it happens on its own thread and arrives
+    /// here as a command like anything else. Stale by the time it lands is the
+    /// normal case, and simply ignored.
+    StreamProbed {
+        id: QueueItemId,
+        info: Box<crate::audio::buffer::StreamInfo>,
+    },
     /// Download failed — a cursor parked on this item must stop waiting.
     ///
     /// Without it the player sits on a `Pending` item forever: `Ready` is the

--- a/crates/koan-core/src/player/commands.rs
+++ b/crates/koan-core/src/player/commands.rs
@@ -74,6 +74,11 @@ pub enum PlayerCommand {
     StreamProbed {
         id: QueueItemId,
         info: Box<crate::audio::buffer::StreamInfo>,
+        /// What the probe had to settle for. Decoding has to be opened the same
+        /// way — given a length, a container that went looking for its tail
+        /// once will do it again, on the decode thread, where the cost is
+        /// silence instead of a busy player.
+        mode: crate::audio::streaming::ProbeMode,
     },
     /// Download failed — a cursor parked on this item must stop waiting.
     ///

--- a/crates/koan-core/src/player/mod.rs
+++ b/crates/koan-core/src/player/mod.rs
@@ -471,8 +471,23 @@ impl Player {
     ) {
         let path = path.to_path_buf();
         let tx = self.commands.tx.clone();
-        let status = self.stream_status_fn(id);
         let hint = hint_for(&path);
+
+        // Abandon the moment the track stops being the one wanted. A probe of
+        // a container that needs its tail otherwise reads to the end of a
+        // download nobody is waiting for any more, and skipping through a
+        // queue that is still caching would leave one doing so per skip.
+        let status = {
+            let downloading = self.stream_status_fn(id);
+            let state = self.shared_state.clone();
+            Arc::new(move || {
+                if state.is_cursor(id) {
+                    downloading()
+                } else {
+                    streaming::StreamStatus::Failed
+                }
+            }) as Arc<dyn Fn() -> streaming::StreamStatus + Send + Sync>
+        };
 
         let spawned = thread::Builder::new()
             .name("koan-stream-probe".into())

--- a/crates/koan-core/src/player/mod.rs
+++ b/crates/koan-core/src/player/mod.rs
@@ -3,7 +3,7 @@ pub mod history;
 pub mod state;
 pub mod undo;
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::AtomicU64;
 use std::thread;
@@ -37,6 +37,16 @@ pub enum PlayerError {
     Decode(#[from] buffer::DecodeError),
 }
 
+/// Everything needed to read a track that is still downloading: where it is,
+/// how far the transfer has got, and how the container has to be opened.
+#[derive(Clone)]
+struct StreamSource {
+    path: PathBuf,
+    bytes_written: Arc<AtomicU64>,
+    total: u64,
+    mode: streaming::ProbeMode,
+}
+
 /// Symphonia's format hint for a path — its extension, where it has one.
 fn hint_for(path: &Path) -> symphonia::core::formats::probe::Hint {
     let mut hint = symphonia::core::formats::probe::Hint::new();
@@ -66,6 +76,9 @@ pub struct Player {
     backend: Box<dyn AudioBackend>,
     /// Debounce: timestamp of last NextTrack/PrevTrack to suppress key repeat.
     last_skip: std::time::Instant,
+    /// How the file currently streaming had to be opened. A seek reopens it and
+    /// must not undo what the probe settled on.
+    stream_mode: streaming::ProbeMode,
     /// Writes plays away from this thread. None when there is no database to
     /// write to, and in tests, which must not touch the real library.
     history: Option<PlayRecorder>,
@@ -118,6 +131,7 @@ impl Player {
             output_device_name: cfg.playback.output_device.clone(),
             backend: crate::audio::platform_backend(),
             last_skip: std::time::Instant::now(),
+            stream_mode: streaming::ProbeMode::Full,
             history: None,
             in_flight: None,
             #[cfg(test)]
@@ -513,7 +527,7 @@ impl Player {
                 // the write head, so a container that needs bytes which have
                 // not arrived fails here rather than reading the transfer out.
                 let info = match attempt(streaming::ProbeMode::Full) {
-                    Ok(info) => Some(info),
+                    Ok(info) => Some((info, streaming::ProbeMode::Full)),
                     Err(e) => {
                         // Try again claiming no length. Ogg goes looking for its
                         // last page only when told there is one to find; without
@@ -525,15 +539,18 @@ impl Player {
                             path.display(),
                             e
                         );
-                        attempt(streaming::ProbeMode::Lengthless).ok()
+                        attempt(streaming::ProbeMode::Lengthless)
+                            .ok()
+                            .map(|info| (info, streaming::ProbeMode::Lengthless))
                     }
                 };
 
                 match info {
-                    Some(info) => {
+                    Some((info, mode)) => {
                         tx.send(PlayerCommand::StreamProbed {
                             id,
                             info: Box::new(info),
+                            mode,
                         })
                         .ok();
                     }
@@ -553,7 +570,12 @@ impl Player {
 
     /// A probe finished. Start the track if it is still the one wanted and
     /// nothing has started it in the meantime.
-    fn stream_probed(&mut self, id: QueueItemId, info: buffer::StreamInfo) {
+    fn stream_probed(
+        &mut self,
+        id: QueueItemId,
+        info: buffer::StreamInfo,
+        mode: streaming::ProbeMode,
+    ) {
         if !self.shared_state.is_cursor(id) {
             return; // Moved on.
         }
@@ -573,9 +595,13 @@ impl Player {
                 bytes_written,
                 total,
             }) => {
-                if let Err(e) =
-                    self.start_streaming_playback(id, &path, bytes_written, total, 0, info)
-                {
+                let source = StreamSource {
+                    path,
+                    bytes_written,
+                    total,
+                    mode,
+                };
+                if let Err(e) = self.start_streaming_playback(id, source, 0, info) {
                     log::error!("stream probe: streaming playback failed: {}", e);
                 }
             }
@@ -610,13 +636,11 @@ impl Player {
     fn start_streaming_playback(
         &mut self,
         id: QueueItemId,
-        path: &Path,
-        bytes_written: Arc<AtomicU64>,
-        total: u64,
+        source: StreamSource,
         seek_ms: u64,
         info: buffer::StreamInfo,
     ) -> Result<(), PlayerError> {
-        let result = self.open_streaming_playback(id, path, bytes_written, total, seek_ms, info);
+        let result = self.open_streaming_playback(id, source, seek_ms, info);
         if result.is_err() {
             self.stop_playback_and_clear_state();
         }
@@ -626,17 +650,23 @@ impl Player {
     fn open_streaming_playback(
         &mut self,
         id: QueueItemId,
-        path: &Path,
-        bytes_written: Arc<AtomicU64>,
-        total: u64,
+        source: StreamSource,
         seek_ms: u64,
         info: buffer::StreamInfo,
     ) -> Result<(), PlayerError> {
         self.stop_engine();
+        // Held so a seek can reopen the same way without probing again.
+        self.stream_mode = source.mode;
+        let path = source.path.as_path();
 
         let status = self.stream_status_fn(id);
         let open_source = {
-            let path = path.to_path_buf();
+            let StreamSource {
+                path,
+                bytes_written,
+                total,
+                mode,
+            } = source.clone();
             let status = status.clone();
             move || {
                 streaming::PartialFileSource::open(
@@ -644,6 +674,7 @@ impl Player {
                     bytes_written.clone(),
                     total,
                     status.clone(),
+                    mode,
                 )
             }
         };
@@ -799,14 +830,13 @@ impl Player {
                     bitrate_kbps: info.bitrate_kbps,
                     duration_ms: info.duration_ms,
                 };
-                self.start_streaming_playback(
-                    info.id,
-                    &path,
+                let source = StreamSource {
+                    path,
                     bytes_written,
                     total,
-                    position_ms,
-                    known,
-                )?;
+                    mode: self.stream_mode,
+                };
+                self.start_streaming_playback(info.id, source, position_ms, known)?;
             }
             Some(PlaybackSource::Ready(path)) => {
                 self.start_playback(info.id, &path, position_ms)?;
@@ -1331,7 +1361,7 @@ impl Player {
             PlayerCommand::TrackReady(id) => self.track_ready(id),
             PlayerCommand::DecodeFinished => self.on_decode_finished(),
             PlayerCommand::TrackStreamReady(id) => self.track_stream_ready(id),
-            PlayerCommand::StreamProbed { id, info } => self.stream_probed(id, *info),
+            PlayerCommand::StreamProbed { id, info, mode } => self.stream_probed(id, *info, mode),
             PlayerCommand::TrackFailed(id) => self.track_failed(id),
             PlayerCommand::Undo => self.execute_undo(),
             PlayerCommand::Redo => self.execute_redo(),

--- a/crates/koan-core/src/player/mod.rs
+++ b/crates/koan-core/src/player/mod.rs
@@ -25,6 +25,10 @@ use undo::{UndoEntry, UndoStack};
 /// Ring buffer size in samples. ~1s at 192kHz stereo.
 pub(crate) const RING_BUFFER_SIZE: usize = 192_000 * 2;
 
+/// Kept back from the end of a track when seeking, so dragging the thumb all
+/// the way over lands in the last moment of it rather than in the next track.
+const SEEK_END_GUARD_MS: u64 = 500;
+
 #[derive(Debug, Error)]
 pub enum PlayerError {
     #[error("backend error: {0}")]
@@ -487,20 +491,46 @@ impl Player {
         let spawned = thread::Builder::new()
             .name("koan-stream-probe".into())
             .spawn(move || {
-                let source =
-                    match streaming::PartialFileSource::open(&path, bytes_written, total, status) {
-                        Ok(s) => s,
-                        Err(e) => {
-                            log::warn!("stream probe: cannot open {}: {}", path.display(), e);
-                            return;
-                        }
-                    };
-                let mss = symphonia::core::io::MediaSourceStream::new(
-                    Box::new(source),
-                    Default::default(),
-                );
-                match buffer::probe_source(mss, &hint) {
-                    Ok(info) => {
+                let attempt = |mode| {
+                    streaming::PartialFileSource::open_for_probe(
+                        &path,
+                        bytes_written.clone(),
+                        total,
+                        status.clone(),
+                        mode,
+                    )
+                    .map_err(buffer::DecodeError::Io)
+                    .and_then(|source| {
+                        let mss = symphonia::core::io::MediaSourceStream::new(
+                            Box::new(source),
+                            Default::default(),
+                        );
+                        buffer::probe_source(mss, &hint)
+                    })
+                };
+
+                // Ask for the whole description first. Neither attempt waits at
+                // the write head, so a container that needs bytes which have
+                // not arrived fails here rather than reading the transfer out.
+                let info = match attempt(streaming::ProbeMode::Full) {
+                    Ok(info) => Some(info),
+                    Err(e) => {
+                        // Try again claiming no length. Ogg goes looking for its
+                        // last page only when told there is one to find; without
+                        // it the track opens now and plays, at the price of
+                        // seeking and of the duration that page carries. Both
+                        // come back when the download lands.
+                        log::info!(
+                            "stream probe: {} needs more than has arrived ({}), opening without a length",
+                            path.display(),
+                            e
+                        );
+                        attempt(streaming::ProbeMode::Lengthless).ok()
+                    }
+                };
+
+                match info {
+                    Some(info) => {
                         tx.send(PlayerCommand::StreamProbed {
                             id,
                             info: Box::new(info),
@@ -509,10 +539,9 @@ impl Player {
                     }
                     // Not a failure of the track: it plays from disk once the
                     // download lands, and the cursor is still parked on it.
-                    Err(e) => log::info!(
-                        "stream probe: {} cannot start early ({}), waiting for the download",
-                        path.display(),
-                        e
+                    None => log::info!(
+                        "stream probe: {} cannot start early, waiting for the download",
+                        path.display()
                     ),
                 }
             });
@@ -723,10 +752,19 @@ impl Player {
             return;
         };
         // Stop just short of the end rather than falling into the next track.
-        let ceiling = self
-            .shared_state
-            .seekable_ms()
-            .min(info.duration_ms.saturating_sub(500));
+        let seekable = self.shared_state.seekable_ms();
+        if seekable == 0 {
+            // Nothing of this track can be reached yet — a partial container
+            // that has not said what it is. Restarting it at zero is not what
+            // anyone asked for, so the seek is simply declined.
+            log::debug!("seek declined: {:?} is not seekable yet", info.id);
+            return;
+        }
+        let ceiling = seekable.min(
+            self.shared_state
+                .duration_ms()
+                .saturating_sub(SEEK_END_GUARD_MS),
+        );
         let clamped = position_ms.min(ceiling);
 
         if let Err(e) = self.restart_current(&info, clamped) {

--- a/crates/koan-core/src/player/mod.rs
+++ b/crates/koan-core/src/player/mod.rs
@@ -5,7 +5,7 @@ pub mod undo;
 
 use std::path::Path;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::AtomicU64;
 use std::thread;
 
 use thiserror::Error;
@@ -31,6 +31,15 @@ pub enum PlayerError {
     Backend(#[from] BackendError),
     #[error("decode error: {0}")]
     Decode(#[from] buffer::DecodeError),
+}
+
+/// Symphonia's format hint for a path — its extension, where it has one.
+fn hint_for(path: &Path) -> symphonia::core::formats::probe::Hint {
+    let mut hint = symphonia::core::formats::probe::Hint::new();
+    if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
+        hint.with_extension(ext);
+    }
+    hint
 }
 
 /// The player controller. Owns the audio pipeline and processes commands.
@@ -307,11 +316,12 @@ impl Player {
                 bytes_written,
                 total,
             }) => {
-                if let Err(e) = self.start_streaming_playback(id, &path, bytes_written, total) {
-                    // The cursor stays here, so TrackReady starts it once the
-                    // whole file has landed.
-                    log::error!("streaming play failed, waiting for full download: {}", e);
-                }
+                // Stop what is playing and park here. The probe answers on its
+                // own thread; if it cannot, TrackReady starts the track once
+                // the whole file has landed.
+                self.stop_engine();
+                self.shared_state.set_playback_state(PlaybackState::Stopped);
+                self.probe_stream_for_playback(id, &path, bytes_written, total);
             }
             None => {
                 // Item not ready — stop current playback, wait for TrackReady.
@@ -438,20 +448,136 @@ impl Player {
         Ok(())
     }
 
+    /// Probe a partially-downloaded file on its own thread, and start it when
+    /// the answer comes back.
+    ///
+    /// Nothing here waits. Probing reads as much of the container as it takes
+    /// to describe itself — for Ogg, its last page, which means the whole
+    /// remaining download — and this is the thread that answers play, pause and
+    /// seek. So the probe goes elsewhere and its result returns as a command.
+    ///
+    /// A format that describes itself up front (FLAC, MP3) comes back in
+    /// milliseconds and starts early, which is the point of streaming. One that
+    /// does not comes back whenever it comes back, by which time the download
+    /// has usually landed and `TrackReady` has started the track from disk —
+    /// and the late answer is simply dropped. Either way the player kept
+    /// answering commands throughout.
+    fn probe_stream_for_playback(
+        &self,
+        id: QueueItemId,
+        path: &Path,
+        bytes_written: Arc<AtomicU64>,
+        total: u64,
+    ) {
+        let path = path.to_path_buf();
+        let tx = self.commands.tx.clone();
+        let status = self.stream_status_fn(id);
+        let hint = hint_for(&path);
+
+        let spawned = thread::Builder::new()
+            .name("koan-stream-probe".into())
+            .spawn(move || {
+                let source =
+                    match streaming::PartialFileSource::open(&path, bytes_written, total, status) {
+                        Ok(s) => s,
+                        Err(e) => {
+                            log::warn!("stream probe: cannot open {}: {}", path.display(), e);
+                            return;
+                        }
+                    };
+                let mss = symphonia::core::io::MediaSourceStream::new(
+                    Box::new(source),
+                    Default::default(),
+                );
+                match buffer::probe_source(mss, &hint) {
+                    Ok(info) => {
+                        tx.send(PlayerCommand::StreamProbed {
+                            id,
+                            info: Box::new(info),
+                        })
+                        .ok();
+                    }
+                    // Not a failure of the track: it plays from disk once the
+                    // download lands, and the cursor is still parked on it.
+                    Err(e) => log::info!(
+                        "stream probe: {} cannot start early ({}), waiting for the download",
+                        path.display(),
+                        e
+                    ),
+                }
+            });
+
+        if let Err(e) = spawned {
+            log::warn!("stream probe: could not spawn for {:?}: {}", id, e);
+        }
+    }
+
+    /// A probe finished. Start the track if it is still the one wanted and
+    /// nothing has started it in the meantime.
+    fn stream_probed(&mut self, id: QueueItemId, info: buffer::StreamInfo) {
+        if !self.shared_state.is_cursor(id) {
+            return; // Moved on.
+        }
+        if self.shared_state.playback_state() != PlaybackState::Stopped {
+            return; // Already playing — the download landed first, or the user did.
+        }
+
+        match self.shared_state.item_playback_source(id) {
+            // The download landed while probing: play it as an ordinary file.
+            Some(PlaybackSource::Ready(path)) => {
+                if let Err(e) = self.start_playback(id, &path, 0) {
+                    log::error!("stream probe: playback failed: {}", e);
+                }
+            }
+            Some(PlaybackSource::Streaming {
+                path,
+                bytes_written,
+                total,
+            }) => {
+                if let Err(e) =
+                    self.start_streaming_playback(id, &path, bytes_written, total, 0, info)
+                {
+                    log::error!("stream probe: streaming playback failed: {}", e);
+                }
+            }
+            None => {}
+        }
+    }
+
+    /// What the streaming source asks per read to know whether the download is
+    /// still going. Asked each time rather than passed once: a transfer can
+    /// land, or die, at any point during playback.
+    fn stream_status_fn(
+        &self,
+        id: QueueItemId,
+    ) -> Arc<dyn Fn() -> streaming::StreamStatus + Send + Sync> {
+        let state = self.shared_state.clone();
+        Arc::new(move || match state.item_load_state(id) {
+            Some(LoadState::Ready) => streaming::StreamStatus::Complete,
+            Some(LoadState::Failed(_)) => streaming::StreamStatus::Failed,
+            _ => streaming::StreamStatus::Downloading,
+        })
+    }
+
     /// Internal: start streaming playback from a partially-downloaded file.
     ///
-    /// Creates a StreamBuffer and a pump thread that reads from the on-disk partial
-    /// file as bytes become available (tracked via `bytes_written`). The decode thread
-    /// reads from a StreamingSource backed by that buffer, blocking briefly when it
-    /// catches up to the write head.
+    /// The decoder reads the `.part` file straight off disk through a
+    /// `PartialFileSource`, which blocks when it reaches the write head. The
+    /// download's final rename does not disturb an already-open descriptor, so
+    /// a transfer landing mid-track needs no handover.
+    ///
+    /// `info` is already known — from the off-thread probe when starting, or
+    /// from what is playing when seeking. Nothing here probes.
     fn start_streaming_playback(
         &mut self,
         id: QueueItemId,
         path: &Path,
         bytes_written: Arc<AtomicU64>,
         total: u64,
+        seek_ms: u64,
+        info: buffer::StreamInfo,
     ) -> Result<(), PlayerError> {
-        let result = self.open_streaming_playback(id, path, bytes_written, total);
+        let result = self.open_streaming_playback(id, path, bytes_written, total, seek_ms, info);
         if result.is_err() {
             self.stop_playback_and_clear_state();
         }
@@ -464,136 +590,24 @@ impl Player {
         path: &Path,
         bytes_written: Arc<AtomicU64>,
         total: u64,
+        seek_ms: u64,
+        info: buffer::StreamInfo,
     ) -> Result<(), PlayerError> {
         self.stop_engine();
 
-        // Create a StreamBuffer with known total length.
-        let stream_buf = streaming::StreamBuffer::new(if total > 0 { Some(total) } else { None });
-
-        // Spawn a pump thread: reads bytes from the on-disk partial file as they
-        // become available (per bytes_written) and pushes them into StreamBuffer.
-        // This bridges the disk-based download with StreamingSource's in-memory design.
-        // The playlist item's path points to the .part file during download, so the
-        // pump opens the correct file. After download completes, the .part is renamed
-        // to the final path and the item path is updated — but the pump's open FD
-        // remains valid (Unix rename semantics).
-        let pump_path = path.to_path_buf();
-        let pump_buf = stream_buf.clone();
-        let pump_written = bytes_written.clone();
-        let pump_state = self.shared_state.clone();
-        thread::Builder::new()
-            .name("koan-stream-pump".into())
-            .spawn(move || {
-                use std::fs::File;
-                use std::io::Read;
-                use std::time::{Duration, Instant};
-
-                /// No new bytes for this long and the download is treated as dead.
-                /// `bytes_written` simply stops advancing when one dies, so without
-                /// a deadline the pump spins and the decode thread parks forever.
-                const STALL_LIMIT: Duration = Duration::from_secs(30);
-
-                let mut file = match File::open(&pump_path) {
-                    Ok(f) => f,
-                    Err(e) => {
-                        log::error!("stream pump: failed to open {}: {}", pump_path.display(), e);
-                        pump_buf.fail();
-                        return;
-                    }
-                };
-                let mut buf = vec![0u8; 65536];
-                let mut offset: u64 = 0;
-                let mut last_progress = Instant::now();
-                loop {
-                    // Nothing left to read the bytes, so nothing left to write them for.
-                    if pump_buf.is_abandoned() {
-                        return;
-                    }
-                    match pump_state.item_load_state(id) {
-                        Some(LoadState::Failed(e)) => {
-                            log::warn!("stream pump: download of {:?} failed: {}", id, e);
-                            pump_buf.fail();
-                            return;
-                        }
-                        // The download landed: drain to EOF rather than trusting
-                        // `total`, which is 0 for a chunked transfer.
-                        Some(LoadState::Ready) => match file.read(&mut buf) {
-                            Ok(0) => break,
-                            Ok(n) => {
-                                pump_buf.push(&buf[..n]);
-                                offset += n as u64;
-                                continue;
-                            }
-                            Err(e) => {
-                                log::warn!("stream pump read error: {}", e);
-                                pump_buf.fail();
-                                return;
-                            }
-                        },
-                        _ => {}
-                    }
-
-                    let available = pump_written.load(Ordering::Acquire);
-                    if offset >= available {
-                        if total > 0 && available >= total {
-                            break; // Download complete.
-                        }
-                        if last_progress.elapsed() >= STALL_LIMIT {
-                            log::warn!(
-                                "stream pump: no data for {}s, abandoning {}",
-                                STALL_LIMIT.as_secs(),
-                                pump_path.display()
-                            );
-                            pump_buf.fail();
-                            return;
-                        }
-                        thread::sleep(Duration::from_millis(10));
-                        continue;
-                    }
-                    let to_read = ((available - offset) as usize).min(buf.len());
-                    match file.read(&mut buf[..to_read]) {
-                        Ok(0) => {
-                            // File data may lag behind bytes_written (OS buffer flush timing).
-                            // Only treat as true EOF if we've pumped all expected data.
-                            if total > 0 && offset >= total {
-                                break;
-                            }
-                            let latest = pump_written.load(Ordering::Acquire);
-                            if total > 0 && latest >= total && offset >= latest {
-                                break;
-                            }
-                            // Data not yet visible on disk — back off and retry.
-                            thread::sleep(Duration::from_millis(1));
-                            continue;
-                        }
-                        Ok(n) => {
-                            pump_buf.push(&buf[..n]);
-                            offset += n as u64;
-                            last_progress = Instant::now();
-                        }
-                        Err(e) => {
-                            log::warn!("stream pump read error: {}", e);
-                            pump_buf.fail();
-                            return;
-                        }
-                    }
-                }
-                pump_buf.finish();
-            })
-            .map_err(|e| PlayerError::Decode(buffer::DecodeError::Io(e)))?;
-
-        // Probe via a streaming reader — blocks (via condvar) until enough header data arrives.
-        let probe_reader = stream_buf.reader();
-        let probe_hint = {
-            let mut h = symphonia::core::formats::probe::Hint::new();
-            if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
-                h.with_extension(ext);
+        let status = self.stream_status_fn(id);
+        let open_source = {
+            let path = path.to_path_buf();
+            let status = status.clone();
+            move || {
+                streaming::PartialFileSource::open(
+                    &path,
+                    bytes_written.clone(),
+                    total,
+                    status.clone(),
+                )
             }
-            h
         };
-        let probe_mss =
-            symphonia::core::io::MediaSourceStream::new(Box::new(probe_reader), Default::default());
-        let info = buffer::probe_source(probe_mss, &probe_hint)?;
 
         self.shared_state.set_track_info(Some(TrackInfo {
             id,
@@ -605,16 +619,21 @@ impl Player {
             channels: info.channels,
             duration_ms: info.duration_ms,
         }));
-        self.shared_state.set_position_ms(0);
+        self.shared_state.set_position_ms(seek_ms);
         self.on_track_changed(id);
         log::info!(
-            "streaming: {} ({:?}) — {} {}Hz/{}ch, {}ms",
+            "streaming: {} ({:?}) — {} {}Hz/{}ch, {}ms{}",
             path.display(),
             id,
             info.codec,
             info.sample_rate,
             info.channels,
             info.duration_ms,
+            if seek_ms > 0 {
+                format!(" @{}ms", seek_ms)
+            } else {
+                String::new()
+            },
         );
 
         let (producer, consumer) = rtrb::RingBuffer::new(RING_BUFFER_SIZE);
@@ -634,28 +653,13 @@ impl Player {
             next
         };
 
-        // Decode using a fresh StreamingSource reader — reads from the StreamBuffer
-        // that the pump thread feeds. The decode thread blocks when it catches up to
-        // the write head, resuming as more data arrives.
-        // Build a SourceEntry using a fresh StreamingSource reader for the decode thread.
-        let decode_reader = stream_buf.reader();
-        let path_buf = path.to_path_buf();
-        let ext = path
-            .extension()
-            .and_then(|e| e.to_str())
-            .unwrap_or("")
-            .to_string();
-        let mut decode_hint = symphonia::core::formats::probe::Hint::new();
-        if !ext.is_empty() {
-            decode_hint.with_extension(&ext);
-        }
         let first = buffer::SourceEntry {
             id,
-            path: path_buf,
-            hint: decode_hint,
+            path: path.to_path_buf(),
+            hint: hint_for(path),
             make_mss: Box::new(move || {
                 Ok(symphonia::core::io::MediaSourceStream::new(
-                    Box::new(decode_reader),
+                    Box::new(open_source()?),
                     Default::default(),
                 ))
             }),
@@ -670,7 +674,7 @@ impl Player {
         let (_stream_info, decode_handle) = buffer::start_decode(
             first,
             producer,
-            0,
+            seek_ms,
             move || {
                 let (next_id, next_path) = next_track()?;
                 Some(buffer::SourceEntry::from_file(next_id, next_path))
@@ -698,36 +702,54 @@ impl Player {
         Ok(())
     }
 
-    /// Seek within the current track. Clamps to just before the end to avoid
-    /// accidentally skipping. Preserves pause state.
+    /// Seek within the current track, preserving pause state.
+    ///
+    /// A track still downloading is seekable only as far as its bytes reach, so
+    /// the target is clamped to `seekable_ms` and the restart goes back through
+    /// the streaming path — reopening a partial file as a plain file would
+    /// decode whatever happens to be on disk and end the track early.
     pub fn seek(&mut self, position_ms: u64) {
-        let info = match self.shared_state.track_info() {
-            Some(info) => info,
-            None => return,
+        let Some(info) = self.shared_state.track_info() else {
+            return;
         };
         let id = info.id;
-        let path = info.path.clone();
-        let duration = info.duration_ms;
 
-        // Clamp to just before the end so we don't skip to the next track.
-        let mut clamped = if duration > 0 {
-            position_ms.min(duration.saturating_sub(500))
-        } else {
-            position_ms
-        };
-
-        // Clamp to downloaded portion if streaming to prevent seeking into
-        // data that hasn't arrived yet.
-        if let Some(dl_frac) = self.shared_state.current_download_fraction() {
-            let max_ms = (dl_frac * duration as f64) as u64;
-            if max_ms > 5_000 {
-                clamped = clamped.min(max_ms - 5_000);
-            }
-        }
+        // Stop just short of the end rather than falling into the next track.
+        let ceiling = self
+            .shared_state
+            .seekable_ms()
+            .min(info.duration_ms.saturating_sub(500));
+        let clamped = position_ms.min(ceiling);
 
         let was_paused = self.shared_state.playback_state() == PlaybackState::Paused;
 
-        if let Err(e) = self.start_playback(id, &path, clamped) {
+        // The source is resolved now rather than from `info.path`, which names
+        // the `.part` file for a track that was still downloading when it
+        // started and is not renamed when the download lands.
+        let result = match self.shared_state.item_playback_source(id) {
+            Some(PlaybackSource::Streaming {
+                path,
+                bytes_written,
+                total,
+            }) => {
+                // No probe: what is playing already said what this is, and
+                // re-reading an Ogg's last page to learn it again would be the
+                // whole remaining download.
+                let known = buffer::StreamInfo {
+                    codec: info.codec.clone(),
+                    sample_rate: info.sample_rate,
+                    channels: info.channels,
+                    bit_depth: info.bit_depth,
+                    bitrate_kbps: info.bitrate_kbps,
+                    duration_ms: info.duration_ms,
+                };
+                self.start_streaming_playback(id, &path, bytes_written, total, clamped, known)
+            }
+            Some(PlaybackSource::Ready(path)) => self.start_playback(id, &path, clamped),
+            None => return,
+        };
+
+        if let Err(e) = result {
             log::error!("seek failed: {}", e);
             return;
         }
@@ -909,13 +931,8 @@ impl Player {
                 bytes_written,
                 total,
             }) => {
-                log::info!(
-                    "track_stream_ready: starting streaming playback for {:?}",
-                    id
-                );
-                if let Err(e) = self.start_streaming_playback(id, &path, bytes_written, total) {
-                    log::error!("track_stream_ready streaming failed: {}", e);
-                }
+                log::info!("track_stream_ready: probing partial file for {:?}", id);
+                self.probe_stream_for_playback(id, &path, bytes_written, total);
             }
             Some(PlaybackSource::Ready(path)) => {
                 // Download finished between threshold and now — just play normally.
@@ -958,18 +975,29 @@ impl Player {
                 // The initial probe was done on partial streaming data and may have
                 // underestimated duration, causing premature seek clamping or wrong
                 // progress bar display.
-                if let Ok(stream_info) = buffer::probe_file(&path)
-                    && let Some(current) = self.shared_state.track_info()
+                //
+                // The path is taken over at the same time. Playback started
+                // against the `.part` file and the download's last act is to
+                // rename it, so what `track_info` holds now names nothing.
+                if let Some(current) = self.shared_state.track_info()
                     && current.id == id
-                    && stream_info.duration_ms > current.duration_ms
                 {
-                    log::info!(
-                        "track_ready: duration corrected {}ms → {}ms",
-                        current.duration_ms,
-                        stream_info.duration_ms
-                    );
+                    let probed = buffer::probe_file(&path).ok();
+                    let duration_ms = probed
+                        .as_ref()
+                        .map(|s| s.duration_ms)
+                        .filter(|d| *d > current.duration_ms)
+                        .unwrap_or(current.duration_ms);
+                    if duration_ms != current.duration_ms {
+                        log::info!(
+                            "track_ready: duration corrected {}ms → {}ms",
+                            current.duration_ms,
+                            duration_ms
+                        );
+                    }
                     self.shared_state.set_track_info(Some(TrackInfo {
-                        duration_ms: stream_info.duration_ms,
+                        duration_ms,
+                        path: path.clone(),
                         ..current
                     }));
                 }
@@ -1242,6 +1270,7 @@ impl Player {
             PlayerCommand::TrackReady(id) => self.track_ready(id),
             PlayerCommand::DecodeFinished => self.on_decode_finished(),
             PlayerCommand::TrackStreamReady(id) => self.track_stream_ready(id),
+            PlayerCommand::StreamProbed { id, info } => self.stream_probed(id, *info),
             PlayerCommand::TrackFailed(id) => self.track_failed(id),
             PlayerCommand::Undo => self.execute_undo(),
             PlayerCommand::Redo => self.execute_redo(),
@@ -2261,7 +2290,7 @@ mod tests {
     /// freed while AudioUnitUninitialize is still tearing it down → crash.
     #[test]
     fn stop_engine_drops_engine_synchronously() {
-        use std::sync::atomic::AtomicBool;
+        use std::sync::atomic::{AtomicBool, Ordering};
 
         struct MockEngine {
             dropped: Arc<AtomicBool>,

--- a/crates/koan-core/src/player/mod.rs
+++ b/crates/koan-core/src/player/mod.rs
@@ -278,14 +278,9 @@ impl Player {
     /// current position (e.g. after switching output devices). Preserves pause state.
     fn restart_on_current_track(&mut self) {
         if let Some(info) = self.shared_state.track_info() {
-            let was_paused = self.shared_state.playback_state() == PlaybackState::Paused;
             let position_ms = self.shared_state.position_ms();
-            if let Err(e) = self.start_playback(info.id, &info.path, position_ms) {
+            if let Err(e) = self.restart_current(&info, position_ms) {
                 log::error!("failed to restart playback on device switch: {}", e);
-                return;
-            }
-            if was_paused {
-                self.pause();
             }
         }
     }
@@ -727,8 +722,6 @@ impl Player {
         let Some(info) = self.shared_state.track_info() else {
             return;
         };
-        let id = info.id;
-
         // Stop just short of the end rather than falling into the next track.
         let ceiling = self
             .shared_state
@@ -736,20 +729,30 @@ impl Player {
             .min(info.duration_ms.saturating_sub(500));
         let clamped = position_ms.min(ceiling);
 
+        if let Err(e) = self.restart_current(&info, clamped) {
+            log::error!("seek failed: {}", e);
+        }
+    }
+
+    /// Restart what is playing at `position_ms`, preserving pause state.
+    ///
+    /// What a seek does, and what switching output device does, and what going
+    /// back from the first track does. All three restart the same track, so all
+    /// three resolve the source the same way: from the queue item, never from
+    /// `info.path`, which names the `.part` file for a track that was still
+    /// downloading when it started and is not renamed when the download lands.
+    fn restart_current(&mut self, info: &TrackInfo, position_ms: u64) -> Result<(), PlayerError> {
         let was_paused = self.shared_state.playback_state() == PlaybackState::Paused;
 
-        // The source is resolved now rather than from `info.path`, which names
-        // the `.part` file for a track that was still downloading when it
-        // started and is not renamed when the download lands.
-        let result = match self.shared_state.item_playback_source(id) {
+        match self.shared_state.item_playback_source(info.id) {
             Some(PlaybackSource::Streaming {
                 path,
                 bytes_written,
                 total,
             }) => {
                 // No probe: what is playing already said what this is, and
-                // re-reading an Ogg's last page to learn it again would be the
-                // whole remaining download.
+                // reading an Ogg's last page to learn it again would mean
+                // waiting for the rest of the download.
                 let known = buffer::StreamInfo {
                     codec: info.codec.clone(),
                     sample_rate: info.sample_rate,
@@ -758,20 +761,25 @@ impl Player {
                     bitrate_kbps: info.bitrate_kbps,
                     duration_ms: info.duration_ms,
                 };
-                self.start_streaming_playback(id, &path, bytes_written, total, clamped, known)
+                self.start_streaming_playback(
+                    info.id,
+                    &path,
+                    bytes_written,
+                    total,
+                    position_ms,
+                    known,
+                )?;
             }
-            Some(PlaybackSource::Ready(path)) => self.start_playback(id, &path, clamped),
-            None => return,
-        };
-
-        if let Err(e) = result {
-            log::error!("seek failed: {}", e);
-            return;
+            Some(PlaybackSource::Ready(path)) => {
+                self.start_playback(info.id, &path, position_ms)?;
+            }
+            None => return Ok(()),
         }
 
         if was_paused {
             self.pause();
         }
+        Ok(())
     }
 
     /// Skip to next track in playlist.
@@ -800,7 +808,7 @@ impl Player {
             None => {
                 // No previous track — restart current from the beginning.
                 if let Some(info) = self.shared_state.track_info()
-                    && let Err(e) = self.start_playback(info.id, &info.path, 0)
+                    && let Err(e) = self.restart_current(&info, 0)
                 {
                     log::error!("restart failed: {}", e);
                 }

--- a/crates/koan-core/src/player/state.rs
+++ b/crates/koan-core/src/player/state.rs
@@ -715,6 +715,36 @@ impl SharedPlayerState {
             })
     }
 
+    /// Put back to `Pending` every queue item whose file has gone, and say
+    /// which they were so they can be fetched again.
+    ///
+    /// The queue holds paths, and clearing downloads deletes the files under
+    /// them. An item left claiming `Ready` opens nothing when it is played —
+    /// it is not broken, it is a remote track that has to be fetched a second
+    /// time. Only items with a database row behind them: one without has
+    /// nowhere to be fetched from, and parking the cursor on it would be worse
+    /// than letting it fail honestly.
+    pub fn reset_items_with_missing_files(&self) -> Vec<(i64, QueueItemId)> {
+        let mut pl = self.playlist.write();
+        let mut reset = Vec::new();
+        for item in pl.items.iter_mut() {
+            let Some(db_id) = item.db_id else { continue };
+            if !matches!(item.load_state, LoadState::Ready) {
+                continue;
+            }
+            if item.path.exists() {
+                continue;
+            }
+            item.load_state = LoadState::Pending;
+            reset.push((db_id, item.id));
+        }
+        drop(pl);
+        if !reset.is_empty() {
+            self.bump_version();
+        }
+        reset
+    }
+
     /// Get the path of an item if it's Ready (legacy convenience — use item_playback_source for streaming).
     pub fn item_path_if_ready(&self, id: QueueItemId) -> Option<PathBuf> {
         let pl = self.playlist.read();

--- a/crates/koan-core/src/player/state.rs
+++ b/crates/koan-core/src/player/state.rs
@@ -77,6 +77,15 @@ pub const SEEK_SAFETY_MS: u64 = 2_000;
 pub enum LoadState {
     Pending,
     Downloading {
+        /// Where the bytes are going: the in-progress `.part` file, not the
+        /// destination it is renamed to at the end.
+        ///
+        /// Carried here rather than read off the item, whose path is written by
+        /// the download thread and read by the player, and which the two can
+        /// disagree about — a track whose copy was cleared mid-flight kept a
+        /// path pointing at the file that had just been deleted. A load state
+        /// that says a download is running should say where it is running to.
+        path: PathBuf,
         /// Total bytes expected, or 0 when the server sent no Content-Length.
         total: u64,
         /// How many bytes have landed. The download thread writes it per chunk
@@ -282,6 +291,7 @@ impl SharedPlayerState {
         let LoadState::Downloading {
             total,
             bytes_written,
+            ..
         } = &item.load_state
         else {
             return info.duration_ms;
@@ -696,14 +706,14 @@ impl SharedPlayerState {
             .and_then(|item| match &item.load_state {
                 LoadState::Ready => Some(PlaybackSource::Ready(item.path.clone())),
                 LoadState::Downloading {
+                    path,
                     total,
                     bytes_written,
-                    ..
                 } => {
                     let written = bytes_written.load(Ordering::Acquire);
                     if written >= STREAM_THRESHOLD {
                         Some(PlaybackSource::Streaming {
-                            path: item.path.clone(),
+                            path: path.clone(),
                             bytes_written: bytes_written.clone(),
                             total: *total,
                         })
@@ -805,6 +815,7 @@ impl SharedPlayerState {
                 LoadState::Downloading {
                     total,
                     bytes_written,
+                    ..
                 } => Some((item.id, bytes_written.load(Ordering::Relaxed), *total)),
                 _ => None,
             })
@@ -1155,6 +1166,7 @@ mod tests {
         let item = make_item(
             "train",
             LoadState::Downloading {
+                path: PathBuf::from("/cache/train.opus.part"),
                 total,
                 bytes_written: written,
             },
@@ -1496,6 +1508,7 @@ mod tests {
         let dl_cursor = make_item(
             "downloading-at-cursor",
             LoadState::Downloading {
+                path: PathBuf::from("/cache/cursor.flac.part"),
                 total: 1_000_000,
                 bytes_written: bytes_cursor.clone(),
             },
@@ -1503,6 +1516,7 @@ mod tests {
         let dl_queued = make_item(
             "downloading-queued",
             LoadState::Downloading {
+                path: PathBuf::from("/cache/queued.flac.part"),
                 total: 500_000,
                 bytes_written: bytes_queued.clone(),
             },
@@ -1528,6 +1542,7 @@ mod tests {
         let item = make_item(
             "downloading",
             LoadState::Downloading {
+                path: PathBuf::from("/cache/one.flac.part"),
                 total: 1_000,
                 bytes_written: bytes.clone(),
             },

--- a/crates/koan-core/src/player/state.rs
+++ b/crates/koan-core/src/player/state.rs
@@ -65,6 +65,13 @@ pub struct TrackInfo {
 /// Minimum bytes written before streaming playback can begin.
 pub const STREAM_THRESHOLD: u64 = 256 * 1024; // 256 KB
 
+/// Held back from the seekable extent of a downloading track.
+///
+/// Bytes are converted to time at the average bitrate, so on VBR the estimate
+/// wanders either side of the truth; landing short of the write head costs a
+/// couple of seconds of reach and landing past it costs a stall.
+pub const SEEK_SAFETY_MS: u64 = 2_000;
+
 /// Load state of a playlist item — tracks download lifecycle.
 #[derive(Debug, Clone)]
 pub enum LoadState {
@@ -248,6 +255,62 @@ impl SharedPlayerState {
 
     pub fn set_track_info(&self, info: Option<TrackInfo>) {
         *self.track_info.write() = info;
+    }
+
+    /// How far into the currently playing track a seek can land.
+    ///
+    /// A track on disk is seekable end to end. One still downloading is
+    /// seekable only as far as its bytes reach: bytes map to time by the
+    /// average bitrate, exact for lossless and CBR and drifting on VBR, which
+    /// is what `SEEK_SAFETY_MS` covers. Zero when nothing is playing.
+    ///
+    /// The one value both the clamp in `Player::seek` and the extent front ends
+    /// draw on the seek bar come from — a bar that shows a reachable position
+    /// the player then refuses is worse than no bar.
+    pub fn seekable_ms(&self) -> u64 {
+        let Some(info) = self.track_info.read().clone() else {
+            return 0;
+        };
+
+        // Released before the playlist lock is taken: derive_visible_queue takes
+        // these two in the opposite order, so holding both would close a cycle.
+        let pl = self.playlist.read();
+        let Some(item) = pl.items.iter().find(|item| item.id == info.id) else {
+            return info.duration_ms;
+        };
+
+        let LoadState::Downloading {
+            total,
+            bytes_written,
+        } = &item.load_state
+        else {
+            return info.duration_ms;
+        };
+
+        let written = bytes_written.load(Ordering::Acquire);
+        let reached = if *total > 0 && info.duration_ms > 0 {
+            ((written as f64 / *total as f64) * info.duration_ms as f64) as u64
+        } else if let Some(kbps) = info.bitrate_kbps.filter(|k| *k > 0) {
+            // No Content-Length. Bytes still say how much audio has arrived,
+            // given what the probe measured the bitrate to be: 1 kbps is
+            // 1 bit per ms, so bits divided by kbps is milliseconds.
+            written.saturating_mul(8) / kbps as u64
+        } else {
+            // Nothing to derive a position from — forward seeking would be a
+            // guess, so allow only what has already been played.
+            return self.position_ms();
+        };
+
+        reached.saturating_sub(SEEK_SAFETY_MS).min(info.duration_ms)
+    }
+
+    /// `seekable_ms`, but `None` when the whole track is reachable — which is
+    /// every track that is not mid-download. What a front end draws a boundary
+    /// from: no boundary is the normal case and should cost no mark.
+    pub fn seek_ceiling_ms(&self) -> Option<u64> {
+        let duration = self.track_info.read().as_ref()?.duration_ms;
+        let seekable = self.seekable_ms();
+        (seekable < duration).then_some(seekable)
     }
 
     /// Download fraction (0.0..1.0) for the currently playing track, if streaming.
@@ -1001,6 +1064,110 @@ mod tests {
 
     fn failed_item(title: &str) -> PlaylistItem {
         make_item(title, LoadState::Failed("nope".into()))
+    }
+
+    /// A nine-hour track under the cursor, `downloaded` bytes of `total` in.
+    /// `total` of 0 stands for a server that sent no Content-Length.
+    fn streaming_state(
+        downloaded: u64,
+        total: u64,
+        bitrate_kbps: Option<u32>,
+    ) -> Arc<SharedPlayerState> {
+        const DURATION_MS: u64 = 32_523_787;
+        let written = Arc::new(AtomicU64::new(downloaded));
+        let item = make_item(
+            "train",
+            LoadState::Downloading {
+                total,
+                bytes_written: written,
+            },
+        );
+        let id = item.id;
+        let path = item.path.clone();
+
+        let state = SharedPlayerState::new();
+        state.add_items(vec![item]);
+        state.set_cursor(Some(id));
+        state.set_track_info(Some(TrackInfo {
+            id,
+            path,
+            codec: "Opus".into(),
+            sample_rate: 48_000,
+            bit_depth: None,
+            bitrate_kbps,
+            channels: 2,
+            duration_ms: DURATION_MS,
+        }));
+        state
+    }
+
+    // --- seekable_ms ---
+
+    #[test]
+    fn a_track_on_disk_is_seekable_end_to_end() {
+        let item = ready_item("done");
+        let id = item.id;
+        let path = item.path.clone();
+        let state = SharedPlayerState::new();
+        state.add_items(vec![item]);
+        state.set_cursor(Some(id));
+        state.set_track_info(Some(TrackInfo {
+            id,
+            path,
+            codec: "FLAC".into(),
+            sample_rate: 44_100,
+            bit_depth: Some(16),
+            bitrate_kbps: None,
+            channels: 2,
+            duration_ms: 200_000,
+        }));
+
+        assert_eq!(state.seekable_ms(), 200_000);
+        // Nothing to draw a boundary for, so front ends are told there isn't one.
+        assert_eq!(state.seek_ceiling_ms(), None);
+    }
+
+    #[test]
+    fn a_downloading_track_is_seekable_as_far_as_its_bytes_reach() {
+        // A quarter of a nine-hour file in: a quarter of the way through it,
+        // less the margin the byte-to-time estimate is worth.
+        let state = streaming_state(100, 400, None);
+        assert_eq!(state.seekable_ms(), 32_523_787 / 4 - SEEK_SAFETY_MS);
+        assert_eq!(
+            state.seek_ceiling_ms(),
+            Some(32_523_787 / 4 - SEEK_SAFETY_MS)
+        );
+    }
+
+    #[test]
+    fn a_transfer_without_a_content_length_falls_back_to_bitrate() {
+        // No total to take a fraction of. 128 kbps is 128 bits per ms, so a
+        // megabyte is 8 388 608 bits and a little over 65 seconds.
+        let state = streaming_state(1024 * 1024, 0, Some(128));
+        assert_eq!(state.seekable_ms(), 1024 * 1024 * 8 / 128 - SEEK_SAFETY_MS);
+    }
+
+    #[test]
+    fn nothing_to_estimate_from_allows_no_forward_seek() {
+        // Neither a length nor a bitrate: anywhere past the playhead is a
+        // guess, and a guess that lands past the write head is a stall.
+        let state = streaming_state(1024 * 1024, 0, None);
+        state.set_position_ms(12_000);
+        assert_eq!(state.seekable_ms(), 12_000);
+    }
+
+    #[test]
+    fn the_seekable_extent_never_exceeds_the_track() {
+        // A download reporting more bytes than it advertised must not offer a
+        // seek past the end of the music.
+        let state = streaming_state(500, 400, None);
+        assert_eq!(state.seekable_ms(), 32_523_787);
+    }
+
+    #[test]
+    fn nothing_playing_is_seekable_nowhere() {
+        assert_eq!(SharedPlayerState::new().seekable_ms(), 0);
+        assert_eq!(SharedPlayerState::new().seek_ceiling_ms(), None);
     }
 
     // --- advance_cursor_loadable ---

--- a/crates/koan-core/src/player/state.rs
+++ b/crates/koan-core/src/player/state.rs
@@ -287,6 +287,14 @@ impl SharedPlayerState {
             return info.duration_ms;
         };
 
+        // A container that could not describe itself from the bytes downloaded
+        // states no duration, and cannot be seeked at all until the rest of it
+        // lands — there is no index to seek against and no end to seek within.
+        // Ogg is the one that does this; it keeps its duration in its last page.
+        if info.duration_ms == 0 {
+            return 0;
+        }
+
         let written = bytes_written.load(Ordering::Acquire);
         let reached = if *total > 0 && info.duration_ms > 0 {
             ((written as f64 / *total as f64) * info.duration_ms as f64) as u64
@@ -304,11 +312,38 @@ impl SharedPlayerState {
         reached.saturating_sub(SEEK_SAFETY_MS).min(info.duration_ms)
     }
 
+    /// The duration to show for what is playing.
+    ///
+    /// The container's own answer wherever it gave one. A partial file that
+    /// could not be read far enough to state a duration has none, and the
+    /// library's figure stands in — it came from the server, it is right, and
+    /// a transport that reads 0:00 for nine hours of music is worse than one
+    /// reading a figure the container has not caught up with yet.
+    pub fn duration_ms(&self) -> u64 {
+        let Some(info) = self.track_info.read().clone() else {
+            return 0;
+        };
+        if info.duration_ms > 0 {
+            return info.duration_ms;
+        }
+        // Released before the playlist lock, as everywhere else here.
+        self.playlist
+            .read()
+            .items
+            .iter()
+            .find(|item| item.id == info.id)
+            .and_then(|item| item.duration_ms)
+            .unwrap_or(0)
+    }
+
     /// `seekable_ms`, but `None` when the whole track is reachable — which is
     /// every track that is not mid-download. What a front end draws a boundary
     /// from: no boundary is the normal case and should cost no mark.
     pub fn seek_ceiling_ms(&self) -> Option<u64> {
-        let duration = self.track_info.read().as_ref()?.duration_ms;
+        let duration = self.duration_ms();
+        if duration == 0 {
+            return None;
+        }
         let seekable = self.seekable_ms();
         (seekable < duration).then_some(seekable)
     }
@@ -1066,6 +1101,8 @@ mod tests {
         make_item(title, LoadState::Failed("nope".into()))
     }
 
+    const DURATION_MS: u64 = 32_523_787;
+
     /// A nine-hour track under the cursor, `downloaded` bytes of `total` in.
     /// `total` of 0 stands for a server that sent no Content-Length.
     fn streaming_state(
@@ -1073,7 +1110,17 @@ mod tests {
         total: u64,
         bitrate_kbps: Option<u32>,
     ) -> Arc<SharedPlayerState> {
-        const DURATION_MS: u64 = 32_523_787;
+        streaming_state_with_duration(downloaded, total, bitrate_kbps, DURATION_MS)
+    }
+
+    /// The same, but saying what the container managed to state about itself.
+    /// A partial Ogg states nothing, which is zero here.
+    fn streaming_state_with_duration(
+        downloaded: u64,
+        total: u64,
+        bitrate_kbps: Option<u32>,
+        container_duration_ms: u64,
+    ) -> Arc<SharedPlayerState> {
         let written = Arc::new(AtomicU64::new(downloaded));
         let item = make_item(
             "train",
@@ -1096,7 +1143,7 @@ mod tests {
             bit_depth: None,
             bitrate_kbps,
             channels: 2,
-            duration_ms: DURATION_MS,
+            duration_ms: container_duration_ms,
         }));
         state
     }
@@ -1168,6 +1215,52 @@ mod tests {
     fn nothing_playing_is_seekable_nowhere() {
         assert_eq!(SharedPlayerState::new().seekable_ms(), 0);
         assert_eq!(SharedPlayerState::new().seek_ceiling_ms(), None);
+    }
+
+    #[test]
+    fn a_container_that_cannot_state_its_duration_cannot_be_seeked() {
+        // A partial Ogg keeps its duration in a last page that has not arrived,
+        // so it opens and plays but has nothing to seek against. Half the bytes
+        // being present does not change that.
+        let state = streaming_state_with_duration(200, 400, Some(128), 0);
+        assert_eq!(state.seekable_ms(), 0);
+    }
+
+    #[test]
+    fn the_library_duration_stands_in_for_a_silent_container() {
+        // What is shown on the transport, so nine hours of music does not read
+        // as 0:00 while it caches.
+        let state = streaming_state_with_duration(200, 400, Some(128), 0);
+        assert_eq!(state.duration_ms(), 200_000, "the item's own figure");
+        // And it is a display figure only — it grants no seeking.
+        assert_eq!(state.seekable_ms(), 0);
+        assert_eq!(state.seek_ceiling_ms(), Some(0));
+    }
+
+    #[test]
+    fn the_container_duration_wins_where_there_is_one() {
+        let state = streaming_state(200, 400, None);
+        assert_eq!(state.duration_ms(), DURATION_MS);
+    }
+
+    #[test]
+    fn the_download_landing_restores_seeking() {
+        // The sequence the whole design turns on: a track that opened without a
+        // duration gets one when the finished file is re-read, and is seekable
+        // end to end from that moment — no restart, no handover.
+        let state = streaming_state_with_duration(400, 400, Some(128), 0);
+        assert_eq!(state.seekable_ms(), 0);
+
+        let id = state.cursor().expect("cursor");
+        state.update_load_state(id, LoadState::Ready);
+        let info = state.track_info().expect("track info");
+        state.set_track_info(Some(TrackInfo {
+            duration_ms: DURATION_MS,
+            ..info
+        }));
+
+        assert_eq!(state.seekable_ms(), DURATION_MS);
+        assert_eq!(state.seek_ceiling_ms(), None, "no boundary left to draw");
     }
 
     // --- advance_cursor_loadable ---

--- a/crates/koan-core/src/remote/downloads.rs
+++ b/crates/koan-core/src/remote/downloads.rs
@@ -1,0 +1,321 @@
+//! The download store — what koan is fetching, and what it just fetched.
+//!
+//! One place every front end reads, rather than each deriving its own answer
+//! from the queue. The queue only knows about transfers for tracks that are in
+//! it, and it forgets a download the instant it lands — which is exactly when
+//! somebody wants to see that it did.
+//!
+//! Progress and structure are deliberately separate. The byte counter is an
+//! `Arc<AtomicU64>` the downloader writes without taking any lock, because it
+//! moves hundreds of times a second; `version` moves only when an entry is
+//! added, finishes or fails. A client polls the counter and watches the
+//! version, and neither costs the download anything.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use crate::player::state::QueueItemId;
+
+/// Where a transfer has got to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DownloadState {
+    /// Accepted, not yet started. A queue of six shows five of these.
+    Queued,
+    /// Bytes are arriving.
+    Running,
+    /// Every byte landed and the file is at its final path.
+    Done,
+    /// Gave up. The reason is worth keeping — it is the only account of why a
+    /// track will not play.
+    Failed(String),
+}
+
+impl DownloadState {
+    pub fn is_settled(&self) -> bool {
+        matches!(self, Self::Done | Self::Failed(_))
+    }
+}
+
+/// One transfer.
+#[derive(Debug, Clone)]
+pub struct Download {
+    /// The queue item this is being fetched for. Also the identity of the
+    /// transfer, because a track wanted twice is wanted by two queue entries.
+    pub id: QueueItemId,
+    pub track_id: i64,
+    pub title: String,
+    pub artist: String,
+    /// Where the bytes are being written — the `.part` file.
+    pub source: PathBuf,
+    /// Where they end up.
+    pub dest: PathBuf,
+    /// Total expected, or 0 when the server sent no Content-Length.
+    pub total: u64,
+    /// Live byte count, shared with the downloader. Read it, do not store it.
+    pub written: Arc<AtomicU64>,
+    pub state: DownloadState,
+}
+
+impl Download {
+    /// 0–1, or `None` when the server never said how big this is.
+    pub fn fraction(&self) -> Option<f64> {
+        (self.total > 0)
+            .then(|| self.written.load(Ordering::Relaxed) as f64 / self.total as f64)
+            .map(|f| f.clamp(0.0, 1.0))
+    }
+
+    pub fn bytes_written(&self) -> u64 {
+        self.written.load(Ordering::Relaxed)
+    }
+}
+
+/// Every transfer koan knows about.
+#[derive(Debug, Default)]
+pub struct DownloadStore {
+    entries: parking_lot::RwLock<Vec<Download>>,
+    version: AtomicU64,
+    /// How many settled entries to keep. This is a view of now, not an archive,
+    /// and old rows would push the live ones off the end of it.
+    settled_limit: usize,
+}
+
+impl DownloadStore {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self {
+            entries: parking_lot::RwLock::new(Vec::new()),
+            version: AtomicU64::new(0),
+            settled_limit: 50,
+        })
+    }
+
+    /// Bumped when an entry appears, settles or is forgotten — not when its
+    /// byte count moves. A client redraws its list on this and reads the
+    /// counters every frame regardless.
+    pub fn version(&self) -> u64 {
+        self.version.load(Ordering::Acquire)
+    }
+
+    /// Everything, running first, then whatever settled most recently.
+    pub fn all(&self) -> Vec<Download> {
+        self.entries.read().clone()
+    }
+
+    /// How many transfers are actually moving.
+    pub fn active(&self) -> usize {
+        self.entries
+            .read()
+            .iter()
+            .filter(|d| !d.state.is_settled())
+            .count()
+    }
+
+    /// Note that a transfer is wanted. Replaces any earlier entry for the same
+    /// queue item — a track cleared and fetched again is the same row starting
+    /// over, not a second one.
+    pub fn queued(&self, download: Download) {
+        let mut entries = self.entries.write();
+        entries.retain(|d| d.id != download.id);
+        entries.insert(0, download);
+        drop(entries);
+        self.settle();
+    }
+
+    /// Bytes have started arriving, and this is how many there are in total.
+    pub fn started(&self, id: QueueItemId, total: u64, written: Arc<AtomicU64>) {
+        let mut entries = self.entries.write();
+        if let Some(entry) = entries.iter_mut().find(|d| d.id == id) {
+            entry.total = total;
+            entry.written = written;
+            entry.state = DownloadState::Running;
+        }
+        drop(entries);
+        self.bump();
+    }
+
+    /// It landed.
+    pub fn finished(&self, id: QueueItemId) {
+        self.settle_one(id, DownloadState::Done);
+    }
+
+    /// It did not.
+    pub fn failed(&self, id: QueueItemId, reason: String) {
+        self.settle_one(id, DownloadState::Failed(reason));
+    }
+
+    /// Drop everything that has already settled. The running ones are not this
+    /// call's business — stopping a transfer is a different verb.
+    pub fn clear_settled(&self) {
+        let mut entries = self.entries.write();
+        let before = entries.len();
+        entries.retain(|d| !d.state.is_settled());
+        let changed = entries.len() != before;
+        drop(entries);
+        if changed {
+            self.bump();
+        }
+    }
+
+    fn settle_one(&self, id: QueueItemId, state: DownloadState) {
+        let mut entries = self.entries.write();
+        if let Some(entry) = entries.iter_mut().find(|d| d.id == id) {
+            entry.state = state;
+        }
+        drop(entries);
+        self.settle();
+    }
+
+    /// Keep running transfers at the top and the settled tail bounded.
+    fn settle(&self) {
+        let mut entries = self.entries.write();
+        // Stable, so a list being watched does not shuffle under the pointer.
+        let (mut running, settled): (Vec<_>, Vec<_>) =
+            entries.drain(..).partition(|d| !d.state.is_settled());
+        running.extend(settled.into_iter().take(self.settled_limit));
+        *entries = running;
+        drop(entries);
+        self.bump();
+    }
+
+    fn bump(&self) {
+        self.version.fetch_add(1, Ordering::Release);
+    }
+}
+
+/// The process's download store.
+///
+/// A singleton for the same reason the download queue is one: there is one set
+/// of transfers happening, and everything that reports on them — the queue, the
+/// front ends, the downloader itself — has to be looking at the same set.
+pub fn store() -> &'static Arc<DownloadStore> {
+    static STORE: std::sync::OnceLock<Arc<DownloadStore>> = std::sync::OnceLock::new();
+    STORE.get_or_init(DownloadStore::new)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn download(title: &str) -> Download {
+        Download {
+            id: QueueItemId::new(),
+            track_id: 1,
+            title: title.into(),
+            artist: "Artist".into(),
+            source: PathBuf::from(format!("/cache/{title}.opus.part")),
+            dest: PathBuf::from(format!("/cache/{title}.opus")),
+            total: 0,
+            written: Arc::new(AtomicU64::new(0)),
+            state: DownloadState::Queued,
+        }
+    }
+
+    #[test]
+    fn a_transfer_runs_then_settles() {
+        let store = DownloadStore::new();
+        let entry = download("train");
+        let id = entry.id;
+        store.queued(entry);
+        assert_eq!(store.active(), 1);
+
+        let written = Arc::new(AtomicU64::new(0));
+        store.started(id, 400, written.clone());
+        written.store(100, Ordering::Relaxed);
+        assert_eq!(store.all()[0].fraction(), Some(0.25));
+
+        store.finished(id);
+        assert_eq!(store.active(), 0);
+        assert_eq!(store.all()[0].state, DownloadState::Done);
+    }
+
+    #[test]
+    fn progress_does_not_move_the_version() {
+        // The counter is read every frame and the list is rebuilt on the
+        // version; if bytes bumped it, every client would rebuild at the rate
+        // the download writes.
+        let store = DownloadStore::new();
+        let entry = download("train");
+        let id = entry.id;
+        store.queued(entry);
+        let written = Arc::new(AtomicU64::new(0));
+        store.started(id, 1000, written.clone());
+
+        let before = store.version();
+        written.store(500, Ordering::Relaxed);
+        assert_eq!(store.version(), before);
+        assert_eq!(store.all()[0].bytes_written(), 500);
+    }
+
+    #[test]
+    fn no_content_length_means_no_fraction() {
+        // A bar drawn at zero for a transfer that is going fine reads as stuck.
+        let store = DownloadStore::new();
+        let entry = download("chunked");
+        let id = entry.id;
+        store.queued(entry);
+        store.started(id, 0, Arc::new(AtomicU64::new(9000)));
+        assert_eq!(store.all()[0].fraction(), None);
+        assert_eq!(store.all()[0].bytes_written(), 9000);
+    }
+
+    #[test]
+    fn fetching_the_same_item_again_restarts_its_row() {
+        // Clearing a download and playing the track again is the same transfer
+        // starting over, not a second one to scroll past.
+        let store = DownloadStore::new();
+        let first = download("train");
+        let id = first.id;
+        store.queued(first);
+        store.finished(id);
+
+        let mut again = download("train");
+        again.id = id;
+        store.queued(again);
+
+        assert_eq!(store.all().len(), 1);
+        assert_eq!(store.all()[0].state, DownloadState::Queued);
+    }
+
+    #[test]
+    fn running_transfers_sort_above_settled_ones() {
+        let store = DownloadStore::new();
+        let done = download("done");
+        let done_id = done.id;
+        store.queued(done);
+        let running = download("running");
+        store.queued(running);
+        store.finished(done_id);
+
+        let all = store.all();
+        assert_eq!(all[0].title, "running");
+        assert_eq!(all[1].title, "done");
+    }
+
+    #[test]
+    fn a_failure_keeps_its_reason() {
+        let store = DownloadStore::new();
+        let entry = download("gone");
+        let id = entry.id;
+        store.queued(entry);
+        store.failed(id, "server returned 404".into());
+        assert_eq!(
+            store.all()[0].state,
+            DownloadState::Failed("server returned 404".into())
+        );
+    }
+
+    #[test]
+    fn clearing_settled_leaves_the_running_alone() {
+        let store = DownloadStore::new();
+        let done = download("done");
+        let done_id = done.id;
+        store.queued(done);
+        store.queued(download("running"));
+        store.finished(done_id);
+
+        store.clear_settled();
+        let all = store.all();
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].title, "running");
+    }
+}

--- a/crates/koan-core/src/remote/downloads.rs
+++ b/crates/koan-core/src/remote/downloads.rs
@@ -11,9 +11,11 @@
 //! added, finishes or fails. A client polls the counter and watches the
 //! version, and neither costs the download anything.
 
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
 
 use crate::player::state::QueueItemId;
 
@@ -55,6 +57,10 @@ pub struct Download {
     /// Live byte count, shared with the downloader. Read it, do not store it.
     pub written: Arc<AtomicU64>,
     pub state: DownloadState,
+    /// Bytes per second, smoothed. Zero until there are two samples to take a
+    /// rate from — and zero is the honest answer for a transfer that has
+    /// stopped moving, which is the one worth noticing.
+    pub bytes_per_second: u64,
 }
 
 impl Download {
@@ -75,6 +81,10 @@ impl Download {
 pub struct DownloadStore {
     entries: parking_lot::RwLock<Vec<Download>>,
     version: AtomicU64,
+    /// The last reading taken of each transfer, for working out a rate.
+    /// Separate from the entries so taking a sample does not touch the list
+    /// every client is reading.
+    samples: parking_lot::Mutex<HashMap<QueueItemId, Sample>>,
     /// How many settled entries to keep. This is a view of now, not an archive,
     /// and old rows would push the live ones off the end of it.
     settled_limit: usize,
@@ -85,6 +95,7 @@ impl DownloadStore {
         Arc::new(Self {
             entries: parking_lot::RwLock::new(Vec::new()),
             version: AtomicU64::new(0),
+            samples: parking_lot::Mutex::new(HashMap::new()),
             settled_limit: 50,
         })
     }
@@ -182,6 +193,79 @@ impl DownloadStore {
     }
 }
 
+/// The last reading of one transfer.
+#[derive(Debug)]
+struct Sample {
+    at: Instant,
+    bytes: u64,
+    /// Smoothed rate, so a figure on screen does not jump about between frames.
+    bps: f64,
+}
+
+/// How much of a new reading to believe against the running average. Low
+/// enough to be steady, high enough that a transfer stopping shows within a
+/// second or so.
+const RATE_SMOOTHING: f64 = 0.3;
+
+/// Ignore samples closer together than this — over a short enough interval the
+/// arithmetic is mostly noise.
+const MIN_SAMPLE_GAP: Duration = Duration::from_millis(250);
+
+impl DownloadStore {
+    /// Take a rate reading. Called on a timer by whoever is watching.
+    ///
+    /// Rates live here rather than in each front end because every one of them
+    /// would otherwise keep its own last-reading map and get a different
+    /// answer.
+    pub fn sample_rates(&self) {
+        self.sample_rates_at(Instant::now());
+    }
+
+    fn sample_rates_at(&self, now: Instant) {
+        let mut entries = self.entries.write();
+        let mut samples = self.samples.lock();
+
+        for entry in entries.iter_mut() {
+            if entry.state.is_settled() {
+                entry.bytes_per_second = 0;
+                samples.remove(&entry.id);
+                continue;
+            }
+            let bytes = entry.written.load(Ordering::Relaxed);
+            match samples.get_mut(&entry.id) {
+                Some(previous) => {
+                    let elapsed = now.saturating_duration_since(previous.at);
+                    if elapsed < MIN_SAMPLE_GAP {
+                        entry.bytes_per_second = previous.bps as u64;
+                        continue;
+                    }
+                    let moved = bytes.saturating_sub(previous.bytes) as f64;
+                    let instant = moved / elapsed.as_secs_f64();
+                    previous.bps = previous.bps * (1.0 - RATE_SMOOTHING) + instant * RATE_SMOOTHING;
+                    previous.at = now;
+                    previous.bytes = bytes;
+                    entry.bytes_per_second = previous.bps as u64;
+                }
+                None => {
+                    samples.insert(
+                        entry.id,
+                        Sample {
+                            at: now,
+                            bytes,
+                            bps: 0.0,
+                        },
+                    );
+                    entry.bytes_per_second = 0;
+                }
+            }
+        }
+
+        // A transfer that left the list leaves its reading behind with it.
+        let live: std::collections::HashSet<QueueItemId> = entries.iter().map(|e| e.id).collect();
+        samples.retain(|id, _| live.contains(id));
+    }
+}
+
 /// The process's download store.
 ///
 /// A singleton for the same reason the download queue is one: there is one set
@@ -207,6 +291,7 @@ mod tests {
             total: 0,
             written: Arc::new(AtomicU64::new(0)),
             state: DownloadState::Queued,
+            bytes_per_second: 0,
         }
     }
 
@@ -302,6 +387,53 @@ mod tests {
             store.all()[0].state,
             DownloadState::Failed("server returned 404".into())
         );
+    }
+
+    #[test]
+    fn a_rate_needs_two_readings_and_a_gap_between_them() {
+        let store = DownloadStore::new();
+        let entry = download("train");
+        let (id, written) = (entry.id, entry.written.clone());
+        store.queued(entry);
+        store.started(id, 1_000_000, written.clone());
+
+        let start = Instant::now();
+        store.sample_rates_at(start);
+        assert_eq!(
+            store.all()[0].bytes_per_second,
+            0,
+            "one reading is not a rate"
+        );
+
+        // A second too close to the first says nothing.
+        written.store(100_000, Ordering::Relaxed);
+        store.sample_rates_at(start + Duration::from_millis(50));
+        assert_eq!(store.all()[0].bytes_per_second, 0);
+
+        // A second far enough away does. Smoothed, so it reads low at first.
+        store.sample_rates_at(start + Duration::from_secs(1));
+        let bps = store.all()[0].bytes_per_second;
+        assert!(bps > 0, "a rate should have been worked out, got {bps}");
+        assert!(bps < 100_000, "and smoothed rather than taken whole: {bps}");
+    }
+
+    #[test]
+    fn a_settled_transfer_has_no_rate() {
+        // Zero, not the speed it happened to be going when it stopped.
+        let store = DownloadStore::new();
+        let entry = download("train");
+        let (id, written) = (entry.id, entry.written.clone());
+        store.queued(entry);
+        store.started(id, 1000, written.clone());
+        let start = Instant::now();
+        store.sample_rates_at(start);
+        written.store(500, Ordering::Relaxed);
+        store.sample_rates_at(start + Duration::from_secs(1));
+        assert!(store.all()[0].bytes_per_second > 0);
+
+        store.finished(id);
+        store.sample_rates_at(start + Duration::from_secs(2));
+        assert_eq!(store.all()[0].bytes_per_second, 0);
     }
 
     #[test]

--- a/crates/koan-core/src/remote/mod.rs
+++ b/crates/koan-core/src/remote/mod.rs
@@ -1,5 +1,6 @@
 pub mod client;
 pub mod download;
+pub mod downloads;
 pub mod listenbrainz;
 pub mod lrclib;
 pub mod musicbrainz;

--- a/crates/koan-ffi/src/lib.rs
+++ b/crates/koan-ffi/src/lib.rs
@@ -1780,6 +1780,7 @@ impl KoanEngine {
             let cfg = Config::load().unwrap_or_default();
             let cleared = koan_core::helpers::clear_download_cache(&db, &cfg);
             koan_core::helpers::requeue_cleared_downloads(&self.state, &self.tx);
+            self.bump_library();
             Ok(CacheCleared {
                 files: cleared.files,
                 bytes: cleared.bytes,
@@ -1798,6 +1799,7 @@ impl KoanEngine {
             let db = self.db()?;
             let cleared = koan_core::helpers::clear_downloads_for(&db, &track_ids);
             koan_core::helpers::requeue_cleared_downloads(&self.state, &self.tx);
+            self.bump_library();
             Ok(CacheCleared {
                 files: cleared.files,
                 bytes: cleared.bytes,
@@ -2230,6 +2232,20 @@ impl KoanEngine {
                         })
                         .collect();
                     if downloads != last_downloads {
+                        // A transfer leaving the set landed on disk, which wrote
+                        // a cached path onto a library row. Nothing else says
+                        // so — the download runs in koan-core, which has no
+                        // notion of this version — and without it a track goes
+                        // on reading as "on the server, not here" until
+                        // something unrelated reloads the row.
+                        let still_running: std::collections::HashSet<&str> =
+                            downloads.iter().map(|d| d.queue_item_id.as_str()).collect();
+                        if last_downloads
+                            .iter()
+                            .any(|d| !still_running.contains(d.queue_item_id.as_str()))
+                        {
+                            engine.bump_library();
+                        }
                         last_downloads = downloads.clone();
                         publish(PlayerEvent::DownloadsChanged { downloads });
                     }

--- a/crates/koan-ffi/src/lib.rs
+++ b/crates/koan-ffi/src/lib.rs
@@ -120,6 +120,46 @@ pub trait ProgressReporter: Send + Sync {
     fn advanced(&self, done: u64, detail: String);
 }
 
+/// One client's place in the event stream.
+///
+/// Held for as long as the client is listening, which is the whole point: a
+/// broadcast receiver only sees what is published after it subscribes, so
+/// subscribing per message loses everything that arrives between one message
+/// being handed over and the next call asking for another. That gap is small
+/// and the loss was invisible while playback position was the only thing being
+/// published — with transfers running and three times the traffic, position
+/// updates were being dropped and the transport appeared to stall.
+///
+/// Keeping the receiver means the channel's buffer does its job: messages
+/// queue while the client is busy and are delivered in order when it comes
+/// back.
+#[derive(uniffi::Object)]
+pub struct EventStream {
+    rx: tokio::sync::Mutex<tokio::sync::broadcast::Receiver<PlayerEvent>>,
+}
+
+#[uniffi::export]
+impl EventStream {
+    /// The next thing to change. `None` once the engine is gone, which ends
+    /// the caller's loop.
+    ///
+    /// A client that falls far enough behind loses the messages it missed
+    /// rather than delaying the engine — every variant carries an absolute
+    /// value, so the one that does arrive is still correct.
+    pub async fn next(&self) -> Option<PlayerEvent> {
+        let mut rx = self.rx.lock().await;
+        loop {
+            match rx.recv().await {
+                Ok(event) => return Some(event),
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                    log::warn!("client missed {n} events");
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => return None,
+            }
+        }
+    }
+}
+
 /// The player, the library, and the bridge between them.
 /// Send `log` output to `~/.config/koan/koan.log`, the same file the CLI
 /// writes.
@@ -262,18 +302,10 @@ impl KoanEngine {
     /// that falls behind loses the events it missed rather than delaying the
     /// engine — every variant carries an absolute value, so the one that does
     /// arrive is still correct.
-    pub async fn next_event(self: Arc<Self>) -> Option<PlayerEvent> {
-        let mut rx = self.events.subscribe();
-        loop {
-            match rx.recv().await {
-                Ok(event) => return Some(event),
-                // Fell behind. The next event supersedes whatever was dropped.
-                Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
-                    log::debug!("client missed {n} events");
-                }
-                Err(tokio::sync::broadcast::error::RecvError::Closed) => return None,
-            }
-        }
+    pub fn subscribe(&self) -> Arc<EventStream> {
+        Arc::new(EventStream {
+            rx: tokio::sync::Mutex::new(self.events.subscribe()),
+        })
     }
 
     /// Every transfer koan knows about: what it is fetching now, and what it

--- a/crates/koan-ffi/src/lib.rs
+++ b/crates/koan-ffi/src/lib.rs
@@ -88,6 +88,12 @@ pub enum PlayerEvent {
     /// is in flight any more, which is also how a client learns a download
     /// finished.
     DownloadsChanged { downloads: Vec<DownloadProgress> },
+    /// The set of transfers changed — one appeared, settled or was forgotten.
+    ///
+    /// Separate from `DownloadsChanged`, which carries byte counts and fires
+    /// several times a second. This one fires when the *list* changes, which is
+    /// what a client rebuilds a list on.
+    DownloadStoreChanged { version: u64 },
     /// The library's rows changed — a scan, a sync, an import, an organize or
     /// a folder being forgotten. Carries a version so a client can tell one
     /// change from a repeat of the one it already handled.
@@ -269,6 +275,32 @@ impl KoanEngine {
                 Err(tokio::sync::broadcast::error::RecvError::Closed) => return None,
             }
         }
+    }
+
+    /// Every transfer koan knows about: what it is fetching now, and what it
+    /// fetched a moment ago.
+    ///
+    /// Running first, then whatever settled most recently. Read it on
+    /// `DownloadStoreChanged` for the list and on `DownloadsChanged` for the
+    /// figures — the byte counts here are a snapshot taken as this was called.
+    pub fn downloads(&self) -> Vec<DownloadEntry> {
+        koan_core::remote::downloads::store()
+            .all()
+            .iter()
+            .map(DownloadEntry::from)
+            .collect()
+    }
+
+    /// How many transfers are actually moving. Cheap enough for a sidebar to
+    /// read on every redraw.
+    pub fn active_download_count(&self) -> u32 {
+        koan_core::remote::downloads::store().active() as u32
+    }
+
+    /// Forget the transfers that have already settled. Running ones are left
+    /// alone — stopping one is a different verb.
+    pub fn clear_settled_downloads(&self) {
+        koan_core::remote::downloads::store().clear_settled();
     }
 
     /// Cheap enough to poll every frame — use it to decide whether to call
@@ -2178,6 +2210,7 @@ impl KoanEngine {
                 let mut last_position = u64::MAX;
                 let mut last_signature: Option<(PlaybackState, Option<String>, u64)> = None;
                 let mut last_downloads: Vec<DownloadProgress> = Vec::new();
+                let mut last_store = u64::MAX;
                 // Starts where the engine starts, so a launch is not announced
                 // as a change to a library nobody has read yet.
                 let mut last_library = 0u64;
@@ -2248,6 +2281,14 @@ impl KoanEngine {
                         }
                         last_downloads = downloads.clone();
                         publish(PlayerEvent::DownloadsChanged { downloads });
+                    }
+
+                    let store_version = koan_core::remote::downloads::store().version();
+                    if store_version != last_store {
+                        last_store = store_version;
+                        publish(PlayerEvent::DownloadStoreChanged {
+                            version: store_version,
+                        });
                     }
 
                     let library = engine

--- a/crates/koan-ffi/src/lib.rs
+++ b/crates/koan-ffi/src/lib.rs
@@ -2074,7 +2074,7 @@ impl KoanEngine {
             .spawn(move || {
                 let mut last_version = u64::MAX;
                 let mut last_position = u64::MAX;
-                let mut last_signature: Option<(PlaybackState, Option<String>)> = None;
+                let mut last_signature: Option<(PlaybackState, Option<String>, u64)> = None;
                 let mut last_downloads: Vec<DownloadProgress> = Vec::new();
 
                 loop {
@@ -2091,7 +2091,15 @@ impl KoanEngine {
 
                     let state = engine.state.playback_state();
                     let cursor = engine.state.cursor().map(|c| c.0.to_string());
-                    let signature = (state, cursor);
+                    // The seekable extent belongs in the signature: it moves
+                    // while a track downloads without the state or the cursor
+                    // moving, and a client draws a boundary from it. Rounded to
+                    // the second, because it is drawn as a bar a few hundred
+                    // pixels wide and nothing finer is visible. It stops moving
+                    // the moment the download lands, so this costs a snapshot
+                    // per tick only while one is in flight.
+                    let seekable = engine.state.seekable_ms() / 1000;
+                    let signature = (state, cursor, seekable);
                     if last_signature.as_ref() != Some(&signature) {
                         last_signature = Some(signature);
                         publish(PlayerEvent::PlaybackChanged {
@@ -2305,6 +2313,7 @@ impl KoanEngine {
             state: play_state.into(),
             position_ms: self.state.position_ms(),
             duration_ms: info.as_ref().map(|i| i.duration_ms).unwrap_or(0),
+            seekable_ms: self.state.seekable_ms(),
             queue_item_id: cursor.map(|c| c.0.to_string()),
             entry,
             format: info

--- a/crates/koan-ffi/src/lib.rs
+++ b/crates/koan-ffi/src/lib.rs
@@ -328,15 +328,21 @@ impl KoanEngine {
             // record. A queue with no database behind it simply has no album
             // IDs; the art falls back to the per-track lookup as before.
             let track_ids: Vec<i64> = entries.iter().filter_map(|e| e.db_id).collect();
-            let album_ids = self
-                .db()
-                .ok()
+            // Two questions of the same rows, asked once each for the whole
+            // queue rather than once per row.
+            let db = self.db().ok();
+            let album_ids = db
+                .as_ref()
                 .and_then(|db| queries::batch::album_ids_for_tracks(&db.conn, &track_ids).ok())
+                .unwrap_or_default();
+            let sources = db
+                .as_ref()
+                .and_then(|db| queries::batch::sources_for_tracks(&db.conn, &track_ids).ok())
                 .unwrap_or_default();
 
             entries
                 .iter()
-                .map(|e| QueueItem::from_entry(e, &album_ids))
+                .map(|e| QueueItem::from_entry(e, &album_ids, &sources))
                 .collect()
         })
         .await

--- a/crates/koan-ffi/src/lib.rs
+++ b/crates/koan-ffi/src/lib.rs
@@ -1701,6 +1701,7 @@ impl KoanEngine {
             let db = self.db()?;
             let cfg = Config::load().unwrap_or_default();
             let cleared = koan_core::helpers::clear_download_cache(&db, &cfg);
+            koan_core::helpers::requeue_cleared_downloads(&self.state, &self.tx);
             Ok(CacheCleared {
                 files: cleared.files,
                 bytes: cleared.bytes,
@@ -1718,6 +1719,7 @@ impl KoanEngine {
         offload::offload(move || {
             let db = self.db()?;
             let cleared = koan_core::helpers::clear_downloads_for(&db, &track_ids);
+            koan_core::helpers::requeue_cleared_downloads(&self.state, &self.tx);
             Ok(CacheCleared {
                 files: cleared.files,
                 bytes: cleared.bytes,

--- a/crates/koan-ffi/src/lib.rs
+++ b/crates/koan-ffi/src/lib.rs
@@ -1846,6 +1846,41 @@ impl KoanEngine {
         .await
     }
 
+    /// Fetch these tracks into the cache now, without queueing them.
+    ///
+    /// Downloads are normally a side effect of wanting to play something; this
+    /// is for wanting the bytes on the machine and nothing else — before going
+    /// somewhere without a server, most obviously. Tracks already downloaded
+    /// are skipped, so asking twice costs nothing.
+    ///
+    /// The transfers get identities of their own rather than borrowing a queue
+    /// item's, because there is no queue item: they appear in the download
+    /// store and nowhere else.
+    pub async fn download_to_cache(self: Arc<Self>, track_ids: Vec<i64>) -> Result<(), KoanError> {
+        offload::offload(move || {
+            let pending: Vec<(i64, koan_core::player::state::QueueItemId)> = track_ids
+                .into_iter()
+                .map(|id| (id, koan_core::player::state::QueueItemId::new()))
+                .collect();
+            koan_core::helpers::spawn_downloads(pending, self.tx.clone(), self.state.clone());
+            Ok(())
+        })
+        .await
+    }
+
+    /// Which of these tracks have a downloaded copy. What a menu asks before
+    /// deciding whether it is offering to fetch or to throw away.
+    pub async fn downloaded_track_ids(
+        self: Arc<Self>,
+        track_ids: Vec<i64>,
+    ) -> Result<Vec<i64>, KoanError> {
+        offload::offload(move || {
+            let db = self.db()?;
+            queries::downloaded_of(&db.conn, &track_ids).map_err(db_err)
+        })
+        .await
+    }
+
     /// Rescans every configured library folder. Minutes, on a large library.
     pub async fn scan(self: Arc<Self>, force: bool) -> Result<ScanSummary, KoanError> {
         offload::offload(move || self.scan_blocking(force, None)).await
@@ -2217,6 +2252,12 @@ impl KoanEngine {
                 let mut last_signature: Option<(PlaybackState, Option<String>, u64)> = None;
                 let mut last_downloads: Vec<DownloadProgress> = Vec::new();
                 let mut last_store = u64::MAX;
+                // Temporary: answers "is the watcher actually emitting?" from
+                // the log rather than from reasoning about it.
+                let mut emitted_progress: u64 = 0;
+                let mut emitted_store: u64 = 0;
+                let mut emitted_position: u64 = 0;
+                let mut ticks: u64 = 0;
                 // Starts where the engine starts, so a launch is not announced
                 // as a change to a library nobody has read yet.
                 let mut last_library = 0u64;
@@ -2286,15 +2327,37 @@ impl KoanEngine {
                             engine.bump_library();
                         }
                         last_downloads = downloads.clone();
+                        emitted_progress += 1;
                         publish(PlayerEvent::DownloadsChanged { downloads });
                     }
+
+                    // Ten a second, which is this loop's rate and fast enough
+                    // that a figure on screen reacts as a transfer changes pace.
+                    koan_core::remote::downloads::store().sample_rates();
 
                     let store_version = koan_core::remote::downloads::store().version();
                     if store_version != last_store {
                         last_store = store_version;
+                        emitted_store += 1;
                         publish(PlayerEvent::DownloadStoreChanged {
                             version: store_version,
                         });
+                    }
+
+                    // Once every five seconds, and only while something is
+                    // happening. Fifty ticks is the ceiling for each count.
+                    ticks += 1;
+                    if ticks.is_multiple_of(50)
+                        && (emitted_progress > 0 || emitted_position > 0 || emitted_store > 0)
+                    {
+                        log::info!(
+                            "watcher/5s: position {emitted_position}, downloads {emitted_progress}, \
+                             store {emitted_store}, in flight {}",
+                            koan_core::remote::downloads::store().active()
+                        );
+                        emitted_progress = 0;
+                        emitted_store = 0;
+                        emitted_position = 0;
                     }
 
                     let library = engine
@@ -2311,6 +2374,7 @@ impl KoanEngine {
                         let position = engine.state.position_ms();
                         if position != last_position {
                             last_position = position;
+                            emitted_position += 1;
                             publish(PlayerEvent::PositionChanged {
                                 position_ms: position,
                             });

--- a/crates/koan-ffi/src/lib.rs
+++ b/crates/koan-ffi/src/lib.rs
@@ -2508,6 +2508,10 @@ impl KoanEngine {
             message: e.to_string(),
         })?;
 
+        // Before anything can start a download of its own, so this only ever
+        // sees files left by a previous run.
+        koan_core::helpers::sweep_partial_downloads(&Config::load().unwrap_or_default());
+
         let (state, _timeline, viz, tx) = Player::spawn();
         koan_core::radio::spawn_autoqueue(state.clone(), tx.clone(), db_path.clone());
 

--- a/crates/koan-ffi/src/lib.rs
+++ b/crates/koan-ffi/src/lib.rs
@@ -2312,7 +2312,7 @@ impl KoanEngine {
         NowPlaying {
             state: play_state.into(),
             position_ms: self.state.position_ms(),
-            duration_ms: info.as_ref().map(|i| i.duration_ms).unwrap_or(0),
+            duration_ms: self.state.duration_ms(),
             seekable_ms: self.state.seekable_ms(),
             queue_item_id: cursor.map(|c| c.0.to_string()),
             entry,

--- a/crates/koan-ffi/src/lib.rs
+++ b/crates/koan-ffi/src/lib.rs
@@ -1709,6 +1709,23 @@ impl KoanEngine {
         .await
     }
 
+    /// Delete the downloaded copies of just these tracks. The library rows
+    /// stay, and they fetch again on demand.
+    pub async fn clear_downloads(
+        self: Arc<Self>,
+        track_ids: Vec<i64>,
+    ) -> Result<CacheCleared, KoanError> {
+        offload::offload(move || {
+            let db = self.db()?;
+            let cleared = koan_core::helpers::clear_downloads_for(&db, &track_ids);
+            Ok(CacheCleared {
+                files: cleared.files,
+                bytes: cleared.bytes,
+            })
+        })
+        .await
+    }
+
     /// Rescans every configured library folder. Minutes, on a large library.
     pub async fn scan(self: Arc<Self>, force: bool) -> Result<ScanSummary, KoanError> {
         offload::offload(move || self.scan_blocking(force, None)).await

--- a/crates/koan-ffi/src/lib.rs
+++ b/crates/koan-ffi/src/lib.rs
@@ -595,21 +595,8 @@ impl KoanEngine {
         limit: u32,
         offset: u32,
     ) -> Result<Vec<Track>, KoanError> {
-        offload::offload(move || {
-            // Temporary: says whether a slow album is slow in the database or
-            // slow to reach the screen. Anything over a frame is worth a line.
-            let began = std::time::Instant::now();
-            let out = self.tracks_blocking(album_id, artist_id, sort, limit, offset);
-            let took = began.elapsed();
-            if took > std::time::Duration::from_millis(16) {
-                log::info!(
-                    "tracks(album {album_id:?}) took {took:?} for {} rows",
-                    out.as_ref().map(|r| r.len()).unwrap_or(0)
-                );
-            }
-            out
-        })
-        .await
+        offload::offload(move || self.tracks_blocking(album_id, artist_id, sort, limit, offset))
+            .await
     }
 
     pub async fn track(self: Arc<Self>, track_id: i64) -> Result<Option<Track>, KoanError> {
@@ -2296,12 +2283,6 @@ impl KoanEngine {
                 let mut last_signature: Option<(PlaybackState, Option<String>, u64)> = None;
                 let mut last_downloads: Vec<DownloadProgress> = Vec::new();
                 let mut last_store = u64::MAX;
-                // Temporary: answers "is the watcher actually emitting?" from
-                // the log rather than from reasoning about it.
-                let mut emitted_progress: u64 = 0;
-                let mut emitted_store: u64 = 0;
-                let mut emitted_position: u64 = 0;
-                let mut ticks: u64 = 0;
                 // Starts where the engine starts, so a launch is not announced
                 // as a change to a library nobody has read yet.
                 let mut last_library = 0u64;
@@ -2371,7 +2352,6 @@ impl KoanEngine {
                             engine.bump_library();
                         }
                         last_downloads = downloads.clone();
-                        emitted_progress += 1;
                         publish(PlayerEvent::DownloadsChanged { downloads });
                     }
 
@@ -2382,26 +2362,9 @@ impl KoanEngine {
                     let store_version = koan_core::remote::downloads::store().version();
                     if store_version != last_store {
                         last_store = store_version;
-                        emitted_store += 1;
                         publish(PlayerEvent::DownloadStoreChanged {
                             version: store_version,
                         });
-                    }
-
-                    // Once every five seconds, and only while something is
-                    // happening. Fifty ticks is the ceiling for each count.
-                    ticks += 1;
-                    if ticks.is_multiple_of(50)
-                        && (emitted_progress > 0 || emitted_position > 0 || emitted_store > 0)
-                    {
-                        log::info!(
-                            "watcher/5s: position {emitted_position}, downloads {emitted_progress}, \
-                             store {emitted_store}, in flight {}",
-                            koan_core::remote::downloads::store().active()
-                        );
-                        emitted_progress = 0;
-                        emitted_store = 0;
-                        emitted_position = 0;
                     }
 
                     let library = engine
@@ -2418,7 +2381,6 @@ impl KoanEngine {
                         let position = engine.state.position_ms();
                         if position != last_position {
                             last_position = position;
-                            emitted_position += 1;
                             publish(PlayerEvent::PositionChanged {
                                 position_ms: position,
                             });

--- a/crates/koan-ffi/src/lib.rs
+++ b/crates/koan-ffi/src/lib.rs
@@ -186,7 +186,6 @@ pub struct KoanEngine {
     /// The analyser's latest frame. Only the three-band summary crosses the
     /// boundary — see `viz_levels`.
     viz: Arc<VizSnapshot>,
-    db_path: PathBuf,
     events: tokio::sync::broadcast::Sender<PlayerEvent>,
     /// Set while the automatic sync is running, so a UI can say so rather than
     /// appearing to do nothing for the minute it takes.
@@ -564,8 +563,21 @@ impl KoanEngine {
         limit: u32,
         offset: u32,
     ) -> Result<Vec<Track>, KoanError> {
-        offload::offload(move || self.tracks_blocking(album_id, artist_id, sort, limit, offset))
-            .await
+        offload::offload(move || {
+            // Temporary: says whether a slow album is slow in the database or
+            // slow to reach the screen. Anything over a frame is worth a line.
+            let began = std::time::Instant::now();
+            let out = self.tracks_blocking(album_id, artist_id, sort, limit, offset);
+            let took = began.elapsed();
+            if took > std::time::Duration::from_millis(16) {
+                log::info!(
+                    "tracks(album {album_id:?}) took {took:?} for {} rows",
+                    out.as_ref().map(|r| r.len()).unwrap_or(0)
+                );
+            }
+            out
+        })
+        .await
     }
 
     pub async fn track(self: Arc<Self>, track_id: i64) -> Result<Option<Track>, KoanError> {
@@ -1644,7 +1656,7 @@ impl KoanEngine {
                 remote_signed_in: koan_core::helpers::get_remote_password(&cfg).is_some(),
                 remote_tracks: db
                     .as_ref()
-                    .map(koan_core::helpers::tracks_from_server)
+                    .map(|db| koan_core::helpers::tracks_from_server(db))
                     .unwrap_or(0),
                 download_workers: cfg.remote.download_workers as u32,
                 cache_limit: cfg.remote.cache_limit.clone().unwrap_or_default(),
@@ -2559,7 +2571,6 @@ impl KoanEngine {
             state,
             tx,
             viz,
-            db_path,
             events,
             auto_syncing,
             auto_scanning,
@@ -2593,8 +2604,14 @@ impl KoanEngine {
         }
     }
 
-    fn db(&self) -> Result<Database, KoanError> {
-        Database::open(&self.db_path).map_err(db_err)
+    /// A connection for one piece of work, borrowed from the pool.
+    ///
+    /// This used to open one: a connection, a permissions syscall, the whole
+    /// schema DDL and a WAL checkpoint, every time, before a row came back.
+    /// Clicking an album paid all of it, and while downloads were writing the
+    /// checkpoint contended with them and it took seconds.
+    fn db(&self) -> Result<koan_core::db::pool::Handle<'static>, KoanError> {
+        koan_core::db::pool::shared().get().map_err(db_err)
     }
 
     fn send(&self, cmd: PlayerCommand) -> Result<(), KoanError> {

--- a/crates/koan-ffi/src/types.rs
+++ b/crates/koan-ffi/src/types.rs
@@ -257,6 +257,56 @@ pub struct QueueItem {
     pub failure_reason: Option<String>,
 }
 
+/// One transfer, as the download store has it.
+#[derive(uniffi::Record, Debug, Clone, PartialEq)]
+pub struct DownloadEntry {
+    pub queue_item_id: String,
+    pub track_id: i64,
+    pub title: String,
+    pub artist: String,
+    /// 0.0–1.0, or `None` when the server sent no Content-Length — a bar drawn
+    /// at zero for a transfer that is going fine reads as stuck.
+    pub progress: Option<f64>,
+    pub bytes_written: u64,
+    pub total_bytes: u64,
+    pub state: DownloadEntryState,
+    /// Why it stopped, when it failed.
+    pub failure_reason: Option<String>,
+}
+
+#[derive(uniffi::Enum, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DownloadEntryState {
+    Queued,
+    Running,
+    Done,
+    Failed,
+}
+
+impl From<&koan_core::remote::downloads::Download> for DownloadEntry {
+    fn from(d: &koan_core::remote::downloads::Download) -> Self {
+        use koan_core::remote::downloads::DownloadState;
+        Self {
+            queue_item_id: d.id.0.to_string(),
+            track_id: d.track_id,
+            title: d.title.clone(),
+            artist: d.artist.clone(),
+            progress: d.fraction(),
+            bytes_written: d.bytes_written(),
+            total_bytes: d.total,
+            state: match &d.state {
+                DownloadState::Queued => DownloadEntryState::Queued,
+                DownloadState::Running => DownloadEntryState::Running,
+                DownloadState::Done => DownloadEntryState::Done,
+                DownloadState::Failed(_) => DownloadEntryState::Failed,
+            },
+            failure_reason: match &d.state {
+                DownloadState::Failed(reason) => Some(reason.clone()),
+                _ => None,
+            },
+        }
+    }
+}
+
 /// How far one in-flight download has got.
 ///
 /// Its own record rather than a queue refetch: progress moves several times a

--- a/crates/koan-ffi/src/types.rs
+++ b/crates/koan-ffi/src/types.rs
@@ -274,6 +274,9 @@ pub struct DownloadEntry {
     pub progress: Option<f64>,
     pub bytes_written: u64,
     pub total_bytes: u64,
+    /// Smoothed. Zero for a transfer that has settled, and for one that has
+    /// stopped moving — which is the case worth seeing.
+    pub bytes_per_second: u64,
     pub state: DownloadEntryState,
     /// Why it stopped, when it failed.
     pub failure_reason: Option<String>,
@@ -298,6 +301,7 @@ impl From<&koan_core::remote::downloads::Download> for DownloadEntry {
             progress: d.fraction(),
             bytes_written: d.bytes_written(),
             total_bytes: d.total,
+            bytes_per_second: d.bytes_per_second,
             state: match &d.state {
                 DownloadState::Queued => DownloadEntryState::Queued,
                 DownloadState::Running => DownloadEntryState::Running,

--- a/crates/koan-ffi/src/types.rs
+++ b/crates/koan-ffi/src/types.rs
@@ -255,6 +255,11 @@ pub struct QueueItem {
     pub download_progress: Option<f64>,
     /// Why this item cannot play, when `status` is `Failed`.
     pub failure_reason: Option<String>,
+    /// The server knows about this track. False for a queue item with no
+    /// library row behind it, which has nowhere to have come from.
+    pub on_server: bool,
+    /// The bytes are on this machine — an indexed file or a finished download.
+    pub on_disk: bool,
 }
 
 /// One transfer, as the download store has it.
@@ -363,6 +368,11 @@ impl QueueItem {
                 LoadState::Failed(reason) => Some(reason.clone()),
                 _ => None,
             },
+            // The transport polls this and there is no connection here to ask.
+            // Nothing it draws needs them; the queue's own rows carry the real
+            // reading.
+            on_server: false,
+            on_disk: false,
         }
     }
 }
@@ -371,7 +381,16 @@ impl QueueItem {
     /// Build from a derived queue entry, taking album IDs from a map resolved
     /// for the whole queue in one query — one statement per queue read rather
     /// than one per row.
-    pub(crate) fn from_entry(e: &QueueEntry, album_ids: &HashMap<i64, i64>) -> Self {
+    pub(crate) fn from_entry(
+        e: &QueueEntry,
+        album_ids: &HashMap<i64, i64>,
+        sources: &HashMap<i64, (bool, bool)>,
+    ) -> Self {
+        let (on_server, on_disk) = e
+            .db_id
+            .and_then(|id| sources.get(&id))
+            .copied()
+            .unwrap_or((false, false));
         let download_progress = e.download_progress.and_then(|(done, total)| {
             (total > 0).then(|| (done as f64 / total as f64).clamp(0.0, 1.0))
         });
@@ -392,6 +411,8 @@ impl QueueItem {
             status: e.status.into(),
             download_progress,
             failure_reason: e.error.clone(),
+            on_server,
+            on_disk,
         }
     }
 }

--- a/crates/koan-ffi/src/types.rs
+++ b/crates/koan-ffi/src/types.rs
@@ -216,6 +216,10 @@ pub struct NowPlaying {
     pub state: PlayState,
     pub position_ms: u64,
     pub duration_ms: u64,
+    /// How far into the track a seek can land. Equal to `duration_ms` for
+    /// anything on disk; short of it while the bytes are still arriving, which
+    /// is the extent a client draws as downloaded and refuses to scrub past.
+    pub seekable_ms: u64,
     /// Queue item currently under the cursor, if any.
     pub queue_item_id: Option<String>,
     pub entry: Option<QueueItem>,

--- a/crates/koan-server/src/graphql/types.rs
+++ b/crates/koan-server/src/graphql/types.rs
@@ -359,6 +359,10 @@ pub(super) struct GqlNowPlaying {
     pub state: PlaybackStateEnum,
     pub position_ms: u64,
     pub duration_ms: Option<u64>,
+    /// How far into the track a seek can land. Equal to `durationMs` for
+    /// anything on disk, and short of it while a download is still arriving —
+    /// the extent a client draws as downloaded and refuses to scrub past.
+    pub seekable_ms: Option<u64>,
     pub track: Option<GqlNowPlayingTrack>,
     pub queue_item_id: Option<String>,
 }
@@ -401,6 +405,7 @@ impl GqlNowPlaying {
                 state: playback_state,
                 position_ms,
                 duration_ms: None,
+                seekable_ms: None,
                 track: None,
                 queue_item_id: None,
             };
@@ -412,6 +417,7 @@ impl GqlNowPlaying {
             state: playback_state,
             position_ms,
             duration_ms: Some(info.duration_ms),
+            seekable_ms: Some(state.seekable_ms()),
             track: Some(GqlNowPlayingTrack {
                 track_id: playlist_item.and_then(|i| i.db_id),
                 title: playlist_item.map(|i| i.title.clone()).unwrap_or_default(),

--- a/crates/koan-server/src/graphql/types.rs
+++ b/crates/koan-server/src/graphql/types.rs
@@ -416,7 +416,7 @@ impl GqlNowPlaying {
         Self {
             state: playback_state,
             position_ms,
-            duration_ms: Some(info.duration_ms),
+            duration_ms: Some(state.duration_ms()),
             seekable_ms: Some(state.seekable_ms()),
             track: Some(GqlNowPlayingTrack {
                 track_id: playlist_item.and_then(|i| i.db_id),
@@ -428,7 +428,7 @@ impl GqlNowPlaying {
                 bit_depth: info.bit_depth,
                 bitrate_kbps: info.bitrate_kbps,
                 channels: info.channels,
-                duration_ms: info.duration_ms,
+                duration_ms: state.duration_ms(),
                 output_sample_rate: state.output_sample_rate(),
             }),
             queue_item_id: Some(info.id.0.to_string()),

--- a/crates/koan-tui/src/app.rs
+++ b/crates/koan-tui/src/app.rs
@@ -768,15 +768,11 @@ impl App {
                 self.tx.send(PlayerCommand::PrevTrack).ok();
             }
             KeyCode::Char('.') | KeyCode::Right => {
-                let pos = self.state.position_ms();
-                let mut target = pos.saturating_add(10_000);
-                // Clamp to downloaded portion if streaming.
-                if let Some(dl_frac) = self.state.current_download_fraction()
-                    && let Some(info) = self.state.track_info()
-                {
-                    let max_ms = (dl_frac * info.duration_ms as f64) as u64;
-                    target = target.min(max_ms.saturating_sub(5_000));
-                }
+                let target = self
+                    .state
+                    .position_ms()
+                    .saturating_add(10_000)
+                    .min(self.state.seekable_ms());
                 self.tx.send(PlayerCommand::Seek(target)).ok();
             }
             KeyCode::Char(',') | KeyCode::Left => {
@@ -1837,14 +1833,14 @@ impl App {
                 {
                     let click_x = event.column;
                     let dur = info.duration_ms;
-                    let dl_frac = self.state.current_download_fraction();
+                    let seekable_ms = self.state.seek_ceiling_ms();
 
                     if let Some(pos) = TransportBar::seek_from_click(
                         self.layout.seek_bar_start,
                         self.layout.seek_bar_width,
                         click_x,
                         dur,
-                        dl_frac,
+                        seekable_ms,
                     ) {
                         self.tx.send(PlayerCommand::Seek(pos)).ok();
                     } else if click_x < self.layout.seek_bar_start {

--- a/crates/koan-tui/src/remote_bridge.rs
+++ b/crates/koan-tui/src/remote_bridge.rs
@@ -183,8 +183,8 @@ fn download_and_play(
         return;
     }
 
-    // Point the queue item at the in-progress file so the streaming pump reads
-    // bytes as they land; it flips to `dest` once the rename has happened.
+    // Point the queue item at the in-progress file so the decoder reads bytes
+    // as they land; it flips to `dest` once the rename has happened.
     state.update_paths(&[(queue_id, download::part_path(dest))]);
 
     let bytes_written = Arc::new(AtomicU64::new(0));
@@ -496,6 +496,7 @@ fn command_loop(
             // catches new variants.
             PlayerCommand::TrackReady(_)
             | PlayerCommand::TrackStreamReady(_)
+            | PlayerCommand::StreamProbed { .. }
             | PlayerCommand::TrackFailed(_)
             | PlayerCommand::BeginUndoBatch
             | PlayerCommand::EndUndoBatch

--- a/crates/koan-tui/src/remote_bridge.rs
+++ b/crates/koan-tui/src/remote_bridge.rs
@@ -193,12 +193,14 @@ fn download_and_play(
     // Once per attempt, not per chunk — see `helpers::download_track`. The
     // counter carries progress; the load state only carries the fact.
     let announced_total = AtomicU64::new(u64::MAX);
+    let in_progress = download::part_path(dest);
     let result = streamer.stream_to_file(&track_id.to_string(), dest, |downloaded, total| {
         bytes_written.store(downloaded, Ordering::Release);
         if announced_total.swap(total, Ordering::Relaxed) != total {
             state.update_load_state(
                 queue_id,
                 LoadState::Downloading {
+                    path: in_progress.clone(),
                     total,
                     bytes_written: bytes_written.clone(),
                 },

--- a/crates/koan-tui/src/transport.rs
+++ b/crates/koan-tui/src/transport.rs
@@ -79,8 +79,9 @@ pub struct TransportBar<'a> {
     position_ms: u64,
     theme: &'a Theme,
     ticker_offset: usize,
-    /// Download fraction (0.0..1.0) for streaming tracks. None = fully downloaded.
-    download_fraction: Option<f64>,
+    /// How far into the track a seek can land. `None` once the whole track is
+    /// reachable, which is every track that is not mid-download.
+    seekable_ms: Option<u64>,
     /// What the output device settled at. None until a track has started.
     output_rate: Option<u32>,
 }
@@ -100,7 +101,7 @@ impl<'a> TransportBar<'a> {
             position_ms,
             theme,
             ticker_offset: 0,
-            download_fraction: None,
+            seekable_ms: None,
             output_rate: None,
         }
     }
@@ -110,8 +111,8 @@ impl<'a> TransportBar<'a> {
         self
     }
 
-    pub fn with_download_fraction(mut self, fraction: Option<f64>) -> Self {
-        self.download_fraction = fraction;
+    pub fn with_seekable_ms(mut self, seekable_ms: Option<u64>) -> Self {
+        self.seekable_ms = seekable_ms;
         self
     }
 
@@ -133,13 +134,14 @@ impl<'a> TransportBar<'a> {
 
     /// Seek from a click using the bar metrics stored from the last render.
     /// This guarantees the click handler uses the exact same bar layout as what's on screen.
-    /// When `download_fraction` is provided, clamps the seek to the downloaded portion.
+    /// `seekable_ms` is the engine's own ceiling, so a click past the downloaded
+    /// extent lands where playback will actually be rather than being refused.
     pub fn seek_from_click(
         bar_start: u16,
         bar_width: u16,
         click_x: u16,
         duration_ms: u64,
-        download_fraction: Option<f64>,
+        seekable_ms: Option<u64>,
     ) -> Option<u64> {
         let bar_end = bar_start + bar_width;
         if click_x < bar_start || click_x >= bar_end || bar_width == 0 {
@@ -147,13 +149,7 @@ impl<'a> TransportBar<'a> {
         }
         let frac = (click_x - bar_start) as f64 / bar_width as f64;
         let pos = (frac * duration_ms as f64) as u64;
-        // Clamp to downloaded portion minus a safety margin.
-        if let Some(dl_frac) = download_fraction {
-            let max_ms = (dl_frac * duration_ms as f64) as u64;
-            Some(pos.min(max_ms.saturating_sub(5_000)))
-        } else {
-            Some(pos)
-        }
+        Some(pos.min(seekable_ms.unwrap_or(u64::MAX)))
     }
 }
 
@@ -201,8 +197,13 @@ impl Widget for TransportBar<'_> {
         }
         .min(bar_width);
 
-        // How much of the bar represents downloaded data.
-        let downloaded = if let Some(dl_frac) = self.download_fraction {
+        // How much of the bar can be seeked into.
+        let downloaded = if let Some(seekable) = self.seekable_ms {
+            let dl_frac = if duration_ms > 0 {
+                seekable as f64 / duration_ms as f64
+            } else {
+                1.0
+            };
             ((dl_frac * bar_width as f64) as usize).min(bar_width)
         } else {
             bar_width // fully downloaded

--- a/crates/koan-tui/src/ui.rs
+++ b/crates/koan-tui/src/ui.rs
@@ -129,7 +129,7 @@ pub fn render(frame: &mut Frame, app: &mut App) {
     app.layout.seek_bar_start = bs;
     app.layout.seek_bar_width = bw;
 
-    let dl_fraction = app.state.current_download_fraction();
+    let seekable_ms = app.state.seek_ceiling_ms();
     let transport = TransportBar::new(
         track_info.as_ref(),
         playing_entry.as_ref(),
@@ -138,7 +138,7 @@ pub fn render(frame: &mut Frame, app: &mut App) {
         &app.theme,
     )
     .with_ticker_offset(app.ticker_offset)
-    .with_download_fraction(dl_fraction)
+    .with_seekable_ms(seekable_ms)
     .with_output_rate(app.state.output_sample_rate());
     frame.render_widget(transport, text_area);
 

--- a/crates/koan-tui/tests/render.rs
+++ b/crates/koan-tui/tests/render.rs
@@ -258,7 +258,7 @@ fn transport_survives_every_size_and_title() {
                 render_widget(
                     TransportBar::new(Some(&info), Some(&e), state, 107_500, &theme)
                         .with_ticker_offset(7)
-                        .with_download_fraction(Some(0.4)),
+                        .with_seekable_ms(Some(86_000)),
                     w,
                     h,
                 );

--- a/docs/guide/graphql-api.md
+++ b/docs/guide/graphql-api.md
@@ -112,10 +112,17 @@ The server binds to `127.0.0.1` by default. Use `--bind 0.0.0.0` or `bind = "0.0
 
 ```graphql
 # What's playing?
+#
+# `seekableMs` is how far in a seek can land. It equals `durationMs` for
+# anything on disk and falls short of it while a track is still downloading,
+# so a client draws its seek bar against it rather than letting someone scrub
+# into audio that has not arrived.
 {
   nowPlaying {
     state
     positionMs
+    durationMs
+    seekableMs
     track { title, artist, codec, sampleRate, bitDepth }
   }
 }


### PR DESCRIPTION
Closes #356.

A nine-hour, 451 MB Opus recording streamed from Navidrome. It eventually played, badly. Chasing why turned up four bugs in the streaming path, and then — because the fixes made downloads visible — a set of much older ones in how state reaches the UI at all.

## Playing a file that is still arriving

**The track kept its name when the download landed.** Playback that starts mid-download reads a `.part` file, and the download's last act is to rename it. `TrackInfo` kept the old name, so from that moment the track named nothing and the next seek killed playback:

```
00:31:10.347  track_ready: download complete while streaming QId(01a03b42)
00:31:23.249  error: seek failed: failed to open file: No such file or directory
```

**Seeking a downloading track stays in the stream.** It used to reopen the partial file as an ordinary one, decoding whatever bytes were on disk and ending the track early.

**One seek ceiling, computed once.** `seekable_ms` on `SharedPlayerState`: the duration for anything on disk; for a download, bytes mapped to time by length where the server gave one and by measured bitrate where it did not. The engine clamps to it and it goes out over FFI and GraphQL, so the bar draws the figure it enforces. That arithmetic previously existed in three places and did nothing at all when `Content-Length` was absent.

**Probing moved off the command loop.** `OggReader` calls `probe_stream_end` during open to find the last page's granule position, so opening one mid-download waited for the tail. Measured against the real file: **22.4 seconds of a completely unresponsive player**. It runs on its own thread now and returns as a command.

**A long Opus starts immediately.** `probe_stream_end` runs only when the source reports both `is_seekable()` and a `byte_len()`, and Ogg's bisection seek needs what it sets — so a partial Ogg can open instantly *or* be seekable, never both. Opening now asks for the full description first, capped at the write head, and falls back to opening without a length:

```
open:   took 2.526666ms at 0.1% downloaded — num_frames=None
decode: 200 packets / 58367 bytes, still at 0.1% downloaded
```

2.5 ms against 22.4 s. Formats that describe themselves from the front never reach the fallback and stay seekable throughout, so nothing regresses for FLAC or MP3. A container that cannot state its duration is the signal for everything downstream: seeks are declined rather than silently restarting at zero, and the library's duration stands in so nine hours does not read `0:00`.

**Nothing is switched over at completion.** The decoder holds an open descriptor and a rename underneath one is not an event it notices. 1.6M packets decoded continuously across the transfer finishing *and* the rename, no error; the completed file is picked up by the next seek, which is the first moment it matters.

**The partial file is read, not copied.** `StreamBuffer` accumulated the download into a `Vec<u8>` while a pump thread fed it from the same file already on disk — as much memory as the track was long, held for as long as it played. `PartialFileSource` reads it directly.

## Why downloads made everything else feel broken

Making transfers visible exposed three problems that predate this work and were only ever hidden by there being nothing else to watch.

**Events were being dropped.** `next_event` opened a *new* subscription every call, and a broadcast receiver only sees what is published after it subscribes — so everything arriving between one event being handed over and the next call asking for another was lost. The buffer could not help; the receiver reading it was always brand new. Invisible while playback position was nearly all the traffic. With transfers running it is a third of it, and the elapsed time appeared to stall. The engine hands out a subscription that lives as long as the client is listening.

**The database was re-initialised on every call.** `Database::open` does a `create_dir_all`, a permissions syscall, the entire schema DDL and an attempted WAL checkpoint. Every read did all of that before returning a row; so did each track fetched. Clicking an album while downloads ran took **two seconds**, because a transfer changing state bumps the queue version, a client reads that as the queue having changed, and rebuilding it is two more of these — a dozen init cycles on the main thread, each checkpointing a WAL the transfers were writing to.

A pool, because `rusqlite::Connection` is `Send` and not `Sync`: one shared connection means a mutex and every read queues behind every other, throwing away the concurrent readers WAL exists to provide. Idle connections are capped so a burst cannot leave hundreds parked. It lives in koan-core because the downloader needs it as much as the front ends do. `mmap_size`, `cache_size` and `temp_store` are set alongside — a library this size maps whole.

**The event loop waited on the database.** Two handlers awaited a queue rebuild, and the loop draining events is sequential, so every message behind one waited too. Applying a snapshot no longer waits, and rebuilds happen off the loop, coalesced.

## Downloads have a home

`remote::downloads` is one account of what koan is fetching: queued, running, landed, failed with the reason. Fed by the downloader rather than watched from outside, because the queue only knows about transfers for tracks in it and forgets each one the moment it lands — which is when you want to see that it did.

Progress and structure are kept apart: the byte counter is an atomic the downloader writes without a lock, the version moves only when a transfer appears or settles. Rates are sampled in the store, so every front end gets the same answer rather than keeping its own last-reading map.

A Downloads section reads it — what is arriving, how fast, how much of how much, and where each row came from. A transfer that has stopped moving says `stalled` rather than sitting at a figure that looks like progress.

Where a track's bytes are is now one mark in one column, meaning the same thing in the queue as in a record: an empty cloud on the server, a ring filling as it arrives, a solid cloud once here. Right-clicking offers whichever verb applies — fetch a track that is not here, remove one that is — and `.part` files from a run that did not finish are swept at startup.

## Verifying it

`cargo test --workspace` — 761 pass, including the streaming source (write-head blocking, seeking below it, failure vs EOF, surviving a rename), every branch of `seekable_ms`, the download store, and the connection pool.

Behaviour against the actual recording was checked with a throttled replay of the real 451 MB file, written into a `.part` at 20 MB/s with a published byte counter and then renamed, exactly as the downloader does:

```
async:  probe returned true after 22.39s; caller served 1792 ticks meanwhile
seek:   asked 4065473ms, landed 4065467ms (drift 6ms)
rename: read 4096 bytes at the midpoint after the .part vanished
ride:   1626189 packets decoded, spanned downloading=true complete=true, error=None
whole:  num_frames=Some(1561141800) -> 32523787ms
seek:   8h in, 20 packets decoded after
```

The 1792 ticks are the point: that is the caller staying live across a probe that used to freeze it. That harness is not checked in — it depends on a 451 MB file in one person's cache.

The event and query instrumentation that found the dropped events is also not checked in; it reported fifty emitted per five seconds while the client saw a handful, which is what pointed at the subscription rather than at downloads.

Not verified by automated test: audio actually coming out of the speakers, and the UI. Both were exercised by hand against the real library.

## Deliberately not here

**Cancel and pause.** Cancel needs a flag threaded through `download_with_retries` → `attempt_download` → the read loop. Pause needs HTTP Range resume, which conflicts with writing the cache file linearly and renaming it once whole — the property that makes a partial download impossible to mistake for a cached track.

**Range-request seeking**, for the same reason.

**Consolidating `LoadState::Downloading` with the download store.** There are two accounts of "is this downloading", and that is the class of bug behind the path disagreement above. Worth fixing, but it touches what gets played and how, and is not worth destabilising this branch for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GBAqs5WN5TNQjjcxEgS4Af
