### PR TITLE
perf(macos): publish a browse listing only when it has changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Performance
+
+- **A browse listing is only redrawn when it has actually changed.** Albums, artists, favourites and history are each read whole and handed to SwiftUI whole — 5,610 records and 7,138 artists on a large library — and assigning that array again is a mutation whether or not a single row moved, so the grid was diffed end to end, laid out and committed for it. It was assigned again on every library version bump, which is every download landing and every playlist edit, and on every return to a section already visited. The rows are now compared before they are published, and the same answer as last time is dropped. The favourite id sets get the same treatment, for the sharper version of the same problem: every cell and every row reads them to draw its heart.
+
+  Nothing about how a listing is read has changed. It still arrives whole, so the scrollbar still tells the truth about how long the library is and one flick still reaches the end of it.
+
+- **A track row no longer copies the whole track list to itself.** Each row carries the ids of the list it belongs to, so playing it keeps the rest queued behind it — and that list was rebuilt inside the row's own body, once per row. It is built once per pass now.
+
 ### Fixed
 
 - **A track no longer leaves its album when its download finishes.** A track that streams starts on the partial tags symphonia can read, so when the file lands koan re-reads it properly and fills the queue item in. It filled in tracks that needed nothing — ones that came out of the library and already carried the record's own title. Where a file's tags disagree with the server's, and on a rip they often do, the item quietly changed album halfway down the queue and its record split in two: ten tracks under one heading, the one that had played under another. The file's word now only counts for a queue item with no library row behind it. Its duration still counts for everything, because that is the file's to know.

--- a/apps/macos/Sources/Koan/Support/LibraryModel.swift
+++ b/apps/macos/Sources/Koan/Support/LibraryModel.swift
@@ -207,20 +207,32 @@ final class LibraryModel {
         )
     }
 
+    /// Publish what came back, and only where it differs from what is already
+    /// on screen.
+    ///
+    /// `@Observable` has no opinion about equality: assigning the same rows
+    /// again is still a mutation, and a mutation of a listing is a `ForEach`
+    /// diff over every id in it, a layout pass and a commit — 5,610 records and
+    /// 7,138 artists on a large library. The same answer as last time is the
+    /// common case, not the rare one: every library version bump reloads, so a
+    /// download landing or a playlist edit asks again, and so does every return
+    /// to a section already visited. Comparing the rows is one walk over them.
+    /// Publishing them is thousands of views' worth of work that changes
+    /// nothing on screen.
     private func show(_ rows: Rows) {
         switch rows {
         case .none:
             break
         case .albums(let rows):
-            visibleAlbums = rows
+            if rows != visibleAlbums { visibleAlbums = rows }
         case .artists(let rows):
-            visibleArtists = rows
+            if rows != visibleArtists { visibleArtists = rows }
         case .favourites(let tracks, let albums, let artists):
-            visibleFavourites = tracks
-            visibleFavouriteAlbums = albums
-            visibleFavouriteArtists = artists
+            if tracks != visibleFavourites { visibleFavourites = tracks }
+            if albums != visibleFavouriteAlbums { visibleFavouriteAlbums = albums }
+            if artists != visibleFavouriteArtists { visibleFavouriteArtists = artists }
         case .history(let rows):
-            visiblePlayHistory = rows
+            if rows != visiblePlayHistory { visiblePlayHistory = rows }
         }
     }
 
@@ -368,9 +380,16 @@ final class LibraryModel {
             async let tracks = engine.favouriteTrackIds()
             async let albums = engine.favouriteAlbumIds()
             async let artists = engine.favouriteArtistIds()
-            favouriteTrackIds = Set((try? await tracks) ?? [])
-            favouriteAlbumIds = Set((try? await albums) ?? [])
-            favouriteArtistIds = Set((try? await artists) ?? [])
+            let trackIds = Set((try? await tracks) ?? [])
+            let albumIds = Set((try? await albums) ?? [])
+            let artistIds = Set((try? await artists) ?? [])
+            // Guarded for the same reason a listing is. Every grid cell and
+            // every row reads these to draw its heart, so republishing a set
+            // that has not moved redraws the whole page for nothing — and a
+            // sync reconciling favourites usually finds them all the same.
+            if trackIds != favouriteTrackIds { favouriteTrackIds = trackIds }
+            if albumIds != favouriteAlbumIds { favouriteAlbumIds = albumIds }
+            if artistIds != favouriteArtistIds { favouriteArtistIds = artistIds }
             reloadFavourites()
         }
     }

--- a/apps/macos/Sources/Koan/Views/FavouritesView.swift
+++ b/apps/macos/Sources/Koan/Views/FavouritesView.swift
@@ -112,6 +112,8 @@ struct FavouritesView: View {
 
     private var trackSection: some View {
         Section("Tracks") {
+            // Once per pass, not once per row — see `TrackListView`.
+            let allTrackIds = tracks.map(\.id)
             ForEach(Array(tracks.enumerated()), id: \.element.id) { index, track in
                 TrackRow(
                     track: track,
@@ -121,7 +123,7 @@ struct FavouritesView: View {
                     // Gathered from all over, so a row carries its own sleeve
                     // and says which record it came from.
                     showsAlbum: true,
-                    allTrackIds: tracks.map(\.id)
+                    allTrackIds: allTrackIds
                 )
                 .rowBehaviour(playable: .track(track))
             }

--- a/apps/macos/Sources/Koan/Views/TrackListView.swift
+++ b/apps/macos/Sources/Koan/Views/TrackListView.swift
@@ -39,6 +39,11 @@ struct TrackListView: View {
                 // clicks resolve against each other and drop; List gives native
                 // selection, shift/⌘ range select and keyboard navigation.
                 ScrollViewReader { proxy in
+                    // Built once per pass rather than once per row. Every row
+                    // carries the list it belongs to so playing it keeps the
+                    // rest behind it, and mapping inside the `ForEach` body
+                    // allocated a fresh copy of the whole thing for each one.
+                    let allTrackIds = tracks.map(\.id)
                     List(selection: $selection) {
                         ForEach(Array(tracks.enumerated()), id: \.element.id) { index, track in
                             TrackRow(
@@ -47,7 +52,7 @@ struct TrackListView: View {
                                 isCurrent: player.currentTrackId == track.id,
                                 isSelected: selection.contains(track.id),
                                 showsAlbum: mixedAlbums,
-                                allTrackIds: tracks.map(\.id)
+                                allTrackIds: allTrackIds
                             )
                             .rowBehaviour(playable: .track(track))
                         }


### PR DESCRIPTION
## What this does

Albums, artists, favourites and history are each read whole and handed to SwiftUI whole — 5,610 records and 7,138 artists on a large library. `@Observable` has no opinion about equality, so assigning that array again is a mutation whether or not a single row moved: a `ForEach` diff over every id in the listing, a layout pass, a commit.

That happened on every library version bump — every download landing, every playlist edit — and on every return to a section already visited, because `showing(_:)` reloads on arrival. `LibraryModel.show(_:)` now compares before it publishes, and drops the same answer as last time.

The favourite id sets get the same guard for the sharper version of the same problem: every grid cell and every row reads them to draw its heart, so republishing an unchanged set redraws the whole page.

Also in here: `TrackRow` carries the ids of the list it belongs to, so playing a row keeps the rest queued behind it. That list was built inside the `ForEach` body — a fresh copy of the whole thing per row, on both the album page and the favourites listing. Built once per pass now.

## Load-bearing decisions

**Nothing about how a listing is read has changed.** It still arrives whole, unpaged, so the scrollbar still tells the truth about how long the library is and one flick still reaches the end of it. No windowed `ForEach`, no spinner at the bottom of the grid — the issue is explicit that trading those away would be fixing the wrong thing.

**Comparing is cheaper than publishing.** One walk over the rows against a graph update and a CoreAnimation commit for the whole grid. `Album`, `Artist`, `Track` and `PlayHistoryEntry` are uniffi records with no object references, so they come out of the generator `Equatable` for free.

**What is left is the floor.** A listing that genuinely changed still gets diffed whole, and it has to be. What is gone is diffing one that did not.

This does **not** make opening a record faster — #380 stands on its own, and the owner already ran the experiment that separates them.

## How to confirm

Browse to Albums on a large library, then navigate away and back: previously a full grid diff each time, now nothing. Same while a download lands, or a playlist is edited, with the grid on screen. Filtering, sorting and reshuffling still redraw, because those genuinely change the rows.

Built with `just macos-build`. No Rust changed.

Closes #381