### PR TITLE
fix(macos): a playlist's tile asks for albums, not tracks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 
 ### Fixed
 
+- **A playlist's tile asked for its covers by track, so the placeholder never got caught.** Artwork is stored and cached per record, and the mosaic named a track off each album instead of the album. Every piece was a second fetch of a sleeve the grid already had, under a key of its own, held twice in memory and twice on disk -- and it sat outside the check that recognises Navidrome's stock blue vinyl, which only ever learns from album lookups. A playlist of records with no artwork drew four vinyls where the library drew four ensōs. It asks for albums now.
+
 - **The wash's drift is far enough to see.** It has moved by the same amounts since it landed in #330, and those amounts were too small to register: blurred at 14 points and magnified about five times, the wash has no feature on screen narrower than eighty points, and the drift carried it about one and a half of those over twenty-three seconds. Slow movement that small does not read as movement -- it reads as a still image. The thing was running, and costing six to nine percent of a core to run, and there was nothing to see.
 
   The excursions now reach about four of those instead: 12% of the window sideways against 4%, 10% down against 6%, and the scale swinging 1.38 to 1.58 rather than 1.19 to 1.31. The periods are untouched at 13, 19 and 23 seconds, so it is exactly as unhurried as it was -- it simply arrives somewhere.

--- a/apps/macos/Sources/Koan/Support/PlaylistsModel.swift
+++ b/apps/macos/Sources/Koan/Support/PlaylistsModel.swift
@@ -119,8 +119,8 @@ final class PlaylistsModel {
     }
 
     private func loadCovers(for id: Int64) async {
-        let ids = (try? await engine.playlistCoverTrackIds(playlistId: id)) ?? []
-        covers[id] = ids.map { .track($0) }
+        let ids = (try? await engine.playlistCoverAlbumIds(playlistId: id)) ?? []
+        covers[id] = ids.map { .album($0) }
     }
 
     // MARK: - Mutations

--- a/crates/koan-core/src/db/queries/playlists.rs
+++ b/crates/koan-core/src/db/queries/playlists.rs
@@ -403,12 +403,15 @@ pub fn set_playlist_tracks(conn: &Connection, id: i64, track_ids: &[i64]) -> Res
 
 /// Up to four covers for the playlist's tile, one per album.
 ///
-/// A track id rather than an album id, because that is what the cover art
-/// endpoint takes for either. Distinct albums, in playlist order: four copies
-/// of the same sleeve is not a mosaic.
-pub fn playlist_cover_track_ids(conn: &Connection, id: i64) -> Result<Vec<i64>, DbError> {
+/// Album ids, because art is stored and cached per record: naming a track here
+/// asks for the same sleeve under a second key, which is a second round trip on
+/// a remote library and a second copy on disk — and it hides the record from
+/// whatever the caller knows about albums whose art is really the server's
+/// placeholder. Distinct albums, in playlist order: four copies of the same
+/// sleeve is not a mosaic.
+pub fn playlist_cover_album_ids(conn: &Connection, id: i64) -> Result<Vec<i64>, DbError> {
     let mut stmt = conn.prepare(
-        "SELECT MIN(pt.position), MIN(pt.track_id)
+        "SELECT MIN(pt.position), t.album_id
          FROM playlist_tracks pt
          JOIN tracks t ON t.id = pt.track_id
          WHERE pt.playlist_id = ?1 AND t.album_id IS NOT NULL
@@ -646,7 +649,18 @@ mod tests {
         let id = create_playlist(&conn, "Mix", None).unwrap();
         add_tracks(&conn, id, &[a1, a2, b1]).unwrap();
 
-        assert_eq!(playlist_cover_track_ids(&conn, id).unwrap(), vec![a1, b1]);
+        let album_of = |track_id: i64| {
+            conn.query_row(
+                "SELECT album_id FROM tracks WHERE id = ?1",
+                params![track_id],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap()
+        };
+        assert_eq!(
+            playlist_cover_album_ids(&conn, id).unwrap(),
+            vec![album_of(a1), album_of(b1)]
+        );
     }
 
     #[test]

--- a/crates/koan-ffi/src/lib.rs
+++ b/crates/koan-ffi/src/lib.rs
@@ -1133,15 +1133,15 @@ impl KoanEngine {
         .await
     }
 
-    /// Up to four tracks whose covers make the playlist's tile — one per album,
-    /// in playlist order.
-    pub async fn playlist_cover_track_ids(
+    /// Up to four albums whose covers make the playlist's tile, in playlist
+    /// order.
+    pub async fn playlist_cover_album_ids(
         self: Arc<Self>,
         playlist_id: i64,
     ) -> Result<Vec<i64>, KoanError> {
         offload::offload(move || {
             let db = self.db()?;
-            queries::playlist_cover_track_ids(&db.conn, playlist_id).map_err(db_err)
+            queries::playlist_cover_album_ids(&db.conn, playlist_id).map_err(db_err)
         })
         .await
     }


### PR DESCRIPTION
The playlist mosaic asked for its four covers by track id — one track off each distinct album. Artwork is stored and cached per *record*, so that was wrong twice:

- **Duplicate work.** `track-N` and `album-M` are different cache keys for the same bytes. Each piece of a playlist tile was a fresh round trip on a remote library, a second file in `~/Library/Caches`, and a second decoded bitmap held in memory — for a sleeve the album grid already had.
- **The placeholder check never fired.** `CoverArtCache.accept` recognises Navidrome's stock blue vinyl by the same bytes turning up under three unrelated *albums*, and deliberately never learns from track lookups. A playlist of artless records therefore drew four blue vinyls where the library page drew four ensōs.

`playlist_cover_track_ids` was already grouping by `album_id` and only picking a track to name the group; it now returns the `album_id` and is named for it. The Swift side builds `.album` sources.

## Verifying

- `covers_are_one_per_album_in_playlist_order` asserts album ids in playlist order (`cargo test -p koan-core --lib playlists`).
- In the app: a playlist holding records with no artwork shows ensōs in its sidebar tile rather than the server's vinyl, once the library has taught the cache that hash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EGwErknQWLeMWNvYepjx3F