### PR TITLE
fix(streaming): let a FLAC start before its whole file has arrived

### DIFF
--- a/crates/koan-core/src/audio/streaming.rs
+++ b/crates/koan-core/src/audio/streaming.rs
@@ -306,6 +306,15 @@ mod tests {
             self.status.store(status, Ordering::Release);
         }
 
+        fn status_fn(&self) -> Arc<dyn Fn() -> StreamStatus + Send + Sync> {
+            let status = self.status.clone();
+            Arc::new(move || match status.load(Ordering::Acquire) {
+                COMPLETE => StreamStatus::Complete,
+                FAILED => StreamStatus::Failed,
+                _ => StreamStatus::Downloading,
+            })
+        }
+
         fn source(&self, total: u64) -> PartialFileSource {
             self.source_with_stall(total, STALL_LIMIT)
         }
@@ -444,6 +453,69 @@ mod tests {
             src.read(&mut out).unwrap_err().kind(),
             io::ErrorKind::BrokenPipe
         );
+    }
+
+    #[test]
+    fn a_probe_reads_only_what_has_arrived() {
+        // The first attempt must fail at the write head rather than wait: a
+        // container that would go looking for its tail has to be detected, not
+        // waited for.
+        let fx = Fixture::new();
+        fx.push(b"0123456789");
+        let mut src = PartialFileSource::open_for_probe(
+            &fx.path,
+            fx.written.clone(),
+            1_000,
+            fx.status_fn(),
+            ProbeMode::Full,
+        )
+        .unwrap();
+
+        let mut out = [0u8; 10];
+        src.read_exact(&mut out).unwrap();
+        assert_eq!(
+            src.read(&mut out).unwrap_err().kind(),
+            io::ErrorKind::UnexpectedEof,
+            "past the write head is an answer, not a wait"
+        );
+    }
+
+    #[test]
+    fn playback_reads_wait_for_what_has_not_arrived() {
+        // And the second attempt does wait, which is what lets a container
+        // whose audio starts further in than the streaming threshold — a FLAC
+        // with a large padding block, most of them — be opened at all.
+        let fx = Fixture::new();
+        fx.push(b"0123456789");
+        let mut src = PartialFileSource::open(
+            &fx.path,
+            fx.written.clone(),
+            1_000,
+            fx.status_fn(),
+            ProbeMode::Lengthless,
+        )
+        .unwrap();
+
+        let mut out = [0u8; 10];
+        src.read_exact(&mut out).unwrap();
+
+        std::thread::spawn({
+            let path = fx.path.clone();
+            let written = fx.written.clone();
+            move || {
+                std::thread::sleep(Duration::from_millis(20));
+                let mut f = std::fs::OpenOptions::new()
+                    .append(true)
+                    .open(&path)
+                    .unwrap();
+                f.write_all(b"abcde").unwrap();
+                f.flush().unwrap();
+                written.fetch_add(5, Ordering::Release);
+            }
+        });
+
+        let n = src.read(&mut out).unwrap();
+        assert_eq!(&out[..n], b"abcde", "it waited rather than giving up");
     }
 
     #[test]

--- a/crates/koan-core/src/player/mod.rs
+++ b/crates/koan-core/src/player/mod.rs
@@ -507,16 +507,31 @@ impl Player {
         let spawned = thread::Builder::new()
             .name("koan-stream-probe".into())
             .spawn(move || {
-                let attempt = |mode| {
-                    streaming::PartialFileSource::open_for_probe(
-                        &path,
-                        bytes_written.clone(),
-                        total,
-                        status.clone(),
-                        mode,
-                    )
-                    .map_err(buffer::DecodeError::Io)
-                    .and_then(|source| {
+                // `wait` says whether a read may sit at the write head for
+                // more of the download. The first attempt must not: a
+                // container that goes looking for its tail would wait for the
+                // whole transfer, and failing at once is how that is detected.
+                // The second has no length to go looking with, so whatever it
+                // still wants is in front of it and worth waiting for.
+                let attempt = |mode, wait: bool| {
+                    let open = if wait {
+                        streaming::PartialFileSource::open(
+                            &path,
+                            bytes_written.clone(),
+                            total,
+                            status.clone(),
+                            mode,
+                        )
+                    } else {
+                        streaming::PartialFileSource::open_for_probe(
+                            &path,
+                            bytes_written.clone(),
+                            total,
+                            status.clone(),
+                            mode,
+                        )
+                    };
+                    open.map_err(buffer::DecodeError::Io).and_then(|source| {
                         let mss = symphonia::core::io::MediaSourceStream::new(
                             Box::new(source),
                             Default::default(),
@@ -528,7 +543,7 @@ impl Player {
                 // Ask for the whole description first. Neither attempt waits at
                 // the write head, so a container that needs bytes which have
                 // not arrived fails here rather than reading the transfer out.
-                let info = match attempt(streaming::ProbeMode::Full) {
+                let info = match attempt(streaming::ProbeMode::Full, false) {
                     Ok(info) => Some((info, streaming::ProbeMode::Full)),
                     Err(e) => {
                         // Try again claiming no length. Ogg goes looking for its
@@ -541,7 +556,7 @@ impl Player {
                             path.display(),
                             e
                         );
-                        attempt(streaming::ProbeMode::Lengthless)
+                        attempt(streaming::ProbeMode::Lengthless, true)
                             .ok()
                             .map(|info| (info, streaming::ProbeMode::Lengthless))
                     }


### PR DESCRIPTION
Regression from #359. FLACs downloaded and played correctly but would not start until the transfer had finished; MP3s streamed immediately.

## Why only FLAC

That difference is the whole diagnosis. An MP3 states what it is in a header at the front. A FLAC keeps a padding block after its tags — space reserved so tags can be edited later without rewriting the file — and most encoders leave a generous one:

```
block STREAMINFO:     34 bytes
block VORBIS_COMMENT: 1860 bytes
block PICTURE:        81579 bytes
block PADDING:        438011 bytes
first audio frame at byte 521504   (STREAM_THRESHOLD is 262144)
```

Streaming begins probing once 256 KB has arrived. The probe could not reach the first audio frame, so it failed — and a track announces itself ready to stream exactly once, so nothing tried again. It fell through to waiting for the whole download, every time.

## The cause

Mine, from the change in #359 that moved probing off the player's command loop. Probe reads were capped at the write head so that a container which goes hunting for its tail — Ogg, looking for the last page's granule position — would fail *at once* rather than wait for the entire transfer.

That is right for the first attempt, which is exactly how that case gets detected. It is wrong for the second, which advertises no length and therefore has nothing to go hunting with: whatever it still wants is in front of it, and arriving.

So the fallback attempt waits for bytes now. That costs nothing — it runs on its own thread, which is the reason the probe was moved there in the first place. The stall limit still applies, so a transfer that genuinely stops still surfaces as an error rather than hanging.

## Verifying

Two tests, one for each half of the contract:

- `a_probe_reads_only_what_has_arrived` — the first attempt returns `UnexpectedEof` at the write head rather than blocking, which is what keeps the Ogg detection working.
- `playback_reads_wait_for_what_has_not_arrived` — the second waits and picks up bytes that land afterwards, which is what lets a container whose audio starts beyond the threshold be opened at all.

`cargo test --workspace` — 961 pass.

Confirmed by hand against the file above: a 53 MB FLAC with a 438 KB padding block now starts on the threshold instead of on completion. MP3 and Opus are unaffected — MP3 never reaches the fallback, and Opus reaches it and succeeds immediately as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GBAqs5WN5TNQjjcxEgS4Af