### PR TITLE
docs(macos): settle the wash's blur on a measurement

### DIFF
--- a/apps/macos/Sources/Koan/Views/DriftingWash.swift
+++ b/apps/macos/Sources/Koan/Views/DriftingWash.swift
@@ -18,13 +18,19 @@ import SwiftUI
 /// it is the only way to have motion that costs nothing.
 ///
 /// The blur is baked into the texture *once*, not left on the layer. A live
-/// `CALayer.filters` looks free — it is the compositor's work, not ours — but a
-/// filter on a layer that is animating and the size of the window is a Gaussian
-/// blur re-run over the whole window every frame. The main thread then blocks
-/// in `CABackingStoreSynchronize` waiting for the render server to finish with
-/// the backing store, which is how a tap took six hundred milliseconds to be
-/// noticed. Blurred once and magnified as a texture, the compositor only has a
-/// transform to apply.
+/// `CALayer.filters` looks free — it is the compositor's work, not ours — but
+/// the compositor re-evaluates a layer's filters every frame it composites it,
+/// and this layer is the size of the window and never stops moving.
+///
+/// Measured on an M1 Pro, this same layer in a 1400x900 window: a live filter
+/// on a *settled* layer is indistinguishable from an empty window, and the
+/// moment the drift starts it costs the render server about a seventh of a core
+/// and ten points of GPU, continuously, for the wash on its own. Baked, the
+/// drift reads as idle on both. So the filter is not free, and what it charges
+/// for is the animation rather than its own presence.
+///
+/// This is not what made a tap slow — that survives at plain graphics, where no
+/// wash is rendered at all (koan#380). Baking is simply the cheaper of the two.
 struct DriftingWash: NSViewRepresentable {
     /// Nothing playing, or a record with no art, means no wash rather than a
     /// grey one.
@@ -167,6 +173,12 @@ final class WashView: NSView {
     /// drawn at, and the image is clamped first — an unclamped blur samples
     /// transparent black past the edge and leaves the sleeve with a soft dark
     /// border all the way round.
+    ///
+    /// It is measured against `side`, so the wash is blurred at 14 points of a
+    /// 360pt reference and then magnified along with the texture. A live filter
+    /// blurs *after* magnification, so 14 points there is a fifth of this blur
+    /// and a different picture — matching it would take a radius around 70, and
+    /// the live filter costs more at that radius, not less.
     private nonisolated static func bake(_ image: NSImage) -> CGImage? {
         var rect = NSRect(origin: .zero, size: image.size)
         guard let source = image.cgImage(forProposedRect: &rect, context: nil, hints: nil)


### PR DESCRIPTION
`DriftingWash` bakes the blur rather than leaving `CALayer.filters` live, on a hypothesis that was never tested. Measured it. The conclusion holds; the reasoning written in the comment did not, so the comment is what changes here. No behaviour change.

## What was measured

The same layer — window-sized, 1.38 overscan, the three drift animations — in a 1400x900 window, both ways, on an M1 Pro at 60Hz. Costs are read from outside the process, because this work belongs to the render server: `WindowServer` CPU time and mean GPU utilisation, sampled over 25s per phase and interleaved so background load cancels.

| | WindowServer CPU | GPU |
|---|---|---|
| empty window | 38.0% | 32.7% |
| baked, drifting | 39.2% | 28.8% |
| live filters, settled | 38.8 / 38.0% | 32.8 / 29.4% |
| live filters, drifting | 52.0 / 53.6% | 41.3 / 43.1% |

Two rounds of each live figure, both consistent.

**Baked is indistinguishable from an empty window.** **A live filter is free while the layer is still and costs about a seventh of a core plus ten points of GPU the moment it moves** — for the wash alone, before any of koan's glass, indicators or lists. That is the compositor re-evaluating the layer's filters every frame it composites it, which is what the original comment claimed and is now measured rather than assumed.

Baking's own cost, for completeness: one blur per record change, on `ImageWork.onCPU` — 1.2ms for a 600px sleeve, 3.0ms at 1200px, 17.5ms at 3000px.

## What the comment got wrong

It attributed a six-hundred-millisecond tap to the live filter via `CABackingStoreSynchronize`. #380 has since eliminated that — the stall survives at plain graphics, where no wash is rendered at all. The comment now says the live filter is the more expensive of the two and explicitly says it is *not* what made a tap slow, so nobody chases it again.

## The trap, also recorded

Restoring the live filter is not a like-for-like swap. The baked radius is 14 points of a 360pt reference, magnified with the texture; a live filter blurs *after* magnification, so 14 there is a fifth of this blur and a visibly different picture. Matching it needs a radius around 70 — which measures worse still (9.9ms vs 7.3ms of GPU per full-screen pass).

## Verifying

Comment-only diff — `git diff` is the whole review. The numbers are reproducible with a standalone harness that lifts `WashView` verbatim and flips the two modes behind an env var; happy to attach it if it is worth keeping.

Closes #382