### PR TITLE
fix(macos): the app hears a rate change it didn't make

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@
 
 ### Fixed
 
+- **A rate something else changed now reaches the macOS app.** koan has watched the device's nominal sample rate since #323 and the watch fires -- the log has been saying so all along. What never moved was the app. The FFI announces a playback change only when its snapshot differs from the last one, and that comparison was a signature of two things: playback state and cursor. The output rate is neither, so retuning the interface under a playing track left the badge claiming the rate the device held when the track started, until the next track happened to move the cursor.
+
+  The snapshot is compared whole now, with the position held out because it has an event of its own. The same omission was swallowing a stream's duration correction, which lands after playback starts and moves nothing else -- the seek bar for a track whose length is only known once the download does.
+
 - **The wash's drift is far enough to see.** It has moved by the same amounts since it landed in #330, and those amounts were too small to register: blurred at 14 points and magnified about five times, the wash has no feature on screen narrower than eighty points, and the drift carried it about one and a half of those over twenty-three seconds. Slow movement that small does not read as movement -- it reads as a still image. The thing was running, and costing six to nine percent of a core to run, and there was nothing to see.
 
   The excursions now reach about four of those instead: 12% of the window sideways against 4%, 10% down against 6%, and the scale swinging 1.38 to 1.58 rather than 1.19 to 1.31. The periods are untouched at 13, 19 and 23 seconds, so it is exactly as unhurried as it was -- it simply arrives somewhere.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,7 +163,7 @@ Swift bindings are generated, not checked in — `just macos-ffi` builds the lib
 | `KoanApp.swift` | `@main`, `AppState`, menu commands, keyboard shortcuts |
 | `Support/ActivityModel.swift` | The one place that knows what koan is busy with. Library tasks are exclusive — they queue behind SQLite's single writer — and each is cancellable |
 | `Support/SettingsModel.swift` | Settings state over `config.toml`. Commits on edit, re-reads on focus |
-| `Support/PlayerModel.swift` | Polls `now_playing()` at 10 Hz; refetches the queue only when `playlistVersion` moves |
+| `Support/PlayerModel.swift` | Follows the engine's event stream; refetches the queue only when `playlistVersion` moves |
 | `Support/Navigator.swift` | Where the app is: one page, the linear history of pages visited, and a cursor. No `NavigationStack` — koan navigates like a browser, any page from any page |
 | `Support/LibraryModel.swift` | Browse state. Holds what the section on screen is showing and nothing else — narrowing and sorting happen in SQL, listings arrive whole. Follows the navigator; never moves it |
 | `Support/CoverArtCache.swift` | Album-keyed art cache: bytes once per record on disk, bitmaps per record and draw size in a bounded `NSCache`. Each miss is an HTTP round trip on remote libraries |

--- a/crates/koan-ffi/src/lib.rs
+++ b/crates/koan-ffi/src/lib.rs
@@ -2155,7 +2155,7 @@ impl KoanEngine {
             .spawn(move || {
                 let mut last_version = u64::MAX;
                 let mut last_position = u64::MAX;
-                let mut last_signature: Option<(PlaybackState, Option<String>)> = None;
+                let mut last_playback: Option<NowPlaying> = None;
                 let mut last_downloads: Vec<DownloadProgress> = Vec::new();
                 // Starts where the engine starts, so a launch is not announced
                 // as a change to a library nobody has read yet.
@@ -2173,13 +2173,24 @@ impl KoanEngine {
                         let _ = engine.events.send(event);
                     };
 
+                    // Compared whole rather than on a signature of state and
+                    // cursor: the output sample rate moves when another client
+                    // retunes the device, and a stream's duration is corrected
+                    // once the download lands, both without the cursor going
+                    // anywhere. A signature has to be remembered to be widened;
+                    // this cannot go stale.
                     let state = engine.state.playback_state();
-                    let cursor = engine.state.cursor().map(|c| c.0.to_string());
-                    let signature = (state, cursor);
-                    if last_signature.as_ref() != Some(&signature) {
-                        last_signature = Some(signature);
+                    let snapshot = engine.now_playing_blocking();
+                    // Position has an event of its own, so it is held out here —
+                    // including it would make every tick a change.
+                    let settled = NowPlaying {
+                        position_ms: 0,
+                        ..snapshot.clone()
+                    };
+                    if last_playback.as_ref() != Some(&settled) {
+                        last_playback = Some(settled);
                         publish(PlayerEvent::PlaybackChanged {
-                            now_playing: engine.now_playing_blocking(),
+                            now_playing: snapshot,
                         });
                     }
 

--- a/crates/koan-ffi/src/types.rs
+++ b/crates/koan-ffi/src/types.rs
@@ -183,7 +183,7 @@ impl Track {
 
 /// Audio format of the track on the wire right now — what the DAC is actually
 /// being fed, as opposed to what the database claims.
-#[derive(uniffi::Record, Debug, Clone)]
+#[derive(uniffi::Record, Debug, Clone, PartialEq)]
 pub struct StreamFormat {
     pub codec: String,
     pub sample_rate: u32,
@@ -211,7 +211,7 @@ impl StreamFormat {
     }
 }
 
-#[derive(uniffi::Record, Debug, Clone)]
+#[derive(uniffi::Record, Debug, Clone, PartialEq)]
 pub struct NowPlaying {
     pub state: PlayState,
     pub position_ms: u64,
@@ -225,7 +225,7 @@ pub struct NowPlaying {
     pub radio_enabled: bool,
 }
 
-#[derive(uniffi::Record, Debug, Clone)]
+#[derive(uniffi::Record, Debug, Clone, PartialEq)]
 pub struct QueueItem {
     pub queue_item_id: String,
     pub track_id: Option<i64>,


### PR DESCRIPTION
Switching the interface's sample rate under a playing track changed nothing in the macOS app. The badge went on claiming whatever the device held when the track started.

The watch was never the problem. koan has subscribed to the device's nominal rate since #323 and the listener fires — `koan.log` has entries for it going back days:

```
[2026-08-26 12:08:00.951] info: device sample rate changed externally: 44100Hz on 'Scarlett 4i4 USB'
```

`SharedPlayerState::set_output_sample_rate` runs, and the TUI — which reads that state every frame — has always shown it. The macOS app doesn't poll; it follows `KoanEngine::events()`, and the watcher thread published `PlaybackChanged` only when a signature of named fields differed from the last tick: playback state, cursor, and — as of #359 — the seekable extent. The output rate is none of them, so nothing was sent until the next track moved the cursor.

## The change

`spawn_watcher` compares the whole `NowPlaying` snapshot, with `position_ms` held out because it has an event of its own. `NowPlaying`, `QueueItem` and `StreamFormat` gain `PartialEq` for it.

A signature has to be remembered to be widened, and this is the third field it forgot — #359 added `seekable_ms` to it for the same reason, one bug earlier. Comparing whole subsumes that (`seekable_ms` is on the snapshot) and picks up the remaining one: a stream's duration correction (`track_ready: duration corrected 0ms → 7370856ms`), which lands after playback starts and moves nothing else.

Cost is one extra `now_playing_blocking()` and one clone per 100ms tick, which is what the model did by polling before the event stream landed. It drops #359's rounding of `seekable_ms` to the second — that was a guard against per-tick events during a download, and `entry.download_progress` is on the snapshot too, so those ticks were already happening. They're absorbed by the guards in `PlayerModel.updateDerived` and `NowPlayingCentre.refresh`, alongside the `DownloadsChanged` event that fires at the same rate.

## Confirming it

Play something, change the device rate in Audio MIDI Setup, and the transport badge picks up the arrow — `OPUS 48 → 44.1` — within 100ms, with the tooltip saying which way the resampling goes. `koan.log` shows the `changed externally` line at the same moment. Confirmed on hardware.

`cargo test --workspace` (959 passing), clippy clean, `just macos-build` links.

## Not done here

The FFI watcher is still a 100ms poll over atomics — the CoreAudio listener's push is flattened into an atomic and rediscovered by the timer. Waking it on a change instead (a generation counter on `SharedPlayerState`, which already has the pattern for `playlist_version`, plus a condvar the watcher waits on with a 100ms timeout so position still ticks) is worth doing, and is separate from this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VfTWR7Ge4yx26jtj7BuLAr