### PR TITLE
fix(player): stop a finished download rewriting what the library knows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- **A track no longer leaves its album when its download finishes.** A track that streams starts on the partial tags symphonia can read, so when the file lands koan re-reads it properly and fills the queue item in. It filled in tracks that needed nothing — ones that came out of the library and already carried the record's own title. Where a file's tags disagree with the server's, and on a rip they often do, the item quietly changed album halfway down the queue and its record split in two: ten tracks under one heading, the one that had played under another. The file's word now only counts for a queue item with no library row behind it. Its duration still counts for everything, because that is the file's to know.
+
 ## v0.33.0 (2026-08-26)
 
 ### Removed

--- a/crates/koan-core/src/player/mod.rs
+++ b/crates/koan-core/src/player/mod.rs
@@ -1082,8 +1082,8 @@ impl Player {
     }
 
     /// Re-read full lofty metadata for a track after its download completes.
-    /// Updates the playlist item's tags and track_info with complete metadata.
     /// Called from track_ready() when a streaming track finishes downloading.
+    /// What the item takes from it is `update_item_metadata`'s call.
     fn refresh_track_metadata(&mut self, id: QueueItemId) {
         use crate::index::metadata;
 
@@ -1094,7 +1094,6 @@ impl Player {
 
         match metadata::read_metadata(&path) {
             Ok(meta) => {
-                // Update playlist item with full lofty tags (title, artist, album, duration).
                 self.shared_state.update_item_metadata(
                     id,
                     meta.title,

--- a/crates/koan-core/src/player/state.rs
+++ b/crates/koan-core/src/player/state.rs
@@ -721,9 +721,15 @@ impl SharedPlayerState {
         self.bump_version();
     }
 
-    /// Update playlist item metadata after a full download completes.
-    /// Used for progressive enhancement: streaming started with partial Symphonia tags,
-    /// now the full file is available so we can refresh with complete lofty metadata.
+    /// Take what a finished download's own tags can add.
+    ///
+    /// Streaming starts on partial Symphonia tags, so an item with nothing
+    /// behind it takes the lot once the whole file is there. An item that came
+    /// out of the library does not: the record is what the queue was built
+    /// from and what every other track on it carries, and a file whose tags
+    /// disagree — a server album titled one way, the file inside titled
+    /// another — would split its album in two the moment it finished
+    /// downloading. The duration is the file's to know either way.
     pub fn update_item_metadata(
         &self,
         id: QueueItemId,
@@ -735,10 +741,12 @@ impl SharedPlayerState {
     ) {
         let mut pl = self.playlist.write();
         if let Some(item) = pl.items.iter_mut().find(|item| item.id == id) {
-            item.title = title;
-            item.artist = artist;
-            item.album_artist = album_artist;
-            item.album = album;
+            if item.db_id.is_none() {
+                item.title = title;
+                item.artist = artist;
+                item.album_artist = album_artist;
+                item.album = album;
+            }
             if let Some(dur) = duration_ms {
                 item.duration_ms = Some(dur);
             }
@@ -1710,6 +1718,53 @@ mod tests {
         let bogus = QueueItemId::new();
         let mates = state.same_album_item_ids(bogus);
         assert!(mates.is_empty());
+    }
+
+    // --- update_item_metadata ---
+
+    #[test]
+    fn test_update_item_metadata_leaves_library_tags_alone() {
+        let state = SharedPlayerState::new();
+        let mut item = make_album_item("A1", "Nite Versions (mixed)", "Soulwax");
+        item.db_id = Some(29615);
+        let id = item.id;
+        state.add_items(vec![item]);
+
+        state.update_item_metadata(
+            id,
+            "[unknown]".into(),
+            "Soulwax".into(),
+            "Soulwax".into(),
+            "Nite Versions".into(),
+            Some(54_000),
+        );
+
+        let pl = state.playlist.read();
+        assert_eq!(pl.items[0].album, "Nite Versions (mixed)");
+        assert_eq!(pl.items[0].title, "A1");
+        assert_eq!(pl.items[0].duration_ms, Some(54_000));
+    }
+
+    #[test]
+    fn test_update_item_metadata_fills_in_an_item_with_nothing_behind_it() {
+        let state = SharedPlayerState::new();
+        let item = make_album_item("A1", "", "");
+        let id = item.id;
+        state.add_items(vec![item]);
+
+        state.update_item_metadata(
+            id,
+            "Teachers".into(),
+            "Soulwax".into(),
+            "Soulwax".into(),
+            "Nite Versions".into(),
+            Some(148_000),
+        );
+
+        let pl = state.playlist.read();
+        assert_eq!(pl.items[0].title, "Teachers");
+        assert_eq!(pl.items[0].album, "Nite Versions");
+        assert_eq!(pl.items[0].duration_ms, Some(148_000));
     }
 
     // --- move_item_to ---


### PR DESCRIPTION
The queue sometimes split one album into two headings — the track that had played sitting alone above the other ten, under a slightly different album name.

## What was happening

A track that starts playing mid-download opens on the partial tags symphonia can scrape, so `refresh_track_metadata` re-reads the file with lofty when the transfer lands and writes title/artist/album/album-artist back onto the queue item. It did that for every item, including ones built from a library row that already carried the server's metadata.

Soulwax — *Nite Versions*: the server calls the album `Nite Versions (mixed)`; the FLACs inside say `Nite Versions`. Every queue item was built from the DB, so the queue was coherent until the first track finished downloading — at which point that one item's album string changed and the macOS queue view, which groups contiguous runs of the same `(album, albumArtist)`, drew two groups. The album *page* stayed whole, because it groups by `album_id`.

## The fix

`SharedPlayerState::update_item_metadata` now takes the file's tags only for an item with no `db_id` — one that came off disk with nothing behind it, which is the case the progressive-enhancement path existed for. Duration is taken either way; that one really is the file's to know.

## Verifying

- Two tests in `player/state.rs`: a library-backed item keeps its tags and takes the duration; an item with nothing behind it takes the lot.
- By hand: queue an album from a remote server whose files disagree with the server's album tag, play the first track, let it finish downloading. It stays under one heading.
- Existing queues heal on restart — `restore_items` rebuilds every item it can resolve from the DB, so the corrupted string does not survive a session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGDBjDuimCiodJvXCKBwL7