### PR TITLE
refactor(downloads): derive load state rather than storing it twice

### DIFF
--- a/apps/macos/Sources/Koan/Views/DownloadsView.swift
+++ b/apps/macos/Sources/Koan/Views/DownloadsView.swift
@@ -90,12 +90,13 @@ private struct DownloadRow: View {
             // rendered the same full-width track whatever it was given, which
             // made six transfers at six different percentages look identical.
             //
-            // A named colour rather than `.tint`, which a `Canvas` resolves
-            // against its own environment and not the view's — hierarchical
-            // styles come through, that one comes out invisible.
+            // Hierarchical styles, which a `Canvas` resolves against its own
+            // environment — `.tint` does not come through it and drew nothing.
+            // What has arrived reads as present rather than as coloured: this
+            // is a quantity, not a state, and the accent said neither.
             Canvas { context, size in
                 context.fill(Self.bar(in: size, fraction: 1), with: .style(.quaternary))
-                context.fill(Self.bar(in: size, fraction: fraction), with: .color(.koanAccent))
+                context.fill(Self.bar(in: size, fraction: fraction), with: .style(.primary))
             }
             .frame(height: 4)
             .opacity(isRunning ? 1 : 0.35)

--- a/crates/koan-cli/src/commands/mod.rs
+++ b/crates/koan-cli/src/commands/mod.rs
@@ -32,7 +32,7 @@ use std::path::{Path, PathBuf};
 
 use koan_core::db::connection::Database;
 use koan_core::db::queries;
-use koan_core::player::state::{LoadState, PlaylistItem, QueueItemId};
+use koan_core::player::state::{ItemState, PlaylistItem, QueueItemId};
 use owo_colors::OwoColorize;
 
 pub(crate) fn open_db() -> Database {
@@ -277,7 +277,7 @@ fn playlist_item_from_track_row(track: &queries::TrackRow, path: &Path) -> Playl
         track_number: track.track_number.map(|n| n as i64),
         disc: track.disc.map(|n| n as i64),
         duration_ms: track.duration_ms.map(|d| d as u64),
-        load_state: LoadState::Ready,
+        state: ItemState::Ready,
     }
 }
 
@@ -303,7 +303,7 @@ fn read_metadata_to_item(p: &Path) -> PlaylistItem {
             track_number: meta.track_number.map(|n| n as i64),
             disc: meta.disc.map(|n| n as i64),
             duration_ms: meta.duration_ms.map(|d| d as u64),
-            load_state: LoadState::Ready,
+            state: ItemState::Ready,
         },
         Err(_) => {
             let title = p
@@ -325,7 +325,7 @@ fn read_metadata_to_item(p: &Path) -> PlaylistItem {
                 track_number: None,
                 disc: None,
                 duration_ms: None,
-                load_state: LoadState::Ready,
+                state: ItemState::Ready,
             }
         }
     }

--- a/crates/koan-cli/src/commands/play.rs
+++ b/crates/koan-cli/src/commands/play.rs
@@ -6,7 +6,7 @@ use koan_core::config;
 use koan_core::db::queries;
 use koan_core::player::Player;
 use koan_core::player::commands::PlayerCommand;
-use koan_core::player::state::LoadState;
+use koan_core::player::state::ItemState;
 use owo_colors::OwoColorize;
 
 use koan_tui::app::PickerAction;
@@ -163,7 +163,7 @@ pub fn cmd_play(
         if !items.is_empty() {
             let pending: Vec<(i64, koan_core::player::state::QueueItemId)> = items
                 .iter()
-                .filter(|i| matches!(i.load_state, LoadState::Pending))
+                .filter(|i| matches!(i.state, ItemState::Pending))
                 .filter_map(|i| i.db_id.map(|db_id| (db_id, i.id)))
                 .collect();
 

--- a/crates/koan-core/examples/end_of_queue.rs
+++ b/crates/koan-core/examples/end_of_queue.rs
@@ -7,7 +7,7 @@ fn main() {
 
     use koan_core::player::Player;
     use koan_core::player::commands::PlayerCommand;
-    use koan_core::player::state::{LoadState, PlaybackState, PlaylistItem, QueueItemId};
+    use koan_core::player::state::{ItemState, PlaybackState, PlaylistItem, QueueItemId};
 
     let path = std::path::PathBuf::from(
         std::env::args()
@@ -31,7 +31,7 @@ fn main() {
         track_number: Some(1),
         disc: Some(1),
         duration_ms: None,
-        load_state: LoadState::Ready,
+        state: ItemState::Ready,
     };
     let id = item.id;
     tx.send(PlayerCommand::AddToPlaylist(vec![item])).unwrap();

--- a/crates/koan-core/src/db/queries/playback_state.rs
+++ b/crates/koan-core/src/db/queries/playback_state.rs
@@ -156,17 +156,17 @@ impl PersistedQueueItem {
 
     /// Convert back to a PlaylistItem with fresh ID.
     /// Verifies the file path still exists on disk — missing cache files
-    /// get `LoadState::Pending` so the player re-triggers their download.
+    /// get `ItemState::Pending` so the player re-triggers their download.
     pub fn to_playlist_item(&self) -> crate::player::state::PlaylistItem {
         let path = PathBuf::from(&self.path);
-        let load_state = if path.exists() {
-            crate::player::state::LoadState::Ready
+        let state = if path.exists() {
+            crate::player::state::ItemState::Ready
         } else {
             log::debug!(
                 "session restore: path missing, marking pending: {}",
                 self.path,
             );
-            crate::player::state::LoadState::Pending
+            crate::player::state::ItemState::Pending
         };
         crate::player::state::PlaylistItem {
             id: crate::player::state::QueueItemId::new(),
@@ -184,7 +184,7 @@ impl PersistedQueueItem {
             track_number: self.track_number,
             disc: self.disc,
             duration_ms: self.duration_ms,
-            load_state,
+            state,
         }
     }
 }
@@ -339,11 +339,11 @@ mod tests {
         let playlist_item = item.to_playlist_item();
         assert!(
             matches!(
-                playlist_item.load_state,
-                crate::player::state::LoadState::Pending
+                playlist_item.state,
+                crate::player::state::ItemState::Pending
             ),
             "missing file should be Pending, got {:?}",
-            playlist_item.load_state,
+            playlist_item.state,
         );
         assert_eq!(playlist_item.db_id, Some(42), "db_id should be preserved");
     }
@@ -368,12 +368,9 @@ mod tests {
         };
         let playlist_item = item.to_playlist_item();
         assert!(
-            matches!(
-                playlist_item.load_state,
-                crate::player::state::LoadState::Ready
-            ),
+            matches!(playlist_item.state, crate::player::state::ItemState::Ready),
             "existing file should be Ready, got {:?}",
-            playlist_item.load_state,
+            playlist_item.state,
         );
     }
 
@@ -578,7 +575,7 @@ mod tests {
         assert_eq!(playlist_items.len(), 3);
         for pi in &playlist_items {
             assert!(
-                matches!(pi.load_state, crate::player::state::LoadState::Pending),
+                matches!(pi.state, crate::player::state::ItemState::Pending),
                 "non-existent paths should be Pending"
             );
         }

--- a/crates/koan-core/src/helpers.rs
+++ b/crates/koan-core/src/helpers.rs
@@ -11,7 +11,7 @@ use crate::config::Config;
 use crate::db::connection::Database;
 use crate::db::queries;
 use crate::player::commands::PlayerCommand;
-use crate::player::state::{LoadState, PlaylistItem, QueueItemId, SharedPlayerState};
+use crate::player::state::{ItemState, PlaylistItem, QueueItemId, SharedPlayerState};
 use crate::remote::client::{SubsonicAuth, SubsonicClient};
 
 // ---------------------------------------------------------------------------
@@ -966,40 +966,41 @@ pub fn cache_path_for_track(
 // ---------------------------------------------------------------------------
 
 /// Resolve a track to its path + load state (without downloading).
-/// Returns (path, LoadState::Ready) for local/cached, (cache_path, LoadState::Pending) for remote.
+/// Returns (path, `ItemState::Ready`) for local/cached, (cache path, `ItemState::Pending`)
+/// for remote — a track with no copy here yet has to be fetched before it plays.
 pub fn resolve_item_path(
     db: &Database,
     cfg: &Config,
     id: i64,
     track: &queries::TrackRow,
     album_date: Option<&str>,
-) -> (PathBuf, LoadState) {
+) -> (PathBuf, ItemState) {
     match queries::resolve_playback_path(&db.conn, id) {
-        Ok(Some(queries::PlaybackSource::Local(p))) => (p, LoadState::Ready),
+        Ok(Some(queries::PlaybackSource::Local(p))) => (p, ItemState::Ready),
         // A cache entry is only as good as its contents. Older builds could
         // store a Subsonic error body here, which reports Ready and then fails
         // to decode forever; treating it as Pending sends it back through the
         // download path, which discards it and re-fetches.
         Ok(Some(queries::PlaybackSource::Cached(p))) => {
             let state = if is_cached_audio(&p) {
-                LoadState::Ready
+                ItemState::Ready
             } else {
-                LoadState::Pending
+                ItemState::Pending
             };
             (p, state)
         }
         Ok(Some(queries::PlaybackSource::Remote(_))) => {
             let dest = cache_path_for_track(&cfg.cache_dir(), track, album_date);
             if dest.exists() && is_cached_audio(&dest) {
-                (dest, LoadState::Ready)
+                (dest, ItemState::Ready)
             } else {
-                (dest, LoadState::Pending)
+                (dest, ItemState::Pending)
             }
         }
         _ => {
             // Fallback: construct a cache path and mark pending.
             let dest = cache_path_for_track(&cfg.cache_dir(), track, album_date);
-            (dest, LoadState::Pending)
+            (dest, ItemState::Pending)
         }
     }
 }
@@ -1009,7 +1010,7 @@ pub fn playlist_item_from_track(
     track: &queries::TrackRow,
     album_date: Option<&str>,
     dest: PathBuf,
-    load_state: LoadState,
+    state: ItemState,
 ) -> PlaylistItem {
     let year = album_date.and_then(|d| {
         if d.len() >= 4 {
@@ -1032,7 +1033,7 @@ pub fn playlist_item_from_track(
         track_number: track.track_number.map(|n| n as i64),
         disc: track.disc.map(|n| n as i64),
         duration_ms: track.duration_ms.map(|d| d as u64),
-        load_state,
+        state,
     }
 }
 
@@ -1058,9 +1059,8 @@ pub fn playlist_items_for_tracks(db: &Database, tracks: &[queries::TrackRow]) ->
                     .clone(),
                 None => None,
             };
-            let (path, load_state) =
-                resolve_item_path(db, &cfg, track.id, track, album_date.as_deref());
-            playlist_item_from_track(track, album_date.as_deref(), path, load_state)
+            let (path, state) = resolve_item_path(db, &cfg, track.id, track, album_date.as_deref());
+            playlist_item_from_track(track, album_date.as_deref(), path, state)
         })
         .collect()
 }
@@ -1072,7 +1072,7 @@ pub fn track_to_playlist_item(track: &queries::TrackRow, db: &Database) -> Playl
         .and_then(|aid| queries::album_date(&db.conn, aid).ok().flatten());
 
     let cfg = Config::load().unwrap_or_default();
-    let (path, load_state) = resolve_item_path(db, &cfg, track.id, track, album_date.as_deref());
+    let (path, state) = resolve_item_path(db, &cfg, track.id, track, album_date.as_deref());
 
     let year = album_date.as_deref().and_then(|d| {
         if d.len() >= 4 {
@@ -1096,7 +1096,7 @@ pub fn track_to_playlist_item(track: &queries::TrackRow, db: &Database) -> Playl
         track_number: track.track_number.map(|n| n as i64),
         disc: track.disc.map(|n| n as i64),
         duration_ms: track.duration_ms.map(|d| d as u64),
-        load_state,
+        state,
     }
 }
 
@@ -1168,7 +1168,7 @@ pub fn download_track(
                 let p = std::path::PathBuf::from(path);
                 if p.exists() {
                     state.update_paths(&[(queue_id, p)]);
-                    state.update_load_state(queue_id, LoadState::Ready);
+                    state.update_item_state(queue_id, ItemState::Ready);
                     if state.is_cursor(queue_id) {
                         tx.send(PlayerCommand::TrackReady(queue_id)).ok();
                     }
@@ -1191,7 +1191,7 @@ pub fn download_track(
         if p.exists() {
             log::info!("download_track: local file exists, using {}", p.display());
             state.update_paths(&[(queue_id, p)]);
-            state.update_load_state(queue_id, LoadState::Ready);
+            state.update_item_state(queue_id, ItemState::Ready);
             if state.is_cursor(queue_id) {
                 tx.send(PlayerCommand::TrackReady(queue_id)).ok();
             }
@@ -1219,7 +1219,7 @@ pub fn download_track(
     }
     if dest.exists() {
         state.update_paths(&[(queue_id, dest)]);
-        state.update_load_state(queue_id, LoadState::Ready);
+        state.update_item_state(queue_id, ItemState::Ready);
         if state.is_cursor(queue_id) {
             tx.send(PlayerCommand::TrackReady(queue_id)).ok();
         }
@@ -1248,33 +1248,19 @@ pub fn download_track(
         bytes_per_second: 0,
     });
 
-    let progress_state = state.clone();
     let progress_qid = queue_id;
     let bytes_written_progress = bytes_written.clone();
     let progress_tx = tx.clone();
     let stream_ready_sent = Arc::new(std::sync::atomic::AtomicBool::new(false));
     let stream_ready_flag = stream_ready_sent.clone();
-    // Announced once, not per chunk. The load state says *that* a download is
-    // running and hands out the counter; the counter itself is where progress
-    // lives. Rewriting the state every 64KB took the playlist write lock and
-    // bumped the queue version a thousand times a transfer, and every front end
-    // reads that version as "the queue changed" and rebuilds it.
-    //
     // A retry restarts the byte count from zero, so a changed total re-announces.
     let announced_total = AtomicU64::new(u64::MAX);
-    let in_progress = crate::remote::download::part_path(&dest);
     let result = client.download_with_progress(&remote_id, &dest, move |downloaded, total| {
         bytes_written_progress.store(downloaded, Ordering::Release);
         if announced_total.swap(total, Ordering::Relaxed) != total {
+            // The store, and only the store. The item's state says whether its
+            // file can be played, which a transfer in flight has not changed.
             store.started(progress_qid, total, bytes_written_progress.clone());
-            progress_state.update_load_state(
-                progress_qid,
-                LoadState::Downloading {
-                    path: in_progress.clone(),
-                    total,
-                    bytes_written: bytes_written_progress.clone(),
-                },
-            );
         }
         if !stream_ready_flag.load(Ordering::Relaxed)
             && downloaded >= crate::player::state::STREAM_THRESHOLD
@@ -1296,7 +1282,7 @@ pub fn download_track(
 
     // Download succeeded.
     state.update_paths(&[(queue_id, dest.clone())]);
-    state.update_load_state(queue_id, LoadState::Ready);
+    state.update_item_state(queue_id, ItemState::Ready);
     // Without this row the file is invisible to cache eviction and never reclaimed.
     if let Err(e) = queries::set_cached_path(&db.conn, db_id, &dest.to_string_lossy()) {
         log::warn!(
@@ -1318,7 +1304,7 @@ pub fn download_track(
 
 /// Mark a queue item unplayable and tell the player, if it is waiting on it.
 ///
-/// Setting `LoadState::Failed` alone is not enough: the player only wakes for
+/// Setting `ItemState::Failed` alone is not enough: the player only wakes for
 /// `TrackReady`, so a cursor parked on the item would wait for a download that
 /// has already given up.
 pub(crate) fn fail_track(
@@ -1327,7 +1313,7 @@ pub(crate) fn fail_track(
     queue_id: QueueItemId,
     reason: String,
 ) {
-    state.update_load_state(queue_id, LoadState::Failed(reason));
+    state.update_item_state(queue_id, ItemState::Failed(reason));
     if state.is_cursor(queue_id) {
         tx.send(PlayerCommand::TrackFailed(queue_id)).ok();
     }
@@ -1362,7 +1348,7 @@ pub fn remote_unavailable(cfg: &Config) -> String {
     "the remote server could not be reached".into()
 }
 
-/// Spawn background downloads for remote tracks with LoadState::Pending.
+/// Spawn background downloads for remote tracks with ItemState::Pending.
 /// Submit tracks for download.
 ///
 /// Everything that is not the TUI reaches downloads through here — the FFI, the

--- a/crates/koan-core/src/player/mod.rs
+++ b/crates/koan-core/src/player/mod.rs
@@ -19,7 +19,9 @@ use crate::audio::{
 use buffer::PlaybackTimeline;
 use commands::{CommandChannel, PlayerCommand};
 use history::{InFlight, PlayEvent, PlayRecorder};
-use state::{LoadState, PlaybackSource, PlaybackState, QueueItemId, SharedPlayerState, TrackInfo};
+use state::{
+    ItemState, LoadState, PlaybackSource, PlaybackState, QueueItemId, SharedPlayerState, TrackInfo,
+};
 use undo::{UndoEntry, UndoStack};
 
 /// Ring buffer size in samples. ~1s at 192kHz stereo.
@@ -975,7 +977,7 @@ impl Player {
     /// If already streaming this item, trigger progressive metadata enhancement.
     pub fn track_ready(&mut self, id: QueueItemId) {
         // Mark as Ready (download thread already did this, but be safe).
-        self.shared_state.update_load_state(id, LoadState::Ready);
+        self.shared_state.update_item_state(id, ItemState::Ready);
 
         if !self.shared_state.is_cursor(id) {
             return;
@@ -1566,7 +1568,7 @@ mod tests {
             track_number: None,
             disc: None,
             duration_ms: None,
-            load_state: LoadState::Ready,
+            state: ItemState::Ready,
         }
     }
 
@@ -1583,7 +1585,7 @@ mod tests {
     fn pending_item(title: &str) -> PlaylistItem {
         PlaylistItem {
             playlist_entry_id: None,
-            load_state: LoadState::Pending,
+            state: ItemState::Pending,
             ..make_item(title)
         }
     }
@@ -1789,7 +1791,7 @@ mod tests {
         // TrackReady actually reaches the player and the queue resumes.
         player
             .shared_state
-            .update_load_state(waiting_id, LoadState::Ready);
+            .update_item_state(waiting_id, ItemState::Ready);
         player.process_command(PlayerCommand::TrackReady(waiting_id));
 
         assert_eq!(player.playback_starts, 1);
@@ -1810,7 +1812,7 @@ mod tests {
         // The download gives up. Ready will never come.
         player
             .shared_state
-            .update_load_state(waiting_id, LoadState::Failed("remote unavailable".into()));
+            .update_item_state(waiting_id, ItemState::Failed("remote unavailable".into()));
         player.process_command(PlayerCommand::TrackFailed(waiting_id));
 
         assert_eq!(
@@ -1833,7 +1835,7 @@ mod tests {
         for id in [first_id, second_id] {
             player
                 .shared_state
-                .update_load_state(id, LoadState::Failed("remote unavailable".into()));
+                .update_item_state(id, ItemState::Failed("remote unavailable".into()));
             player.process_command(PlayerCommand::TrackFailed(id));
         }
 
@@ -1856,7 +1858,7 @@ mod tests {
 
         player
             .shared_state
-            .update_load_state(other_id, LoadState::Failed("remote unavailable".into()));
+            .update_item_state(other_id, ItemState::Failed("remote unavailable".into()));
         player.process_command(PlayerCommand::TrackFailed(other_id));
 
         assert_eq!(

--- a/crates/koan-core/src/player/state.rs
+++ b/crates/koan-core/src/player/state.rs
@@ -72,29 +72,82 @@ pub const STREAM_THRESHOLD: u64 = 256 * 1024; // 256 KB
 /// couple of seconds of reach and landing past it costs a stall.
 pub const SEEK_SAFETY_MS: u64 = 2_000;
 
-/// Load state of a playlist item — tracks download lifecycle.
+/// What a playlist item can say about itself.
+///
+/// Only what is true of the item regardless of any transfer: whether the bytes
+/// at its path can be played. Whether one is *arriving* is the download store's
+/// business, and asking the item would mean two accounts of one fact that have
+/// to be kept in step — which they were not. Read [`LoadState`] for the two
+/// together.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum ItemState {
+    /// Nothing has resolved this yet.
+    #[default]
+    Pending,
+    /// The file at `path` is there and playable.
+    Ready,
+    /// It cannot be made playable, and this is why. Not only download
+    /// failures: a track with no local file and no remote copy fails here
+    /// without a transfer ever being attempted.
+    Failed(String),
+}
+
+/// An item's state, and any transfer against it, as one answer.
+///
+/// Derived rather than stored. `Downloading` carries the store's own figures —
+/// the very same counter the downloader writes — so there is nothing to copy
+/// and nothing that can drift.
 #[derive(Debug, Clone)]
 pub enum LoadState {
     Pending,
     Downloading {
         /// Where the bytes are going: the in-progress `.part` file, not the
         /// destination it is renamed to at the end.
-        ///
-        /// Carried here rather than read off the item, whose path is written by
-        /// the download thread and read by the player, and which the two can
-        /// disagree about — a track whose copy was cleared mid-flight kept a
-        /// path pointing at the file that had just been deleted. A load state
-        /// that says a download is running should say where it is running to.
         path: PathBuf,
         /// Total bytes expected, or 0 when the server sent no Content-Length.
         total: u64,
         /// How many bytes have landed. The download thread writes it per chunk
-        /// without taking the playlist lock — which is the point: progress
-        /// moves far too often to be worth a queue mutation each time.
+        /// without taking any lock the player holds.
         bytes_written: Arc<AtomicU64>,
     },
     Ready,
     Failed(String),
+}
+
+impl LoadState {
+    /// An item's state, with whatever the download store says about it.
+    ///
+    /// The store wins while a transfer is live, because it is the thing being
+    /// told. Once one has settled the item's own state stands: a finished
+    /// transfer leaves a file, and a file is what playback cares about.
+    pub fn of(item: &PlaylistItem) -> Self {
+        use crate::remote::downloads::{DownloadState, store};
+
+        if let Some(transfer) = store().get(item.id) {
+            match transfer.state {
+                DownloadState::Queued | DownloadState::Running => {
+                    return Self::Downloading {
+                        path: transfer.source,
+                        total: transfer.total,
+                        bytes_written: transfer.written,
+                    };
+                }
+                // A transfer that failed explains an item that cannot play,
+                // but only while the item has not since been resolved some
+                // other way — a retry, or a copy found on disk.
+                DownloadState::Failed(reason) if item.state == ItemState::Pending => {
+                    return Self::Failed(reason);
+                }
+                DownloadState::Failed(_) | DownloadState::Done => {}
+            }
+        }
+
+        match &item.state {
+            ItemState::Pending => Self::Pending,
+            ItemState::Ready => Self::Ready,
+            ItemState::Failed(reason) => Self::Failed(reason.clone()),
+        }
+    }
 }
 
 /// Resolved playback source for a playlist item.
@@ -133,7 +186,9 @@ pub struct PlaylistItem {
     pub track_number: Option<i64>,
     pub disc: Option<i64>,
     pub duration_ms: Option<u64>,
-    pub load_state: LoadState,
+    /// What the item can say about itself. Ask [`SharedPlayerState::load_state`]
+    /// for this together with any transfer against it.
+    pub state: ItemState,
 }
 
 /// The playlist — one flat array, one cursor. Everything else derived.
@@ -292,7 +347,7 @@ impl SharedPlayerState {
             total,
             bytes_written,
             ..
-        } = &item.load_state
+        } = LoadState::of(item)
         else {
             return info.duration_ms;
         };
@@ -306,8 +361,8 @@ impl SharedPlayerState {
         }
 
         let written = bytes_written.load(Ordering::Acquire);
-        let reached = if *total > 0 && info.duration_ms > 0 {
-            ((written as f64 / *total as f64) * info.duration_ms as f64) as u64
+        let reached = if total > 0 && info.duration_ms > 0 {
+            ((written as f64 / total as f64) * info.duration_ms as f64) as u64
         } else if let Some(kbps) = info.bitrate_kbps.filter(|k| *k > 0) {
             // No Content-Length. Bytes still say how much audio has arrived,
             // given what the probe measured the bitrate to be: 1 kbps is
@@ -368,18 +423,14 @@ impl SharedPlayerState {
         pl.items
             .iter()
             .find(|item| item.id == id)
-            .and_then(|item| match &item.load_state {
+            .and_then(|item| match LoadState::of(item) {
                 LoadState::Downloading {
                     bytes_written,
                     total,
                     ..
                 } => {
                     let written = bytes_written.load(Ordering::Acquire);
-                    if *total > 0 {
-                        Some((written as f64 / *total as f64).min(1.0))
-                    } else {
-                        None
-                    }
+                    (total > 0).then(|| (written as f64 / total as f64).min(1.0))
                 }
                 _ => None,
             })
@@ -607,7 +658,7 @@ impl SharedPlayerState {
             .items
             .get(start..)?
             .iter()
-            .find(|item| !matches!(item.load_state, LoadState::Failed(_)))
+            .find(|item| !matches!(item.state, ItemState::Failed(_)))
             .map(|item| item.id)?;
 
         pl.cursor = Some(next);
@@ -626,7 +677,7 @@ impl SharedPlayerState {
         let start = pl.items.iter().position(|item| item.id == after_id)? + 1;
 
         for i in start..pl.items.len() {
-            if matches!(pl.items[i].load_state, LoadState::Ready) {
+            if matches!(pl.items[i].state, ItemState::Ready) {
                 let item = &pl.items[i];
                 return Some((item.id, item.path.clone()));
             }
@@ -661,10 +712,10 @@ impl SharedPlayerState {
     // --- Called from resolve thread ---
 
     /// Update the load state of a playlist item. Safe — just a field update under lock.
-    pub fn update_load_state(&self, id: QueueItemId, new_state: LoadState) {
+    pub fn update_item_state(&self, id: QueueItemId, new_state: ItemState) {
         let mut pl = self.playlist.write();
         if let Some(item) = pl.items.iter_mut().find(|item| item.id == id) {
-            item.load_state = new_state;
+            item.state = new_state;
         }
         drop(pl);
         self.bump_version();
@@ -703,7 +754,7 @@ impl SharedPlayerState {
         pl.items
             .iter()
             .find(|item| item.id == id)
-            .and_then(|item| match &item.load_state {
+            .and_then(|item| match LoadState::of(item) {
                 LoadState::Ready => Some(PlaybackSource::Ready(item.path.clone())),
                 LoadState::Downloading {
                     path,
@@ -711,15 +762,11 @@ impl SharedPlayerState {
                     bytes_written,
                 } => {
                     let written = bytes_written.load(Ordering::Acquire);
-                    if written >= STREAM_THRESHOLD {
-                        Some(PlaybackSource::Streaming {
-                            path: path.clone(),
-                            bytes_written: bytes_written.clone(),
-                            total: *total,
-                        })
-                    } else {
-                        None
-                    }
+                    (written >= STREAM_THRESHOLD).then_some(PlaybackSource::Streaming {
+                        path,
+                        bytes_written,
+                        total,
+                    })
                 }
                 _ => None,
             })
@@ -739,13 +786,13 @@ impl SharedPlayerState {
         let mut reset = Vec::new();
         for item in pl.items.iter_mut() {
             let Some(db_id) = item.db_id else { continue };
-            if !matches!(item.load_state, LoadState::Ready) {
+            if !matches!(item.state, ItemState::Ready) {
                 continue;
             }
             if item.path.exists() {
                 continue;
             }
-            item.load_state = LoadState::Pending;
+            item.state = ItemState::Pending;
             reset.push((db_id, item.id));
         }
         drop(pl);
@@ -759,7 +806,7 @@ impl SharedPlayerState {
     pub fn item_path_if_ready(&self, id: QueueItemId) -> Option<PathBuf> {
         let pl = self.playlist.read();
         pl.items.iter().find(|item| item.id == id).and_then(|item| {
-            if matches!(item.load_state, LoadState::Ready) {
+            if matches!(item.state, ItemState::Ready) {
                 Some(item.path.clone())
             } else {
                 None
@@ -797,7 +844,7 @@ impl SharedPlayerState {
         let pl = self.playlist.read();
         pl.items
             .iter()
-            .filter(|item| matches!(item.load_state, LoadState::Pending))
+            .filter(|item| matches!(item.state, ItemState::Pending))
             .filter_map(|item| item.db_id.map(|db_id| (db_id, item.id)))
             .collect()
     }
@@ -808,17 +855,11 @@ impl SharedPlayerState {
     /// writes the byte counter directly — so anything following the version
     /// alone shows a frozen bar. This is how a watcher sees it move.
     pub fn downloads_in_flight(&self) -> Vec<(QueueItemId, u64, u64)> {
-        let pl = self.playlist.read();
-        pl.items
+        crate::remote::downloads::store()
+            .all()
             .iter()
-            .filter_map(|item| match &item.load_state {
-                LoadState::Downloading {
-                    total,
-                    bytes_written,
-                    ..
-                } => Some((item.id, bytes_written.load(Ordering::Relaxed), *total)),
-                _ => None,
-            })
+            .filter(|d| !d.state.is_settled())
+            .map(|d| (d.id, d.bytes_written(), d.total))
             .collect()
     }
 
@@ -837,7 +878,7 @@ impl SharedPlayerState {
         pl.items
             .iter()
             .find(|item| item.id == id)
-            .map(|item| item.load_state.clone())
+            .map(LoadState::of)
     }
 
     // --- Snapshot helpers for undo ---
@@ -1029,7 +1070,11 @@ impl SharedPlayerState {
             // state's own copy: the download thread writes it per chunk
             // without taking the playlist lock, which is what keeps a
             // transfer from bumping the playlist version a thousand times.
-            let dl_progress = match &item.load_state {
+            // Once per row, because it is the item's state and any transfer
+            // against it as one answer, and every branch below wants both.
+            let load_state = LoadState::of(item);
+
+            let dl_progress = match &load_state {
                 LoadState::Downloading {
                     total,
                     bytes_written,
@@ -1040,7 +1085,7 @@ impl SharedPlayerState {
 
             let status = if is_cursor {
                 has_playing = true;
-                match &item.load_state {
+                match &load_state {
                     LoadState::Ready => QueueEntryStatus::Playing,
                     LoadState::Downloading { .. } => QueueEntryStatus::PriorityPending,
                     LoadState::Pending => QueueEntryStatus::PriorityPending,
@@ -1048,7 +1093,7 @@ impl SharedPlayerState {
                 }
             } else if is_before_cursor {
                 finished_count += 1;
-                match &item.load_state {
+                match &load_state {
                     LoadState::Ready => QueueEntryStatus::Played,
                     LoadState::Downloading { .. } => QueueEntryStatus::Downloading,
                     LoadState::Pending => QueueEntryStatus::Downloading,
@@ -1056,7 +1101,7 @@ impl SharedPlayerState {
                 }
             } else {
                 queue_count += 1;
-                match &item.load_state {
+                match &load_state {
                     LoadState::Ready => QueueEntryStatus::Queued,
                     LoadState::Downloading { .. } => QueueEntryStatus::Downloading,
                     LoadState::Pending => QueueEntryStatus::Downloading,
@@ -1089,7 +1134,7 @@ impl SharedPlayerState {
                 duration_ms,
                 status,
                 download_progress: dl_progress,
-                error: match &item.load_state {
+                error: match &load_state {
                     LoadState::Failed(reason) => Some(reason.clone()),
                     _ => None,
                 },
@@ -1111,7 +1156,7 @@ mod tests {
 
     // --- helpers ---
 
-    fn make_item(title: &str, load_state: LoadState) -> PlaylistItem {
+    fn make_item(title: &str, state: ItemState) -> PlaylistItem {
         PlaylistItem {
             playlist_entry_id: None,
             id: QueueItemId::new(),
@@ -1126,20 +1171,41 @@ mod tests {
             track_number: None,
             disc: None,
             duration_ms: Some(200_000),
-            load_state,
+            state,
         }
     }
 
+    /// An item with a transfer running against it, told to the store the way
+    /// the downloader tells it.
+    fn downloading_item(title: &str, total: u64, written: Arc<AtomicU64>) -> PlaylistItem {
+        let item = make_item(title, ItemState::Pending);
+        let store = crate::remote::downloads::store();
+        store.queued(crate::remote::downloads::Download {
+            id: item.id,
+            track_id: 1,
+            title: title.into(),
+            artist: String::new(),
+            source: PathBuf::from(format!("/cache/{title}.flac.part")),
+            dest: PathBuf::from(format!("/cache/{title}.flac")),
+            total,
+            written: written.clone(),
+            state: crate::remote::downloads::DownloadState::Queued,
+            bytes_per_second: 0,
+        });
+        store.started(item.id, total, written);
+        item
+    }
+
     fn ready_item(title: &str) -> PlaylistItem {
-        make_item(title, LoadState::Ready)
+        make_item(title, ItemState::Ready)
     }
 
     fn pending_item(title: &str) -> PlaylistItem {
-        make_item(title, LoadState::Pending)
+        make_item(title, ItemState::Pending)
     }
 
     fn failed_item(title: &str) -> PlaylistItem {
-        make_item(title, LoadState::Failed("nope".into()))
+        make_item(title, ItemState::Failed("nope".into()))
     }
 
     const DURATION_MS: u64 = 32_523_787;
@@ -1163,16 +1229,26 @@ mod tests {
         container_duration_ms: u64,
     ) -> Arc<SharedPlayerState> {
         let written = Arc::new(AtomicU64::new(downloaded));
-        let item = make_item(
-            "train",
-            LoadState::Downloading {
-                path: PathBuf::from("/cache/train.opus.part"),
-                total,
-                bytes_written: written,
-            },
-        );
+        let item = make_item("train", ItemState::Pending);
         let id = item.id;
         let path = item.path.clone();
+
+        // The transfer goes where transfers go. Ids are unique per item, so
+        // tests sharing the process store never see each other's.
+        let store = crate::remote::downloads::store();
+        store.queued(crate::remote::downloads::Download {
+            id,
+            track_id: 1,
+            title: "train".into(),
+            artist: String::new(),
+            source: PathBuf::from("/cache/train.opus.part"),
+            dest: PathBuf::from("/cache/train.opus"),
+            total,
+            written: written.clone(),
+            state: crate::remote::downloads::DownloadState::Queued,
+            bytes_per_second: 0,
+        });
+        store.started(id, total, written);
 
         let state = SharedPlayerState::new();
         state.add_items(vec![item]);
@@ -1293,8 +1369,12 @@ mod tests {
         let state = streaming_state_with_duration(400, 400, Some(128), 0);
         assert_eq!(state.seekable_ms(), 0);
 
+        // What the downloader does when the bytes land: settle the transfer,
+        // then say the file is playable. In that order — while the store still
+        // says a transfer is running, it is.
         let id = state.cursor().expect("cursor");
-        state.update_load_state(id, LoadState::Ready);
+        crate::remote::downloads::store().finished(id);
+        state.update_item_state(id, ItemState::Ready);
         let info = state.track_info().expect("track info");
         state.set_track_info(Some(TrackInfo {
             duration_ms: DURATION_MS,
@@ -1505,22 +1585,8 @@ mod tests {
         let state = SharedPlayerState::new();
         let bytes_cursor = Arc::new(AtomicU64::new(0));
         let bytes_queued = Arc::new(AtomicU64::new(0));
-        let dl_cursor = make_item(
-            "downloading-at-cursor",
-            LoadState::Downloading {
-                path: PathBuf::from("/cache/cursor.flac.part"),
-                total: 1_000_000,
-                bytes_written: bytes_cursor.clone(),
-            },
-        );
-        let dl_queued = make_item(
-            "downloading-queued",
-            LoadState::Downloading {
-                path: PathBuf::from("/cache/queued.flac.part"),
-                total: 500_000,
-                bytes_written: bytes_queued.clone(),
-            },
-        );
+        let dl_cursor = downloading_item("downloading-at-cursor", 1_000_000, bytes_cursor.clone());
+        let dl_queued = downloading_item("downloading-queued", 500_000, bytes_queued.clone());
         let id_cursor = dl_cursor.id;
 
         state.add_items(vec![dl_cursor, dl_queued]);
@@ -1539,14 +1605,7 @@ mod tests {
         // state it was given is the one it still holds.
         let state = SharedPlayerState::new();
         let bytes = Arc::new(AtomicU64::new(0));
-        let item = make_item(
-            "downloading",
-            LoadState::Downloading {
-                path: PathBuf::from("/cache/one.flac.part"),
-                total: 1_000,
-                bytes_written: bytes.clone(),
-            },
-        );
+        let item = downloading_item("downloading", 1_000, bytes.clone());
         state.add_items(vec![item]);
 
         let version = state.playlist_version();
@@ -1559,9 +1618,15 @@ mod tests {
             version,
             "progress must not read as a queue mutation"
         );
-        assert_eq!(
-            state.downloads_in_flight(),
-            vec![(snap.entries[0].id, 250, 1_000)]
+        // Every transfer the process knows about, not just this playlist's —
+        // a fetch with no queue item behind it is still a transfer, and the
+        // store is what is asked. Other tests share it, so this looks for its
+        // own rather than asserting the whole list.
+        assert!(
+            state
+                .downloads_in_flight()
+                .contains(&(snap.entries[0].id, 250, 1_000)),
+            "the counter should be visible through the store"
         );
     }
 
@@ -1598,7 +1663,7 @@ mod tests {
             track_number: None,
             disc: None,
             duration_ms: Some(200_000),
-            load_state: LoadState::Ready,
+            state: ItemState::Ready,
         }
     }
 
@@ -1759,7 +1824,7 @@ mod tests {
             Some(LoadState::Pending)
         ));
 
-        state.update_load_state(id, LoadState::Ready);
+        state.update_item_state(id, ItemState::Ready);
         assert!(matches!(state.item_load_state(id), Some(LoadState::Ready)));
     }
 }

--- a/crates/koan-core/src/playlists.rs
+++ b/crates/koan-core/src/playlists.rs
@@ -441,7 +441,7 @@ mod tests {
     /// this one answer.
     #[test]
     fn a_queue_is_locked_only_while_it_is_still_the_playlist() {
-        use crate::player::state::{LoadState, PlaylistItem, QueueItemId, SharedPlayerState};
+        use crate::player::state::{ItemState, PlaylistItem, QueueItemId, SharedPlayerState};
 
         let dir = tempfile::tempdir().unwrap();
         let db = Database::open(&dir.path().join("koan.db")).unwrap();
@@ -466,7 +466,7 @@ mod tests {
             track_number: None,
             disc: None,
             duration_ms: None,
-            load_state: LoadState::Ready,
+            state: ItemState::Ready,
         };
 
         assert_eq!(
@@ -492,7 +492,7 @@ mod tests {
     /// deriving it: there is no flag anyone has to remember to clear.
     #[test]
     fn rearranging_the_queue_ends_the_lock() {
-        use crate::player::state::{LoadState, PlaylistItem, QueueItemId, SharedPlayerState};
+        use crate::player::state::{ItemState, PlaylistItem, QueueItemId, SharedPlayerState};
 
         let dir = tempfile::tempdir().unwrap();
         let db = Database::open(&dir.path().join("koan.db")).unwrap();
@@ -518,7 +518,7 @@ mod tests {
                 track_number: None,
                 disc: None,
                 duration_ms: None,
-                load_state: LoadState::Ready,
+                state: ItemState::Ready,
             })
             .collect();
         let ids: Vec<QueueItemId> = items.iter().map(|i| i.id).collect();
@@ -542,7 +542,7 @@ mod tests {
     /// is why it survives a relaunch, where nothing remembers what was played.
     #[test]
     fn a_queue_holding_exactly_one_record_is_locked_to_it() {
-        use crate::player::state::{LoadState, PlaylistItem, QueueItemId, SharedPlayerState};
+        use crate::player::state::{ItemState, PlaylistItem, QueueItemId, SharedPlayerState};
 
         let dir = tempfile::tempdir().unwrap();
         let db = Database::open(&dir.path().join("koan.db")).unwrap();
@@ -569,7 +569,7 @@ mod tests {
             track_number: None,
             disc: None,
             duration_ms: None,
-            load_state: LoadState::Ready,
+            state: ItemState::Ready,
         };
 
         state.add_items(vec![queued(a)]);

--- a/crates/koan-core/src/radio.rs
+++ b/crates/koan-core/src/radio.rs
@@ -1012,7 +1012,7 @@ pub fn spawn_autoqueue(
     db_path: std::path::PathBuf,
 ) {
     use crate::player::commands::PlayerCommand;
-    use crate::player::state::{LoadState, QueueEntryStatus, QueueItemId};
+    use crate::player::state::{QueueEntryStatus, QueueItemId};
 
     std::thread::Builder::new()
         .name("koan-radio".into())
@@ -1143,7 +1143,7 @@ pub fn spawn_autoqueue(
                 let new_items = crate::helpers::playlist_items_for_tracks(&db, &rows);
                 let pending: Vec<(i64, QueueItemId)> = new_items
                     .iter()
-                    .filter(|i| matches!(i.load_state, LoadState::Pending))
+                    .filter(|i| matches!(i.state, crate::player::state::ItemState::Pending))
                     .filter_map(|i| i.db_id.map(|id| (id, i.id)))
                     .collect();
 

--- a/crates/koan-core/src/remote/downloads.rs
+++ b/crates/koan-core/src/remote/downloads.rs
@@ -76,6 +76,28 @@ impl Download {
     }
 }
 
+/// What a transfer is doing, in a form cheap enough to ask about per row.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Phase {
+    pub state: PhaseKind,
+    pub written: u64,
+    pub total: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PhaseKind {
+    Queued,
+    Running,
+    Done,
+    Failed,
+}
+
+impl Phase {
+    pub fn is_running(&self) -> bool {
+        matches!(self.state, PhaseKind::Queued | PhaseKind::Running)
+    }
+}
+
 /// Every transfer koan knows about.
 #[derive(Debug, Default)]
 pub struct DownloadStore {
@@ -110,6 +132,36 @@ impl DownloadStore {
     /// Everything, running first, then whatever settled most recently.
     pub fn all(&self) -> Vec<Download> {
         self.entries.read().clone()
+    }
+
+    /// The transfer for one queue item, if there is one.
+    ///
+    /// A scan, deliberately: entries are bounded by the number of download
+    /// workers plus the settled tail, because a transfer only appears here
+    /// when a worker picks it up. Indexing tens of rows would cost more to
+    /// maintain than it saves.
+    pub fn get(&self, id: QueueItemId) -> Option<Download> {
+        self.entries.read().iter().find(|d| d.id == id).cloned()
+    }
+
+    /// Whether a transfer exists for this item and what it is doing, without
+    /// cloning its paths and titles — what deriving a queue row needs, per row
+    /// per frame.
+    pub fn phase_of(&self, id: QueueItemId) -> Option<Phase> {
+        self.entries
+            .read()
+            .iter()
+            .find(|d| d.id == id)
+            .map(|d| Phase {
+                state: match &d.state {
+                    DownloadState::Queued => PhaseKind::Queued,
+                    DownloadState::Running => PhaseKind::Running,
+                    DownloadState::Done => PhaseKind::Done,
+                    DownloadState::Failed(_) => PhaseKind::Failed,
+                },
+                written: d.bytes_written(),
+                total: d.total,
+            })
     }
 
     /// How many transfers are actually moving.
@@ -434,6 +486,27 @@ mod tests {
         store.finished(id);
         store.sample_rates_at(start + Duration::from_secs(2));
         assert_eq!(store.all()[0].bytes_per_second, 0);
+    }
+
+    #[test]
+    fn a_transfer_can_be_found_by_its_queue_item() {
+        let store = DownloadStore::new();
+        let entry = download("train");
+        let (id, written) = (entry.id, entry.written.clone());
+        store.queued(entry);
+        store.started(id, 400, written.clone());
+        written.store(100, Ordering::Relaxed);
+
+        let phase = store.phase_of(id).expect("the transfer is there");
+        assert_eq!(phase.state, PhaseKind::Running);
+        assert_eq!(phase.written, 100);
+        assert_eq!(phase.total, 400);
+        assert!(phase.is_running());
+
+        assert!(
+            store.phase_of(QueueItemId::new()).is_none(),
+            "and only that one"
+        );
     }
 
     #[test]

--- a/crates/koan-ffi/src/lib.rs
+++ b/crates/koan-ffi/src/lib.rs
@@ -2629,7 +2629,7 @@ impl KoanEngine {
         let items = koan_core::helpers::playlist_items_for_tracks(db, &rows);
         let pending = items
             .iter()
-            .filter(|item| matches!(item.load_state, LoadState::Pending))
+            .filter(|item| matches!(item.state, koan_core::player::state::ItemState::Pending))
             .filter_map(|item| item.db_id.map(|id| (id, item.id)))
             .collect();
         (items, pending)
@@ -2801,7 +2801,7 @@ fn restore_items(
     for (saved_item, id) in saved.iter().zip(ids) {
         match id.and_then(|_| resolved.next()) {
             Some(item) => {
-                if matches!(item.load_state, LoadState::Pending)
+                if matches!(item.state, koan_core::player::state::ItemState::Pending)
                     && let Some(db_id) = item.db_id
                 {
                     pending.push((db_id, item.id));

--- a/crates/koan-ffi/src/types.rs
+++ b/crates/koan-ffi/src/types.rs
@@ -332,14 +332,16 @@ impl QueueItem {
     /// The transport bar polls several times a second and only ever wants the
     /// item under the cursor — deriving the whole queue for that is waste.
     pub(crate) fn from_cursor_item(item: &PlaylistItem, state: PlaybackState) -> Self {
-        let status = match (&item.load_state, state) {
+        // The item's own state and any transfer against it, as one answer.
+        let load = LoadState::of(item);
+        let status = match (&load, state) {
             (LoadState::Failed(_), _) => EntryStatus::Failed,
             (LoadState::Downloading { .. }, _) => EntryStatus::Downloading,
             (_, PlaybackState::Playing) => EntryStatus::Playing,
             (_, PlaybackState::Paused) => EntryStatus::Playing,
             (_, PlaybackState::Stopped) => EntryStatus::Queued,
         };
-        let download_progress = match &item.load_state {
+        let download_progress = match &load {
             LoadState::Downloading {
                 total,
                 bytes_written,
@@ -368,7 +370,7 @@ impl QueueItem {
             duration_ms: item.duration_ms,
             status,
             download_progress,
-            failure_reason: match &item.load_state {
+            failure_reason: match &load {
                 LoadState::Failed(reason) => Some(reason.clone()),
                 _ => None,
             },

--- a/crates/koan-server/src/graphql/mod.rs
+++ b/crates/koan-server/src/graphql/mod.rs
@@ -821,7 +821,7 @@ mod tests {
     /// playlist points at rows, not at paths.
     #[tokio::test]
     async fn saving_the_queue_keeps_only_what_the_library_knows() {
-        use koan_core::player::state::{LoadState, PlaylistItem};
+        use koan_core::player::state::{ItemState, PlaylistItem};
 
         let tmp = TempDir::new().unwrap();
         let db_path = tmp.path().join("test.db");
@@ -848,7 +848,7 @@ mod tests {
             track_number: None,
             disc: None,
             duration_ms: None,
-            load_state: LoadState::Ready,
+            state: ItemState::Ready,
         };
         state.add_items(vec![
             item("Known", "/music/known.flac", Some(known)),
@@ -885,7 +885,7 @@ mod tests {
 
     #[tokio::test]
     async fn queue_entries_have_status_and_download_progress() {
-        use koan_core::player::state::{LoadState, PlaylistItem};
+        use koan_core::player::state::{ItemState, PlaylistItem};
 
         // Build schema with a shared state we can manipulate directly.
         let tmp = TempDir::new().unwrap();
@@ -912,7 +912,7 @@ mod tests {
             track_number: Some(1),
             disc: Some(1),
             duration_ms: Some(240000),
-            load_state: LoadState::Ready,
+            state: ItemState::Ready,
         };
         state.add_items(vec![item]);
 

--- a/crates/koan-server/src/graphql/mutations.rs
+++ b/crates/koan-server/src/graphql/mutations.rs
@@ -45,10 +45,7 @@ async fn resolve_tracks(
         for tid in track_ids {
             if let Ok(Some(track)) = queries::get_track_row(&db.conn, tid) {
                 let item = track_to_playlist_item(&track, db);
-                if matches!(
-                    item.load_state,
-                    koan_core::player::state::LoadState::Pending
-                ) {
+                if matches!(item.state, koan_core::player::state::ItemState::Pending) {
                     pending_downloads.push((tid, item.id));
                 }
                 items.push(item);
@@ -513,10 +510,7 @@ impl MutationRoot {
             let mut pending_downloads: Vec<(i64, QueueItemId)> = Vec::new();
             for track in &rows {
                 let item = track_to_playlist_item(track, db);
-                if matches!(
-                    item.load_state,
-                    koan_core::player::state::LoadState::Pending
-                ) {
+                if matches!(item.state, koan_core::player::state::ItemState::Pending) {
                     pending_downloads.push((track.id, item.id));
                 }
                 items.push(item);

--- a/crates/koan-tui/src/enqueue.rs
+++ b/crates/koan-tui/src/enqueue.rs
@@ -7,7 +7,7 @@ use koan_core::config;
 use koan_core::db::queries;
 use koan_core::helpers::{playlist_item_from_track, resolve_item_path};
 use koan_core::player::commands::PlayerCommand;
-use koan_core::player::state::{LoadState, QueueItemId};
+use koan_core::player::state::{ItemState, QueueItemId};
 
 use crate::app::PickerAction;
 use koan_core::remote::queue::DownloadQueue;
@@ -47,7 +47,7 @@ pub fn enqueue_playlist(
         let (dest, load_state) = resolve_item_path(&db, &cfg, id, &track, album_date.as_deref());
 
         let item = playlist_item_from_track(&track, album_date.as_deref(), dest, load_state);
-        if matches!(item.load_state, LoadState::Pending) {
+        if matches!(item.state, ItemState::Pending) {
             pending_downloads.push((id, item.id));
         }
         items.push(item);

--- a/crates/koan-tui/src/remote_bridge.rs
+++ b/crates/koan-tui/src/remote_bridge.rs
@@ -17,10 +17,10 @@ use koan_core::graphql_client::GraphQLClient;
 use koan_core::helpers::sanitise_filename;
 use koan_core::player::commands::PlayerCommand;
 use koan_core::player::state::{
-    LoadState, PlaybackState, PlaylistItem, QueueItemId, SharedPlayerState, TrackInfo,
+    ItemState, PlaybackState, PlaylistItem, QueueItemId, SharedPlayerState, TrackInfo,
 };
 use koan_core::remote::client::SubsonicClient;
-use koan_core::remote::download;
+use koan_core::remote::{download, downloads};
 
 /// Disk budget for streamed-from-server tracks. These files belong to no local
 /// track row, so DB-driven cache eviction cannot see them — the bridge prunes
@@ -178,7 +178,7 @@ fn download_and_play(
 ) {
     // A file at `dest` is always complete — downloads land there by rename only.
     if dest.exists() {
-        state.update_load_state(queue_id, LoadState::Ready);
+        state.update_item_state(queue_id, ItemState::Ready);
         local_tx.send(PlayerCommand::TrackReady(queue_id)).ok();
         return;
     }
@@ -190,21 +190,33 @@ fn download_and_play(
     let bytes_written = Arc::new(AtomicU64::new(0));
     let stream_ready_sent = std::sync::atomic::AtomicBool::new(false);
 
-    // Once per attempt, not per chunk — see `helpers::download_track`. The
-    // counter carries progress; the load state only carries the fact.
+    // Told to the download store like any other transfer. It used not to be,
+    // so anything the remote bridge fetched was invisible to the downloads
+    // page and to everything else reading the store — two ways of fetching a
+    // track and only one of them accounted for.
+    let store = downloads::store();
+    store.queued(downloads::Download {
+        id: queue_id,
+        track_id,
+        title: dest
+            .file_stem()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_default(),
+        artist: String::new(),
+        source: download::part_path(dest),
+        dest: dest.to_path_buf(),
+        total: 0,
+        written: bytes_written.clone(),
+        state: downloads::DownloadState::Queued,
+        bytes_per_second: 0,
+    });
+
+    // Once per attempt, not per chunk — see `helpers::download_track`.
     let announced_total = AtomicU64::new(u64::MAX);
-    let in_progress = download::part_path(dest);
     let result = streamer.stream_to_file(&track_id.to_string(), dest, |downloaded, total| {
         bytes_written.store(downloaded, Ordering::Release);
         if announced_total.swap(total, Ordering::Relaxed) != total {
-            state.update_load_state(
-                queue_id,
-                LoadState::Downloading {
-                    path: in_progress.clone(),
-                    total,
-                    bytes_written: bytes_written.clone(),
-                },
-            );
+            store.started(queue_id, total, bytes_written.clone());
         }
         if !stream_ready_sent.load(Ordering::Relaxed)
             && downloaded >= koan_core::player::state::STREAM_THRESHOLD
@@ -218,12 +230,14 @@ fn download_and_play(
 
     if let Err(e) = result {
         log::warn!("failed to stream {} from server: {}", dest.display(), e);
-        state.update_load_state(queue_id, LoadState::Failed(e.to_string()));
+        store.failed(queue_id, e.to_string());
+        state.update_item_state(queue_id, ItemState::Failed(e.to_string()));
         return;
     }
 
+    store.finished(queue_id);
     state.update_paths(&[(queue_id, dest.to_path_buf())]);
-    state.update_load_state(queue_id, LoadState::Ready);
+    state.update_item_state(queue_id, ItemState::Ready);
     local_tx.send(PlayerCommand::TrackReady(queue_id)).ok();
 }
 
@@ -294,7 +308,7 @@ fn poll_and_stream_loop(
                                 track_number: None,
                                 disc: None,
                                 duration_ms: Some(track.duration_ms),
-                                load_state: LoadState::Pending,
+                                state: ItemState::Pending,
                             };
 
                             local_tx.send(PlayerCommand::ClearPlaylist).ok();
@@ -323,19 +337,19 @@ fn poll_and_stream_loop(
                                         })
                                     {
                                         log::error!("failed to spawn stream download: {}", e);
-                                        state.update_load_state(
+                                        state.update_item_state(
                                             queue_id,
-                                            LoadState::Failed(e.to_string()),
+                                            ItemState::Failed(e.to_string()),
                                         );
                                     }
                                 }
-                                (None, _) => state.update_load_state(
+                                (None, _) => state.update_item_state(
                                     queue_id,
-                                    LoadState::Failed("no [subsonic] credentials".into()),
+                                    ItemState::Failed("no [subsonic] credentials".into()),
                                 ),
-                                (_, None) => state.update_load_state(
+                                (_, None) => state.update_item_state(
                                     queue_id,
-                                    LoadState::Failed("server track has no library id".into()),
+                                    ItemState::Failed("server track has no library id".into()),
                                 ),
                             }
                         }
@@ -387,7 +401,7 @@ fn poll_and_stream_loop(
                             track_number: e.track_number,
                             disc: e.disc,
                             duration_ms: e.duration_ms,
-                            load_state: LoadState::Ready,
+                            state: ItemState::Ready,
                         }
                     })
                     .collect();


### PR DESCRIPTION
Follow-up to #359, which left two accounts of one fact.

## What was wrong

"Is this track downloading" lived in two places that had to be told separately:

- `LoadState::Downloading { path, total, bytes_written }` on the playlist item
- `Download` in `remote::downloads`, written by the downloader

They drifted, twice, and both cost real debugging in #359. A queue item's path pointed at the file a transfer had just been renamed away from, so playing it opened nothing. And the TUI's remote bridge maintained load states the store knew nothing about — so anything fetched through it was invisible to the downloads page and to everything else reading the store.

## The split

A playlist item now says only what is true of it whatever any transfer is doing:

```rust
pub enum ItemState { Pending, Ready, Failed(String) }
```

Whether bytes are *arriving* is the store's business, and `LoadState` is a function of the two:

```rust
LoadState::of(item)   // item's own state + whatever the store says
```

`Downloading` carries the store's own figures — including the very `Arc<AtomicU64>` the downloader writes — so there is nothing to copy and nothing that can fall out of step.

## Why the item keeps a state at all

The store cannot hold everything, and pretending otherwise would be a lie that surfaces later:

- A **local file** is playable and never has a transfer.
- A **cache hit** returns from `download_track` before `store.queued()` is reached.
- `Failed("not in the library folder")`, `Failed("remote unavailable")` are not transfer failures.

Seeding the store with an entry per queue item would make it "acquisition state of every row" — which is `LoadState` again, with a lookup in front. The two questions are genuinely different: *can I play this file* and *is a transfer running*. They are answered by the thing that knows, and joined at the point of use.

## What falls out

`downloads_in_flight` asks the store rather than walking the playlist, so a fetch with **no queue item behind it** — the "download to cache" action, which uses synthetic ids — is finally visible as a transfer like any other. The TUI bridge writes the store, so its downloads appear too.

The dead weight the refactor left behind is the evidence it was duplication: the downloader no longer needs a handle to the playlist to announce progress, and the `.part` path it carried for the load state has nowhere left to go. Both removed by clippy's unused warnings rather than by judgement.

## Verifying it

`cargo test --workspace` — 960 pass. Two existing tests changed, and both changes are the point:

- `progress_follows_the_counter_without_touching_the_playlist` asserted the exact contents of `downloads_in_flight`. It now looks for its own entry, because that list is every transfer in the process rather than one playlist's.
- `the_download_landing_restores_seeking` set the item `Ready` to simulate a transfer landing. It has to settle the transfer too, in that order — while the store says one is running, one is. That is the real sequence `download_track` performs.

Not verified: the queue's status column by eye. This is exactly the kind of refactor that compiles, passes, and gets a status subtly wrong, so it wants a run before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GBAqs5WN5TNQjjcxEgS4Af