### PR TITLE
release: v0.32.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.32.0 (2026-08-26)
 
 ### Removed
 
@@ -30,9 +30,15 @@
 
 - **The seek bar's downloaded extent moves while the download does.** The transport keeps its own copy of what is playing, refreshed when the playback state or the cursor moves — and neither moves during a download, so the mark sat wherever it had been when playback started. It follows the progress it is drawing now.
 
+- **A finished download's bar does not read as an empty one.** The downloads page lit the part that had arrived, so a transfer completing took the highlight away and the bar dropped back to looking untouched. The quiet end is the part still missing, the same way round as the seek bar.
+
 - **The bar no longer darkens when a download finishes.** It lit the downloaded part rather than dimming the part that had not arrived, so completing a transfer took the highlight away and the whole bar dropped a shade. The quiet end is the one that is missing, and a track already on disk looks like the ordinary bar it is.
 
 - **The playhead is visible on a very long track.** A third of a minute into nine hours is a tenth of a percent of the bar — narrower than the bar is thick, and so drawn as nothing at all. It has a head that does not shrink with the fraction.
+
+- **A download landing shows up on the page you are looking at.** A track fetched while its record was on screen kept an empty cloud until you navigated away and back — the page showing the row was not among the things a library change refreshed. A playlist had it twice over: nothing told it a library change had happened at all, and its progress rings never moved, because progress was patched into the queue index keyed by track and not the one keyed by playlist entry, which is the one a playlist row reads.
+
+- **The cloud and the heart sit in the same order everywhere.** The queue and a playlist had them the other way round from a record's own track list.
 
 - **Playing a track twice before it arrives fetches it once.** Downloads were deduplicated by queue entry rather than by track, and playing something again makes a new entry — so nothing matched and a second transfer started over the first. Both wrote the same file, and whichever finished renamed it out from under the other, which is where the failed downloads in the log came from. One transfer now, with every entry waiting on it told when it lands.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2483,7 +2483,7 @@ dependencies = [
 
 [[package]]
 name = "koan-cli"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2507,7 +2507,7 @@ dependencies = [
 
 [[package]]
 name = "koan-core"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "argon2",
  "bliss-audio",
@@ -2549,7 +2549,7 @@ dependencies = [
 
 [[package]]
 name = "koan-ffi"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "chrono",
  "crossbeam-channel",
@@ -2569,7 +2569,7 @@ dependencies = [
 
 [[package]]
 name = "koan-server"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",
@@ -2602,7 +2602,7 @@ dependencies = [
 
 [[package]]
 name = "koan-tui"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "core-foundation 0.10.1",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/koan-core", "crates/koan-ffi", "crates/koan-server", "crates/koan-tui", "crates/koan-cli"]
 
 [workspace.package]
-version = "0.31.2"
+version = "0.32.0"
 edition = "2024"
 rust-version = "1.89"
 homepage = "https://github.com/radiosilence/koan"
@@ -13,9 +13,9 @@ license = "MIT"
 [workspace.dependencies]
 # Internal crates. Keep the version in step with [workspace.package] above —
 # a stale pin here publishes members that resolve against the wrong sibling.
-koan-core = { path = "crates/koan-core", version = "0.31.2" }
-koan-server = { path = "crates/koan-server", version = "0.31.2" }
-koan-tui = { path = "crates/koan-tui", version = "0.31.2" }
+koan-core = { path = "crates/koan-core", version = "0.32.0" }
+koan-server = { path = "crates/koan-server", version = "0.32.0" }
+koan-tui = { path = "crates/koan-tui", version = "0.32.0" }
 # Feature set is the union every member needs; `default-tls` is an alias for
 # `rustls`, so there is exactly one TLS stack.
 reqwest = { version = "0.13", default-features = false, features = [

--- a/apps/macos/Sources/Koan/Views/DownloadsView.swift
+++ b/apps/macos/Sources/Koan/Views/DownloadsView.swift
@@ -90,16 +90,19 @@ private struct DownloadRow: View {
             // rendered the same full-width track whatever it was given, which
             // made six transfers at six different percentages look identical.
             //
+            // The quiet end is the part that has not arrived, the same way
+            // round as the seek bar. Lighting what *had* arrived meant a
+            // transfer finishing took its highlight away and the bar dropped
+            // back to looking empty — a row that had just completed read as
+            // one that had not started.
+            //
             // Hierarchical styles, which a `Canvas` resolves against its own
             // environment — `.tint` does not come through it and drew nothing.
-            // What has arrived reads as present rather than as coloured: this
-            // is a quantity, not a state, and the accent said neither.
             Canvas { context, size in
                 context.fill(Self.bar(in: size, fraction: 1), with: .style(.quaternary))
                 context.fill(Self.bar(in: size, fraction: fraction), with: .style(.primary))
             }
             .frame(height: 4)
-            .opacity(isRunning ? 1 : 0.35)
 
             HStack(spacing: 6) {
                 Text(subtitle)
@@ -137,7 +140,11 @@ private struct DownloadRow: View {
     /// What has arrived. A transfer with no stated length has no fraction, and
     /// draws an empty bar rather than a full one — it is going, not finished.
     private var fraction: Double {
+        // Whole once it has landed, whatever the last figure said — the bar
+        // never goes backwards on completion.
         if item.state == .done { return 1 }
+        // A transfer with no stated length has no fraction and draws an empty
+        // bar rather than a full one: it is going, not finished.
         return item.progress ?? 0
     }
 


### PR DESCRIPTION
Version bump, dated changelog, and one fix that was lost.

## The lost fix

An earlier version of this commit rode on the branch behind #369 and did not make it into that merge — #369 was merged from the state of the branch before the release commit was pushed to it. So `main` carried the dedupe fix but not the version bump, the dated changelog, or the downloads-page bar fix that was cherry-picked alongside them.

That bar fix is back here: the downloads page lit the part of the bar that *had* arrived, so a transfer completing took the highlight away and the bar dropped back to looking untouched. The quiet end is the part still missing, the same way round as the seek bar.

## Version

`0.31.2` → `0.32.0`. Minor rather than patch: alongside a long list of fixes there is new surface — a Downloads section, source badges wherever a track is listed, fetching a track into the cache without queueing it, and removing downloads a record at a time.

## What is in it

Started with a nine-hour Opus recording that played badly (#356). Four faults in the streaming path — a track losing its own filename when the download landed, seeking a partial file reopening it as a complete one, a seek ceiling that did nothing when the server sent no length, and container probing running on the thread that answers play and pause.

Fixing those made downloads visible enough to expose older faults in how state reaches the screen at all:

- events dropped between subscriptions, because asking for the next one opened a new subscription every time
- the library re-running its whole schema, a permissions syscall and a WAL checkpoint on **every read**
- a favourites query reading all 47,944 tracks to find the 124 that were starred, on every listing that shows a heart

None of those were visible while playback position was nearly all the traffic. Downloads changed the ratio and they all surfaced at once.

Full detail in `CHANGELOG.md`.

## Verifying

`cargo test --workspace` — 964 pass. Everything in this release was exercised by hand against a real library over the course of the day, which is how most of it was found.

**No tag is pushed** — that is yours to create after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GBAqs5WN5TNQjjcxEgS4Af