### PR TITLE
fix(macos): show a download landing on the page you are looking at

### DIFF
--- a/apps/macos/Sources/Koan/KoanApp.swift
+++ b/apps/macos/Sources/Koan/KoanApp.swift
@@ -68,7 +68,14 @@ final class AppState {
         // two very different rates — see `DownloadsModel`.
         player.onDownloadStoreChanged = { [weak downloads] in downloads?.reload() }
         player.onDownloadProgress = { [weak downloads] in downloads?.applyProgress($0) }
-        player.onLibraryChanged = { [weak library] in library?.libraryChanged() }
+        // Both, because a library change is a change to whatever rows are on
+        // screen — and a playlist's are the playlists model's, not the
+        // library's. A download landing writes a cached path onto a row, and
+        // the page showing it has to hear about it or its cloud stays empty.
+        player.onLibraryChanged = { [weak library, weak playlists] in
+            library?.libraryChanged()
+            playlists?.reloadTracks()
+        }
 
         // Control Center and the media keys ride the player's existing poll.
         let centre = NowPlayingCentre(player: player, art: art)

--- a/apps/macos/Sources/Koan/Support/LibraryModel.swift
+++ b/apps/macos/Sources/Koan/Support/LibraryModel.swift
@@ -105,6 +105,14 @@ final class LibraryModel {
     private(set) var isLoading = false
 
     private(set) var detailTracks: [Track] = []
+    /// Which record `detailTracks` belongs to.
+    ///
+    /// Two jobs. A library change knows what to ask for again — a download
+    /// landing writes a cached path onto a row, and the page showing that row
+    /// has to hear about it or its cloud stays hollow until you navigate away
+    /// and back. And an answer for a record you have already left cannot land
+    /// on the one you are looking at.
+    private var detailAlbumId: Int64?
 
     /// Set while a scan runs so the UI can show progress and refuse a second
     /// one. Set by `AppState`. Long tasks register here so one place can say
@@ -257,12 +265,20 @@ final class LibraryModel {
 
     /// Tracks for the album detail pane.
     func loadTracks(albumId: Int64) {
+        // Only when it is a different record. Asked again for the one already
+        // showing — which is what a library change does — blanking the list
+        // first would flash it empty for the length of a query.
+        if detailAlbumId != albumId {
+            detailTracks = []
+        }
+        detailAlbumId = albumId
         let engine = self.engine
-        detailTracks = []
         Task {
-            detailTracks = (try? await engine.tracks(
+            let tracks = (try? await engine.tracks(
                 albumId: albumId, artistId: nil, sort: .album, limit: 500, offset: 0
             )) ?? []
+            guard detailAlbumId == albumId else { return }
+            detailTracks = tracks
         }
     }
 
@@ -420,5 +436,11 @@ final class LibraryModel {
         loadStats()
         refreshFavourites()
         reload()
+        // `reload` refreshes the section's own rows, which is not what an album
+        // page is showing. Without this a track downloaded while you watch it
+        // keeps its empty cloud until you leave the record and come back.
+        if let detailAlbumId {
+            loadTracks(albumId: detailAlbumId)
+        }
     }
 }

--- a/apps/macos/Sources/Koan/Support/PlayerModel.swift
+++ b/apps/macos/Sources/Koan/Support/PlayerModel.swift
@@ -254,8 +254,15 @@ final class PlayerModel {
             let progress = byItem[id] ?? nil
             guard queue[index].downloadProgress != progress else { continue }
             queue[index].downloadProgress = progress
+            // Both indexes. A playlist row finds its queue item by entry, not
+            // by track — two copies of one song are two rows — so patching
+            // only the track index left every playlist row holding a figure
+            // from whenever the queue was last rebuilt.
             if let trackId = queue[index].trackId {
                 queuedByTrack[trackId] = queue[index]
+            }
+            if let entryId = queue[index].playlistEntryId {
+                queuedByPlaylistEntry[entryId] = queue[index]
             }
         }
 

--- a/apps/macos/Sources/Koan/Views/QueueRow.swift
+++ b/apps/macos/Sources/Koan/Views/QueueRow.swift
@@ -150,6 +150,17 @@ struct QueueRow: View {
 
             Spacer(minLength: 8)
 
+            // Where the bytes are, in the same mark and the same order as a
+            // record's own track list: the cloud, then the heart. Its own slot
+            // rather than the status column's — a track can be playing and
+            // still arriving at once, and one slot could only ever show
+            // whichever of the two it was told to.
+            SourceBadges(
+                onServer: item.onServer,
+                onDisk: item.onDisk,
+                downloading: downloading
+            )
+
             if let trackId = item.trackId {
                 FavouriteButton(
                     isOn: library.isFavourite(track: trackId),
@@ -164,16 +175,6 @@ struct QueueRow: View {
                 // the durations stay in line down the queue.
                 Color.clear.frame(width: 16, height: 1)
             }
-
-            // Where the bytes are, in the same mark and the same column the
-            // album view uses. Its own slot rather than the status column's:
-            // a track can be playing and still arriving at once, and one slot
-            // could only ever show whichever of the two it was told to.
-            SourceBadges(
-                onServer: item.onServer,
-                onDisk: item.onDisk,
-                downloading: downloading
-            )
 
             if let codec = item.codec {
                 Text(codec.uppercased())


### PR DESCRIPTION
A track downloaded while its record was on screen kept an empty cloud until you navigated away and came back.

## Album pages

The engine does say the library changed when a transfer lands — it writes a cached path onto the row, and the watcher turns that into `LibraryChanged`. The handler then did this:

```swift
func libraryChanged() {
    loadStats()
    refreshFavourites()
    reload()          // ← the *section's* rows: the album list, the artist list
}
```

An album page is not showing those. It shows `detailTracks`, which nothing refetched. So the row on screen kept saying `onDisk: false` until something else reloaded it.

It now asks for the open record's tracks again, remembering which record that is. That identity does a second job: an answer for a record you have already navigated away from can no longer land on the one you are looking at.

## Playlist pages, twice over

Nothing told `PlaylistsModel` a library change had happened, so its rows never heard either — same empty cloud.

And the progress ring never moved at all, which is a separate and older fault. Download progress is patched into the queue in place rather than by refetching it, and that patch updated the index keyed by track:

```swift
if let trackId = queue[index].trackId {
    queuedByTrack[trackId] = queue[index]
}
```

A playlist row does not look itself up by track. Two copies of one song in a playlist are two rows, and only the playlist entry tells them apart — so it reads `queuedByPlaylistEntry`, which was only ever rebuilt wholesale and so held whatever figure was true when the queue last changed. Both indexes are patched now.

## Consistency

The cloud and the heart sat in opposite orders in the queue and on a record. A record's order wins — it is the list you meet first, and `PlaylistView` renders the same row, so both move together.

## The queue was already fine

Worth saying, since it is why this took a while to see: `QueueRow` reads a `QueueItem`, and the queue is refetched whenever the playlist version moves — which a completed download does. So the one surface that worked did so for an entirely different reason than the ones that did not.

## Known gap

Search results still will not refresh. That view owns its own rows and `libraryChanged()` does not reach it, so a cloud there stays empty until the search is run again. Left rather than fixed, because the fix belongs with whatever gives search a shared idea of what a library change means.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GBAqs5WN5TNQjjcxEgS4Af