### PR TITLE
perf(db): find favourites by index instead of reading the library

### DIFF
--- a/crates/koan-core/src/db/queries/tracks.rs
+++ b/crates/koan-core/src/db/queries/tracks.rs
@@ -1298,11 +1298,17 @@ pub fn track_favourite_key(conn: &Connection, track_id: i64) -> Result<Option<St
 /// included — a remote track that has never been cached is favourited by its
 /// remote URL, and comparing only local paths misses every one of them.
 pub fn favourite_track_ids_batch(conn: &Connection) -> Result<HashSet<i64>, DbError> {
+    // Three indexed lookups rather than one join with an OR across three
+    // columns. SQLite cannot use an index for that OR, so it read every track
+    // in the library and probed favourites for each — fifty milliseconds to
+    // find a hundred rows, paid by every listing that shows a star. As a union
+    // each branch searches its own index instead.
     let mut stmt = conn.prepare(
-        "SELECT DISTINCT t.id FROM tracks t
-         JOIN favourites f ON (t.path = f.track_path
-                            OR t.cached_path = f.track_path
-                            OR t.remote_url = f.track_path)",
+        "SELECT id FROM tracks WHERE path IN (SELECT track_path FROM favourites)
+         UNION
+         SELECT id FROM tracks WHERE cached_path IN (SELECT track_path FROM favourites)
+         UNION
+         SELECT id FROM tracks WHERE remote_url IN (SELECT track_path FROM favourites)",
     )?;
     let rows = stmt.query_map([], |row| row.get::<_, i64>(0))?;
     let mut ids = HashSet::new();

--- a/crates/koan-core/src/db/schema.rs
+++ b/crates/koan-core/src/db/schema.rs
@@ -76,6 +76,16 @@ pub fn create_tables(conn: &Connection) -> rusqlite::Result<()> {
         CREATE INDEX IF NOT EXISTS idx_tracks_remote_id ON tracks(remote_id);
         CREATE INDEX IF NOT EXISTS idx_albums_artist ON albums(artist_id);
         CREATE INDEX IF NOT EXISTS idx_tracks_album_order ON tracks(album_id, disc, track_number);
+        -- Favourites are keyed by path, and a track can be reached by three of
+        -- them. Without these, matching a favourite to its track means reading
+        -- every row in the library: the query planner said SCAN, and finding
+        -- a hundred favourites among fifty thousand tracks took fifty
+        -- milliseconds, on every listing that wanted to know what was starred.
+        -- Partial, because both columns are null for anything purely local.
+        CREATE INDEX IF NOT EXISTS idx_tracks_cached_path ON tracks(cached_path)
+            WHERE cached_path IS NOT NULL;
+        CREATE INDEX IF NOT EXISTS idx_tracks_remote_url ON tracks(remote_url)
+            WHERE remote_url IS NOT NULL;
 
         CREATE VIRTUAL TABLE IF NOT EXISTS tracks_fts USING fts5(
             title,


### PR DESCRIPTION
Opening an album flashed the previous album's contents for a moment. The stale render is a separate bug; this is why there was time to see it.

## What was happening

Matching favourites to tracks joined on an `OR` across three columns — a track can be reached by its path, its cached path, or its remote URL, and a favourite is keyed by whichever one it was starred as:

```sql
JOIN favourites f ON (t.path = f.track_path
                   OR t.cached_path = f.track_path
                   OR t.remote_url = f.track_path)
```

SQLite cannot use an index for an `OR` spanning different columns, so it did the only thing left:

```
QUERY PLAN
|--SCAN t
`--SEARCH f USING COVERING INDEX sqlite_autoindex_favourites_1 (track_path=?)
```

It read all 47,944 tracks and probed favourites for each, to find the 124 that were starred. `decorate()` runs this on **every** `tracks()`, `albums()` and `artists()` call, so every listing in the app paid it.

## The fix

Three indexed lookups unioned, so each branch searches its own index, and partial indexes for the two columns that had none — partial because both are null for anything purely local.

```
QUERY PLAN
`--COMPOUND QUERY
   |--LEFT-MOST SUBQUERY
   |  `--SEARCH tracks USING COVERING INDEX sqlite_autoindex_tracks_1 (path=?)
   |--UNION USING TEMP B-TREE
   |  `--SEARCH tracks USING COVERING INDEX idx_tracks_cached_path (cached_path=?)
   `--UNION USING TEMP B-TREE
      `--SEARCH tracks USING COVERING INDEX idx_tracks_remote_url (remote_url=?)
```

No scan.

## Measured

Against a real library, 47,944 tracks and 124 favourites:

| | time | plan |
|---|---|---|
| before | 90 ms | `SCAN t` |
| union, no new indexes | 19 ms | two branches still scanning |
| union + partial indexes | **1 ms** | three `SEARCH`es |

Identical results at each step — same 124 ids, verified by diffing the output.

The indexes are added to the schema, which is `CREATE INDEX IF NOT EXISTS` and applied on open, so existing libraries pick them up on next launch without a migration step.

## Not in scope

This is one query found while chasing something else, and it is unlikely to be the only one. #364 covers auditing the rest: a scan anywhere in this app is a defect, not a slow path — the library is a local file, every question asked of it is answerable from an index, and everything asking is either drawing a frame or deciding what to play next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GBAqs5WN5TNQjjcxEgS4Af
