### PR TITLE
fix(tui): bring the TUI up to what the macOS app learned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,9 +40,15 @@
 
 - **Finding what is favourited no longer reads the whole library.** Matching favourites to tracks joined on three columns at once, which no index can serve, so it read every track to find the hundred that were starred — fifty milliseconds, on every listing that shows a heart, which is all of them. One millisecond now, on a library of forty-eight thousand.
 
+- **Reaching for a position in a track that has not arrived says so.** A track whose container cannot state a duration until the last of its bytes lands — Ogg — is reachable nowhere at all while it downloads, and every seek into one was sent unclamped and taken as a seek to zero, so the arrow keys threw playback back to the start. The TUI now says how far the transfer has got instead of moving.
+
+- **Clicking the TUI's seek bar lands where it was aimed on a track still downloading.** The click was mapped against the duration the container reported, which on a partial file reads short, while the bar was drawn against the one the library knows. Both use the library's now.
+
 - **Half-finished downloads are cleaned up.** koan writes a download straight through and renames it at the end, so a `.part` file still on disk is from a run that did not finish — bytes nothing knows about, since only finished downloads are tracked for eviction. An interrupted nine-hour recording was half a gigabyte that never came back. They are swept at startup, which is the run after the one that left them.
 
 ### Changed
+
+- **The TUI opens the database once rather than per query.** Every read opened its own connection: a `create_dir_all`, a permissions syscall, the whole schema DDL and a WAL checkpoint before a single row came back — and while downloads were writing, that checkpoint contended with them. The TUI's reads are user-triggered rather than per-frame so it never cost what it cost the macOS app, but autosave ran one on a timer. It shares the pool the app uses, which now applies the schema itself so a first run on a fresh machine works the same way.
 
 - **What koan is downloading is kept in one place.** Whether a track was arriving was recorded twice — once against the queue entry and once by the downloader — and the two had to be told separately, so they could and did disagree: a queue entry pointed at the file a transfer had just been renamed away from, and anything the TUI fetched was invisible to everything else. A queue entry now says only whether its own file can be played, and whether bytes are arriving is asked of the downloader.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,7 @@ Pre-push hook (`.claude/settings.json`) runs `cargo fmt --all` + `cargo clippy -
 | `player/history.rs` | Play history recording — writes an entry when a track starts, fills in listening time when it ends. Owns the `koan-history` writer thread |
 | `db/schema.rs` | DDL: artists, albums, tracks, scan_cache, remote_servers, organize_log, tracks_fts (FTS5) |
 | `db/connection.rs` | `Database::open()`, WAL mode, pragmas |
+| `db/pool.rs` | Connections opened once and kept. What every front end reads through — `Database::open` runs the schema DDL and a WAL checkpoint, which is not a thing to do per query |
 | `db/queries/` | Row types, upsert (3-strategy dedup), FTS5 search, scan cache, stats, playlists, `batch` (SQL-side track filtering, batched parent→child reads) |
 | `index/scanner.rs` | Streaming library scan: walkdir → rayon tag reads → bounded channel → batched DB transactions. `ScanOptions` carries a cancel flag and an optional progress sink. `import_paths` indexes named files where they lie (Finder drops), removing nothing |
 | `index/metadata.rs` | Tag reading via lofty (ID3, Vorbis, MP4, APE), codec detection |
@@ -120,6 +121,9 @@ Pre-push hook (`.claude/settings.json`) runs `cargo fmt --all` + `cargo clippy -
 | `remote/client.rs` | Subsonic/Navidrome HTTP client (reqwest blocking, MD5+salt auth) |
 | `remote/download.rs` | Streaming downloads: `.part` → verify → atomic rename, progress, retries. All disk-bound remote bytes go through here |
 | `remote/sync.rs` | Parallel library sync: paginate → rayon fetch → batch DB write |
+| `remote/queue.rs` | The download queue: worker pool, a priority lane for the track under the cursor, cursor-aware reordering |
+| `remote/downloads.rs` | The download store — what koan is fetching and what it just fetched. One place every front end reads, rather than each deriving its own |
+| `radio.rs` | Radio mode: similar artists, MusicBrainz relationships, genre and era, play history — a seed that drifts as it plays |
 | `config.rs` | Figment-based layered config: defaults → config.toml → config.local.toml → KOAN_* env vars |
 | `helpers.rs` | Shared by every front end: sign-in, favourite reconciliation, sharing, auto-sync and folder watching, forget-folder/forget-remote, cache and index maintenance |
 | `playlists.rs` | Playlists beyond the database: two-way Subsonic reconciliation, background pushes, M3U8 export |
@@ -142,7 +146,6 @@ Pre-push hook (`.claude/settings.json`) runs `cargo fmt --all` + `cargo clippy -
 | `lyrics.rs` | Lyrics side panel — synced line highlighting, scroll |
 | `organize.rs` | Organize modal: pattern picker → preview table → background execute |
 | `media_keys.rs` | macOS Control Center via souvlaki, manual CFRunLoop pump |
-| `download_queue.rs` | Persistent download queue with priority/cursor-aware reordering |
 | `enqueue.rs` | `enqueue_playlist()` — build PlaylistItems from track IDs, submit downloads |
 | `remote_bridge.rs` | Remote bridge: connects TUI to a remote koan server via GraphQL |
 

--- a/crates/koan-cli/src/commands/play.rs
+++ b/crates/koan-cli/src/commands/play.rs
@@ -95,7 +95,7 @@ pub fn cmd_play(
             .expect("failed to spawn API server thread");
     }
 
-    if clear_queue && let Ok(db) = koan_core::db::connection::Database::open(&config::db_path()) {
+    if clear_queue && let Ok(db) = koan_core::db::pool::shared().get() {
         let _ = queries::clear_playback_state(&db.conn);
     }
 
@@ -152,7 +152,7 @@ pub fn cmd_play(
             })
             .expect("failed to spawn resolve thread");
     } else if !clear_queue
-        && let Ok(db) = koan_core::db::connection::Database::open(&config::db_path())
+        && let Ok(db) = koan_core::db::pool::shared().get()
         && let Ok(Some(persisted)) = queries::load_playback_state(&db.conn)
     {
         let items: Vec<_> = persisted

--- a/crates/koan-cli/src/commands/play.rs
+++ b/crates/koan-cli/src/commands/play.rs
@@ -196,7 +196,6 @@ pub fn cmd_play(
         install_panic_hook: install_terminal_panic_hook,
         parse_dropped_paths: |text| parse_dropped_paths(text),
         playlist_items_from_paths: |paths, progress| playlist_items_from_paths(paths, progress),
-        open_db,
     };
 
     if let Err(e) = koan_tui::play::run_tui(
@@ -261,7 +260,6 @@ pub fn cmd_play_remote(server_url: &str, jukebox: bool) {
         install_panic_hook: install_terminal_panic_hook,
         parse_dropped_paths: |text| parse_dropped_paths(text),
         playlist_items_from_paths: |paths, progress| playlist_items_from_paths(paths, progress),
-        open_db,
     };
 
     if let Err(e) = koan_tui::play::run_tui(

--- a/crates/koan-core/src/db/pool.rs
+++ b/crates/koan-core/src/db/pool.rs
@@ -20,6 +20,7 @@
 
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use super::connection::{Database, DbError};
 
@@ -27,6 +28,10 @@ pub struct Pool {
     path: PathBuf,
     idle: parking_lot::Mutex<Vec<Database>>,
     keep: usize,
+    /// Whether the schema has been applied in this process.
+    schema: AtomicBool,
+    /// Held while applying it, so two threads arriving at once do it once.
+    applying: parking_lot::Mutex<()>,
 }
 
 /// How many idle connections to hold on to.
@@ -53,7 +58,30 @@ impl Pool {
             path,
             idle: parking_lot::Mutex::new(Vec::new()),
             keep: KEEP_IDLE,
+            schema: AtomicBool::new(false),
+            applying: parking_lot::Mutex::new(()),
         }
+    }
+
+    /// Apply the schema, once, before handing out the first connection.
+    ///
+    /// So the pool is safe as the only way anything reaches the database.
+    /// Pooled connections open with `open_existing`, which does no DDL — fine
+    /// for a running app that opened the library at startup, and wrong for a
+    /// one-shot command on a machine that has never run koan. Doing it here
+    /// rather than relying on a caller having done it first removes the
+    /// invariant instead of documenting it.
+    fn ensure_schema(&self) -> Result<(), DbError> {
+        if self.schema.load(Ordering::Acquire) {
+            return Ok(());
+        }
+        let _applying = self.applying.lock();
+        if self.schema.load(Ordering::Acquire) {
+            return Ok(());
+        }
+        Database::open(&self.path)?;
+        self.schema.store(true, Ordering::Release);
+        Ok(())
     }
 
     /// Borrow a connection, opening one only if none are free.
@@ -61,6 +89,7 @@ impl Pool {
     /// `open_existing`, so this never re-runs the DDL or checkpoints: the
     /// schema is applied once at startup, before any pool exists.
     pub fn get(&self) -> Result<Handle<'_>, DbError> {
+        self.ensure_schema()?;
         let pooled = self.idle.lock().pop();
         let db = match pooled {
             Some(db) => db,
@@ -114,12 +143,25 @@ impl Drop for Handle<'_> {
 mod tests {
     use super::*;
 
+    /// A pool over an empty directory — nothing has opened this database, which
+    /// is the state a one-shot command starts from.
     fn pool() -> (tempfile::TempDir, Pool) {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("koan.db");
-        // What startup does, once.
-        Database::open(&path).unwrap();
         (dir, Pool::new(path))
+    }
+
+    #[test]
+    fn the_first_connection_applies_the_schema() {
+        // A one-shot command on a machine that has never run koan reaches the
+        // database through here and nowhere else.
+        let (_dir, pool) = pool();
+        let db = pool.get().unwrap();
+        let tracks: i64 = db
+            .conn
+            .query_row("SELECT count(*) FROM tracks", [], |r| r.get(0))
+            .expect("the schema should be there");
+        assert_eq!(tracks, 0);
     }
 
     #[test]

--- a/crates/koan-tui/src/app.rs
+++ b/crates/koan-tui/src/app.rs
@@ -401,7 +401,7 @@ impl App {
 
     /// Load favourites from the database.
     pub fn load_favourites(&mut self) {
-        if let Ok(db) = koan_core::db::connection::Database::open(&self.db_path)
+        if let Ok(db) = koan_core::db::pool::shared().get()
             && let Ok(favs) = koan_core::db::queries::load_favourites(&db.conn)
         {
             self.favourites = favs;
@@ -415,7 +415,7 @@ impl App {
     /// on the final path so the star survives.
     pub fn toggle_favourite(&mut self, path: &std::path::Path) -> bool {
         let path = &koan_core::remote::download::strip_part_suffix(path);
-        if let Ok(db) = koan_core::db::connection::Database::open(&self.db_path)
+        if let Ok(db) = koan_core::db::pool::shared().get()
             && let Ok(is_fav) = koan_core::db::queries::toggle_favourite(&db.conn, path)
         {
             if is_fav {
@@ -617,7 +617,6 @@ impl App {
                     let title = entry.title.clone();
                     let album = entry.album.clone();
                     let duration_secs = entry.duration_ms.unwrap_or(0) / 1000;
-                    let db_path = self.db_path.clone();
                     let track_path = entry.path.clone();
 
                     let (tx, rx) = crossbeam_channel::bounded(1);
@@ -628,7 +627,7 @@ impl App {
                         .name("koan-lyrics".into())
                         .spawn(move || {
                             let result = (|| -> Option<koan_core::lyrics::Lyrics> {
-                                let db = match koan_core::db::connection::Database::open(&db_path) {
+                                let db = match koan_core::db::pool::shared().get() {
                                     Ok(db) => db,
                                     Err(e) => {
                                         if let Ok(mut logs) = log_clone.lock() {
@@ -1389,7 +1388,7 @@ impl App {
         let visible = self.visible_queue();
         let selected: Vec<_> = self.queue.selected_ids.iter().copied().collect();
 
-        let db = match koan_core::db::connection::Database::open(&self.db_path) {
+        let db = match koan_core::db::pool::shared().get() {
             Ok(db) => db,
             Err(_) => {
                 self.status_message = Some(("DB error".into(), std::time::Instant::now()));

--- a/crates/koan-tui/src/app.rs
+++ b/crates/koan-tui/src/app.rs
@@ -767,18 +767,10 @@ impl App {
                 self.tx.send(PlayerCommand::PrevTrack).ok();
             }
             KeyCode::Char('.') | KeyCode::Right => {
-                let target = self
-                    .state
-                    .position_ms()
-                    .saturating_add(10_000)
-                    .min(self.state.seekable_ms());
-                self.tx.send(PlayerCommand::Seek(target)).ok();
+                self.seek_to(self.state.position_ms().saturating_add(10_000));
             }
             KeyCode::Char(',') | KeyCode::Left => {
-                let pos = self.state.position_ms();
-                self.tx
-                    .send(PlayerCommand::Seek(pos.saturating_sub(10_000)))
-                    .ok();
+                self.seek_to(self.state.position_ms().saturating_sub(10_000));
             }
             KeyCode::Char('e') => {
                 self.mode = Mode::QueueEdit;
@@ -1828,20 +1820,22 @@ impl App {
                     && event.column >= self.layout.transport_text_area.x
                     && event.column
                         < self.layout.transport_text_area.x + self.layout.transport_text_area.width
-                    && let Some(info) = self.state.track_info()
+                    && self.state.track_info().is_some()
                 {
                     let click_x = event.column;
-                    let dur = info.duration_ms;
-                    let seekable_ms = self.state.seek_ceiling_ms();
+                    // The duration the bar was drawn against, not the probed
+                    // one: a partial file reports short, and a click would then
+                    // land somewhere other than where it was aimed.
+                    let dur = self.state.duration_ms();
 
                     if let Some(pos) = TransportBar::seek_from_click(
                         self.layout.seek_bar_start,
                         self.layout.seek_bar_width,
                         click_x,
                         dur,
-                        seekable_ms,
+                        self.state.seek_ceiling_ms(),
                     ) {
-                        self.tx.send(PlayerCommand::Seek(pos)).ok();
+                        self.seek_to(pos);
                     } else if click_x < self.layout.seek_bar_start {
                         // Clicked on the play/pause status icon — toggle.
                         if self.state.playback_state() == PlaybackState::Playing {
@@ -2911,6 +2905,34 @@ impl App {
         };
         self.status_message = Some((format!("can't play — {fresh}"), std::time::Instant::now()));
         self.noted_failures.insert(fresh);
+    }
+
+    /// Seek, clamped to what the player will accept.
+    ///
+    /// A track still arriving is reachable only as far as its bytes go, and one
+    /// whose container cannot state a duration until the last of them lands —
+    /// Ogg — is reachable nowhere at all. Sent unclamped, every seek into that
+    /// track is a seek to zero, so it says why nothing happened instead.
+    fn seek_to(&mut self, target_ms: u64) {
+        if self.state.track_info().is_none() {
+            return;
+        }
+        let seekable = self.state.seekable_ms();
+        if seekable == 0 {
+            let so_far = self
+                .state
+                .current_download_fraction()
+                .map(|f| format!(" — {}% so far", (f * 100.0) as u32))
+                .unwrap_or_default();
+            self.status_message = Some((
+                format!("still downloading{so_far} — seekable once it lands"),
+                std::time::Instant::now(),
+            ));
+            return;
+        }
+        self.tx
+            .send(PlayerCommand::Seek(target_ms.min(seekable)))
+            .ok();
     }
 
     /// The track info modal renders nothing once its track leaves the queue,

--- a/crates/koan-tui/src/enqueue.rs
+++ b/crates/koan-tui/src/enqueue.rs
@@ -24,7 +24,7 @@ pub fn enqueue_playlist(
     tx: crossbeam_channel::Sender<PlayerCommand>,
     download_queue: DownloadQueue,
 ) {
-    let db = match koan_core::db::connection::Database::open_default() {
+    let db = match koan_core::db::pool::shared().get() {
         Ok(db) => db,
         Err(e) => {
             log::error!("db error: {}", e);

--- a/crates/koan-tui/src/library.rs
+++ b/crates/koan-tui/src/library.rs
@@ -5,7 +5,6 @@ use ratatui::layout::Rect;
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Widget};
 
-use koan_core::db::connection::Database;
 use koan_core::db::queries;
 
 use super::theme::Theme;
@@ -68,8 +67,8 @@ impl LibraryState {
         state
     }
 
-    fn open_db(&self) -> Option<Database> {
-        Database::open(&self.db_path).ok()
+    fn open_db(&self) -> Option<koan_core::db::pool::Handle<'static>> {
+        koan_core::db::pool::shared().get().ok()
     }
 
     fn load_artists(&mut self) {

--- a/crates/koan-tui/src/picker_items.rs
+++ b/crates/koan-tui/src/picker_items.rs
@@ -10,7 +10,7 @@ fn format_time(ms: u64) -> String {
 }
 
 pub fn load_picker_items(kind: PickerKind) -> Vec<PickerItem> {
-    let db = koan_core::db::connection::Database::open_default().unwrap_or_else(|e| {
+    let db = koan_core::db::pool::shared().get().unwrap_or_else(|e| {
         log::error!("db error: {}", e);
         std::process::exit(1);
     });

--- a/crates/koan-tui/src/play.rs
+++ b/crates/koan-tui/src/play.rs
@@ -42,7 +42,7 @@ pub struct TuiCallbacks {
 fn save_playback_state_from_app(app: &app::App) {
     let (items, cursor) = app.state.snapshot_playlist();
     if items.is_empty() {
-        if let Ok(db) = koan_core::db::connection::Database::open(&app.db_path) {
+        if let Ok(db) = koan_core::db::pool::shared().get() {
             let _ = koan_core::db::queries::clear_playback_state(&db.conn);
         }
         return;
@@ -57,7 +57,7 @@ fn save_playback_state_from_app(app: &app::App) {
         .map(|i| i.path.to_string_lossy().into_owned());
     let position_ms = app.state.position_ms();
 
-    match koan_core::db::connection::Database::open(&app.db_path) {
+    match koan_core::db::pool::shared().get() {
         Ok(db) => {
             if let Err(e) = koan_core::db::queries::save_playback_state(
                 &db.conn,

--- a/crates/koan-tui/src/play.rs
+++ b/crates/koan-tui/src/play.rs
@@ -34,8 +34,6 @@ pub struct TuiCallbacks {
         &[PathBuf],
         Option<&std::sync::atomic::AtomicUsize>,
     ) -> Vec<koan_core::player::state::PlaylistItem>,
-    /// Open the database (exits on failure).
-    pub open_db: fn() -> koan_core::db::connection::Database,
 }
 
 /// Save the current queue and playback position to DB.
@@ -329,8 +327,9 @@ pub fn run_tui(
             app.picker = Some(PickerState::new(*kind, items, multi));
         }
 
-        if let Some(artist_id) = app.artist_drill_down.take() {
-            let db = (callbacks.open_db)();
+        if let Some(artist_id) = app.artist_drill_down.take()
+            && let Ok(db) = koan_core::db::pool::shared().get()
+        {
             let albums = queries::albums_for_artist(&db.conn, artist_id).unwrap_or_default();
             if albums.is_empty() {
                 let track_ids: Vec<i64> = queries::tracks_for_artist(&db.conn, artist_id)
@@ -359,7 +358,6 @@ pub fn run_tui(
         if let Some((kind, ids, action)) = app.picker_result.take() {
             let tx_bg = tx.clone();
             let dq_bg = download_queue.clone();
-            let open_db = callbacks.open_db;
 
             app.loading_message = Some("loading...".into());
 
@@ -368,7 +366,9 @@ pub fn run_tui(
                 .spawn(move || {
                     let track_ids = match kind {
                         PickerKind::Album => {
-                            let db = open_db();
+                            let Ok(db) = koan_core::db::pool::shared().get() else {
+                                return;
+                            };
                             let mut expanded = Vec::new();
                             for album_id in &ids {
                                 if is_all_tracks_sentinel(*album_id) {

--- a/crates/koan-tui/src/transport.rs
+++ b/crates/koan-tui/src/transport.rs
@@ -72,6 +72,60 @@ fn format_source(info: &TrackInfo) -> String {
     format!("{} {}{} {}", info.codec, rate_str, detail, ch_str)
 }
 
+/// The playhead. A cell of its own rather than the end of the played run:
+/// twenty seconds into nine hours is a tenth of a percent of the bar, which
+/// rounds to no cells at any width a terminal has, and a bar with no mark on
+/// it says nothing about where playback is.
+const HEAD: &str = "\u{25CF}";
+
+/// The seek bar as cell counts, either side of the playhead: what has played,
+/// what can still be reached, and what has not arrived yet. The three plus the
+/// head fill the bar exactly.
+struct BarRegions {
+    played: usize,
+    reachable: usize,
+    pending: usize,
+}
+
+impl BarRegions {
+    /// `seekable_ms` is where a seek stops short while a download is still
+    /// arriving, and `None` once the whole track is reachable.
+    ///
+    /// The dimming falls on what has not arrived rather than on what has, so
+    /// that a track already on disk — the ordinary case — draws as the
+    /// ordinary bar, and a download finishing changes nothing about it. Lit
+    /// the other way round, a bar goes dark the moment its transfer completes.
+    fn new(bar_width: usize, position_ms: u64, duration_ms: u64, seekable_ms: Option<u64>) -> Self {
+        if bar_width == 0 {
+            return Self {
+                played: 0,
+                reachable: 0,
+                pending: 0,
+            };
+        }
+        let cells = |ms: u64| {
+            let frac = if duration_ms > 0 {
+                ms as f64 / duration_ms as f64
+            } else {
+                0.0
+            };
+            ((frac * bar_width as f64) as usize).min(bar_width)
+        };
+
+        let tail = bar_width - 1; // everything but the head
+        let played = cells(position_ms).min(tail);
+        let reachable = seekable_ms
+            .map_or(bar_width, cells)
+            .saturating_sub(played + 1)
+            .min(tail - played);
+        Self {
+            played,
+            reachable,
+            pending: tail - played - reachable,
+        }
+    }
+}
+
 pub struct TransportBar<'a> {
     track_info: Option<&'a TrackInfo>,
     playing_entry: Option<&'a QueueEntry>,
@@ -190,42 +244,25 @@ impl Widget for TransportBar<'_> {
         let chrome_width = 1 + 2 + 1 + 1 + time_str.len() as u16;
         let bar_width = area.width.saturating_sub(chrome_width) as usize;
 
-        let progress = if duration_ms > 0 {
-            ((self.position_ms as f64 / duration_ms as f64) * bar_width as f64) as usize
-        } else {
-            0
-        }
-        .min(bar_width);
+        let bar = BarRegions::new(bar_width, self.position_ms, duration_ms, self.seekable_ms);
 
-        // How much of the bar can be seeked into.
-        let downloaded = if let Some(seekable) = self.seekable_ms {
-            let dl_frac = if duration_ms > 0 {
-                seekable as f64 / duration_ms as f64
-            } else {
-                1.0
-            };
-            ((dl_frac * bar_width as f64) as usize).min(bar_width)
-        } else {
-            bar_width // fully downloaded
-        };
-
-        let filled = "\u{2501}".repeat(progress);
-        let dl_remaining = "\u{2500}".repeat(downloaded.saturating_sub(progress));
-        // Not-yet-downloaded portion: same char but DIM so it fades out.
-        let not_downloaded = "\u{2500}".repeat(bar_width.saturating_sub(downloaded));
-
-        let mut spans = vec![
-            Span::raw(" "),
-            status_icon,
-            Span::raw(" "),
-            Span::styled(filled, self.theme.progress_filled),
-            Span::styled(dl_remaining, self.theme.progress_empty),
-        ];
-        if !not_downloaded.is_empty() {
+        let mut spans = vec![Span::raw(" "), status_icon, Span::raw(" ")];
+        if bar_width > 0 {
             spans.push(Span::styled(
-                not_downloaded,
-                self.theme.progress_empty.add_modifier(Modifier::DIM),
+                "\u{2501}".repeat(bar.played),
+                self.theme.progress_filled,
             ));
+            spans.push(Span::styled(HEAD, self.theme.progress_filled));
+            spans.push(Span::styled(
+                "\u{2500}".repeat(bar.reachable),
+                self.theme.progress_empty,
+            ));
+            if bar.pending > 0 {
+                spans.push(Span::styled(
+                    "\u{2500}".repeat(bar.pending),
+                    self.theme.progress_empty.add_modifier(Modifier::DIM),
+                ));
+            }
         }
         spans.push(Span::raw(" "));
         spans.push(Span::styled(time_str, self.theme.hint_desc));
@@ -374,5 +411,111 @@ pub fn format_time(ms: u64) -> String {
         format!("{}:{:02}:{:02}", hours, mins, secs)
     } else {
         format!("{}:{:02}", mins, secs)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const NINE_HOURS: u64 = 9 * 60 * 60 * 1000;
+
+    fn regions(position_ms: u64, duration_ms: u64, seekable_ms: Option<u64>) -> BarRegions {
+        BarRegions::new(60, position_ms, duration_ms, seekable_ms)
+    }
+
+    #[test]
+    fn the_regions_and_the_head_fill_the_bar() {
+        for pos in [0, 1, 30_000, NINE_HOURS / 2, NINE_HOURS] {
+            for seekable in [None, Some(0), Some(NINE_HOURS / 3), Some(NINE_HOURS)] {
+                let b = regions(pos, NINE_HOURS, seekable);
+                assert_eq!(
+                    b.played + 1 + b.reachable + b.pending,
+                    60,
+                    "{pos} {seekable:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn a_position_too_small_to_draw_still_has_a_head() {
+        // Twenty seconds into nine hours is a tenth of a percent of the bar.
+        let b = regions(20_000, NINE_HOURS, None);
+        assert_eq!(b.played, 0);
+        assert_eq!(b.reachable, 59);
+    }
+
+    #[test]
+    fn the_head_stays_on_the_bar_at_the_end_of_the_track() {
+        let b = regions(NINE_HOURS, NINE_HOURS, None);
+        assert_eq!(b.played, 59);
+        assert_eq!(b.reachable, 0);
+        assert_eq!(b.pending, 0);
+    }
+
+    #[test]
+    fn a_track_on_disk_has_nothing_dimmed() {
+        let b = regions(NINE_HOURS / 2, NINE_HOURS, None);
+        assert_eq!(b.pending, 0);
+    }
+
+    #[test]
+    fn what_has_not_arrived_is_what_is_dimmed() {
+        let b = regions(0, 100_000, Some(25_000));
+        assert_eq!(b.reachable, 14); // 15 cells reachable, one of them the head
+        assert_eq!(b.pending, 45);
+    }
+
+    #[test]
+    fn a_track_reachable_nowhere_is_dim_the_whole_way() {
+        let b = regions(0, 100_000, Some(0));
+        assert_eq!(b.played, 0);
+        assert_eq!(b.reachable, 0);
+        assert_eq!(b.pending, 59);
+    }
+
+    /// What the bar actually draws, as one string, for a track twenty seconds
+    /// into nine hours — the case a played run alone cannot show.
+    fn rendered(position_ms: u64, duration_ms: u64, seekable_ms: Option<u64>) -> String {
+        let theme = Theme::default();
+        let info = TrackInfo {
+            id: koan_core::player::state::QueueItemId::new(),
+            path: std::path::PathBuf::from("/x.flac"),
+            codec: "FLAC".into(),
+            sample_rate: 44100,
+            bit_depth: Some(16),
+            bitrate_kbps: None,
+            channels: 2,
+            duration_ms,
+        };
+        let area = Rect::new(0, 0, 60, 2);
+        let mut buf = Buffer::empty(area);
+        TransportBar::new(
+            Some(&info),
+            None,
+            PlaybackState::Playing,
+            position_ms,
+            &theme,
+        )
+        .with_seekable_ms(seekable_ms)
+        .render(area, &mut buf);
+        (0..area.width)
+            .map(|x| buf[(x, 0)].symbol())
+            .collect::<String>()
+    }
+
+    #[test]
+    fn the_head_is_drawn_where_a_played_run_would_show_nothing() {
+        let bar = rendered(20_000, NINE_HOURS, None);
+        assert!(bar.contains(HEAD), "{bar}");
+        // Four cells of chrome, then the head at the very start of the bar.
+        assert_eq!(bar.chars().nth(4).unwrap().to_string(), HEAD, "{bar}");
+    }
+
+    #[test]
+    fn a_bar_with_no_room_draws_nothing() {
+        let b = BarRegions::new(0, 30_000, 100_000, None);
+        assert_eq!((b.played, b.reachable, b.pending), (0, 0, 0));
     }
 }

--- a/crates/koan-tui/tests/render.rs
+++ b/crates/koan-tui/tests/render.rs
@@ -224,14 +224,18 @@ fn seek_bar_metrics_match_rendered_bar() {
         assert_eq!(&prefix[..1], " ", "width={width}");
         assert_eq!(bar_start, 4, "width={width}");
 
-        // Every cell inside the reported bar span is a bar glyph, filled or empty.
+        // Every cell inside the reported bar span is a bar glyph — filled,
+        // empty, or the one that marks the playhead.
+        let mut heads = 0;
         for x in bar_start..bar_start + bar_width {
             let sym = buf[(x, 0)].symbol();
+            heads += usize::from(sym == "\u{25CF}");
             assert!(
-                sym == "\u{2501}" || sym == "\u{2500}",
+                sym == "\u{2501}" || sym == "\u{2500}" || sym == "\u{25CF}",
                 "width={width} col={x} is {sym:?}, not a bar glyph"
             );
         }
+        assert_eq!(heads, 1, "width={width}");
         // The cell just past the bar is the separating space, not a bar glyph.
         if bar_start + bar_width < width {
             assert_eq!(


### PR DESCRIPTION
Closes #370.

The v0.32.0 work was driven by the macOS app. The TUI inherited the engine side of it for free — streaming, seeking, the download store, the derived load state — and kept its own version of three things.

## Its own database connections

Every read opened one: a `create_dir_all`, a permissions syscall, the whole schema DDL and an attempted WAL checkpoint before a row came back, and while downloads were writing that checkpoint contended with them. In the app it was two seconds per album click (#359). The TUI's reads are user-triggered rather than per-frame so it never cost that much, but autosave ran one on a timer and five modules did it besides — the last of them a `fn() -> Database` callback the CLI passed in, now deleted.

They read through `db::pool`, which needed one change to be safe outside the app: it opened with `open_existing`, which assumes the schema was applied at startup — true for the app, not for a one-shot command on a machine that has never run koan. It applies the schema itself now, once, so the invariant is gone rather than documented.

## Its seek bar

Rewired to `seekable_ms` in #359 and never run. Two of the three things the app's version needed are questions of meaning, and applied here too:

- **The head.** The bar drew the played run and nothing else, so a position too small to fill a cell drew as nothing at all — twenty seconds into a nine-hour recording is a tenth of a percent of it. The head has a cell of its own now, which does not shrink with the fraction.
- **The dimming.** Already on the end that has not arrived, which is the right way round: a track on disk is the ordinary case and should draw as the ordinary bar, so a download finishing changes nothing. Left alone, now with the reason written down.

## Seeks that could not land

All seeks go through one place. A track whose container cannot state a duration until its last bytes arrive — Ogg — is reachable nowhere at all while it downloads, and an unclamped seek into one is a seek to zero, so `,` and `.` threw playback back to the start. It says how far the transfer has got instead. Clicking the bar mapped the click against the probed duration while the bar was drawn against the library's; on a partial file those are different numbers, and both use the library's now.

## Confirming it

`cargo test -p koan-tui --lib transport` covers the bar: the regions always fill it, the head survives a nine-hour track and the end of one, and what has not arrived is what is dimmed — including a render assertion that the head lands on the first cell of the bar when the played run is empty.

The rest wants driving: play something long off a remote server, seek forwards and back while it is still arriving, and let the transfer land under you.

## Not verified

`remote_bridge.rs` writes the download store since #362 — read through and coherent (queued → started → finished/failed), but nothing exercises it in CI and I had no server to point it at. Unchanged by this PR.

A downloads view for the TUI is still an open question; the store is there to read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011SNaTL1BNeQqqVN82AqMiB
