### PR TITLE
fix(index): stop indexing formats koan cannot play

### DIFF
--- a/.claude/plans/04-tagging.md
+++ b/.claude/plans/04-tagging.md
@@ -18,7 +18,6 @@ lofty writes all major tag formats koan encounters:
 - **ID3v2** (MP3, AIFF, WAV) — v2.3 or v2.4 via `use_id3v23` option
 - **Vorbis Comments** (FLAC, OGG Vorbis, Opus)
 - **MP4/iTunes ilst** (M4A, AAC, ALAC)
-- **APE tags** (APE, WavPack)
 - ID3v1 (legacy, but supported)
 
 ### Write workflow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Removed
+
+- **WavPack and Monkey's Audio are no longer indexed.** koan could not play either: symphonia has no WavPack reader at all — there is no feature to turn on — and its `ape` feature is APE *tags*, not the codec. Both extensions were scanned all the same, so a library holding them showed rows that listed, searched, sorted, and then refused to play. A format koan cannot open is better left out than claimed.
+
+  Anything already indexed disappears on the next scan.
+
 ### Fixed
 
 - **Long tracks streamed from a server no longer break when the download lands.** Playback of a track that started mid-download held on to the name of the temporary file it started from. Finishing a download renames that file, so from then on the track named nothing: the next seek failed to open it and stopped playback outright. A nine-hour recording made it easy to hit, because there was a lot of track left to seek in.

--- a/crates/koan-core/src/audio/buffer.rs
+++ b/crates/koan-core/src/audio/buffer.rs
@@ -6,7 +6,7 @@ use std::thread;
 
 use symphonia::core::codecs::audio::well_known::{
     CODEC_ID_AAC, CODEC_ID_ALAC, CODEC_ID_FLAC, CODEC_ID_MP3, CODEC_ID_OPUS, CODEC_ID_PCM_F32LE,
-    CODEC_ID_PCM_S16LE, CODEC_ID_PCM_S24LE, CODEC_ID_PCM_S32LE, CODEC_ID_VORBIS, CODEC_ID_WAVPACK,
+    CODEC_ID_PCM_S16LE, CODEC_ID_PCM_S24LE, CODEC_ID_PCM_S32LE, CODEC_ID_VORBIS,
 };
 use symphonia::core::codecs::audio::{AudioCodecId, AudioCodecParameters, AudioDecoderOptions};
 use symphonia::core::formats::probe::Hint;
@@ -1039,7 +1039,6 @@ pub fn codec_name(codec: AudioCodecId) -> String {
         CODEC_ID_VORBIS => "Vorbis",
         CODEC_ID_OPUS => "Opus",
         CODEC_ID_ALAC => "ALAC",
-        CODEC_ID_WAVPACK => "WavPack",
         CODEC_ID_PCM_S16LE => "PCM/16",
         CODEC_ID_PCM_S24LE => "PCM/24",
         CODEC_ID_PCM_S32LE => "PCM/32",

--- a/crates/koan-core/src/index/metadata.rs
+++ b/crates/koan-core/src/index/metadata.rs
@@ -20,8 +20,14 @@ pub enum MetadataError {
 }
 
 /// Audio file extensions we care about.
+///
+/// Only what koan can actually decode. WavPack and Monkey's Audio are absent
+/// on purpose: symphonia has no reader for either — there is no `wavpack`
+/// feature to turn on, and its `ape` feature is APE *tags*, not the codec — so
+/// indexing them produced library rows that scanned, listed, and refused to
+/// play. Better not to claim them.
 const AUDIO_EXTENSIONS: &[&str] = &[
-    "flac", "mp3", "m4a", "aac", "ogg", "opus", "wv", "wav", "aiff", "aif", "alac", "ape",
+    "flac", "mp3", "m4a", "aac", "ogg", "opus", "wav", "aiff", "aif", "alac",
 ];
 
 /// Check if a path has a supported audio extension.
@@ -365,7 +371,6 @@ fn symphonia_codec_name(codec: symphonia::core::codecs::audio::AudioCodecId) -> 
         ids::CODEC_ID_ALAC => "ALAC".to_string(),
         ids::CODEC_ID_VORBIS => "Vorbis".to_string(),
         ids::CODEC_ID_OPUS => "Opus".to_string(),
-        ids::CODEC_ID_WAVPACK => "WavPack".to_string(),
         ids::CODEC_ID_PCM_S16LE
         | ids::CODEC_ID_PCM_S24LE
         | ids::CODEC_ID_PCM_S32LE
@@ -485,10 +490,8 @@ pub fn codec_string(ft: lofty::file::FileType) -> &'static str {
         lofty::file::FileType::Mp4 => "AAC",
         lofty::file::FileType::Opus => "Opus",
         lofty::file::FileType::Vorbis => "Vorbis",
-        lofty::file::FileType::WavPack => "WavPack",
         lofty::file::FileType::Wav => "WAV",
         lofty::file::FileType::Aiff => "AIFF",
-        lofty::file::FileType::Ape => "APE",
         _ => "Unknown",
     }
 }
@@ -643,10 +646,13 @@ mod tests {
         assert!(is_audio_file(Path::new("track.m4a")));
         assert!(is_audio_file(Path::new("track.ogg")));
         assert!(is_audio_file(Path::new("track.opus")));
-        assert!(is_audio_file(Path::new("track.wv")));
         assert!(is_audio_file(Path::new("track.wav")));
         assert!(is_audio_file(Path::new("track.aiff")));
-        assert!(is_audio_file(Path::new("track.ape")));
+
+        // Nothing koan cannot decode. Both of these were indexed and neither
+        // could be opened, so a library held rows that refused to play.
+        assert!(!is_audio_file(Path::new("track.wv")));
+        assert!(!is_audio_file(Path::new("track.ape")));
 
         assert!(!is_audio_file(Path::new("cover.jpg")));
         assert!(!is_audio_file(Path::new("notes.txt")));

--- a/crates/koan-server/src/subsonic.rs
+++ b/crates/koan-server/src/subsonic.rs
@@ -770,7 +770,6 @@ fn codec_to_mime(codec: &str) -> (&str, &str) {
         "VORBIS" | "OGG" => ("ogg", "audio/ogg"),
         "WAV" => ("wav", "audio/wav"),
         "AIFF" => ("aiff", "audio/aiff"),
-        "WAVPACK" | "WV" => ("wv", "audio/x-wavpack"),
         "APE" => ("ape", "audio/x-ape"),
         _ => ("bin", "application/octet-stream"),
     }
@@ -785,7 +784,6 @@ fn extension_to_mime(ext: &str) -> &str {
         "ogg" => "audio/ogg",
         "wav" => "audio/wav",
         "aiff" | "aif" => "audio/aiff",
-        "wv" => "audio/x-wavpack",
         "ape" => "audio/x-ape",
         _ => "application/octet-stream",
     }


### PR DESCRIPTION
Closes #366.

A `.wv` in a library folder scanned, indexed, listed, searched, sorted — and then refused to play:

```
wavpack   FAILS: decode error: unsupported feature: core (probe): no suitable format reader found
```

Not a missing feature flag. **symphonia 0.6 has no `wavpack` feature at all** — the reader does not exist. And its `ape` feature turns out to be APE *tags*, not Monkey's Audio, so `.ape` was in exactly the same position:

```toml
ape = ["symphonia-metadata/ape"]     # metadata, not a codec
```

Both extensions were in `AUDIO_EXTENSIONS` regardless, so a library containing them held rows the app would show and could not open.

## What goes

- The two extensions from the scanner.
- `CODEC_ID_WAVPACK` and lofty's `WavPack`/`Ape` codec names, which nothing could produce once the files are not indexed.
- The Subsonic `wv` mime mapping, which nothing could reach for the same reason.
- The APE-tags line from the tagging plan, which listed file types koan no longer sees.

Anything already indexed disappears on the next scan, since it no longer matches a known extension.

The user-facing docs needed no change — `README.md`, `docs/getting-started.md` and `docs/recipes/troubleshooting.md` already list the formats accurately and never claimed either of these. (I said otherwise in #366; that was wrong, and only the code and the plan doc made the claim.)

## Why remove rather than add

Claiming a format koan cannot open is worse than not claiming it: the library says the track is there, and playing it does nothing. Adding support is not an option here — there is no reader to enable, and writing one is not a music player's job.

`cargo test --workspace` — 961 pass. `test_is_audio_file` now asserts both extensions are rejected, so this cannot quietly come back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GBAqs5WN5TNQjjcxEgS4Af