### PR TITLE
fix(macos): every page arrives complete, not filled in afterwards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Changed
+
+- **Every page arrives complete.** A record already loaded before it navigated; everywhere else arrived empty and filled in a query later — an artist's records, a playlist's rows, favourites, history, search results, and the queue you left behind when koan reopened. `Navigator` now loads whatever a page draws and only then moves to it, so the first frame of a page is the finished page. There is no partial render to see and no second render a frame later putting the rows under a heading that was already up.
+
+  A page about one thing holds what it is about as one value, read whole and stamped with the library version it was read at — so asking again for the page on screen costs nothing, and asking after a scan is a real read. Sections hand their rows to the navigator, which adopts the page and its rows in one change rather than two. Typing in the search field no longer jumps to an empty results page on the first keystroke: it stays where you are until there is something to show.
+
 ### Fixed
 
 - **A track no longer leaves its album when its download finishes.** A track that streams starts on the partial tags symphonia can read, so when the file lands koan re-reads it properly and fills the queue item in. It filled in tracks that needed nothing — ones that came out of the library and already carried the record's own title. Where a file's tags disagree with the server's, and on a rip they often do, the item quietly changed album halfway down the queue and its record split in two: ten tracks under one heading, the one that had played under another. The file's word now only counts for a queue item with no library row behind it. Its duration still counts for everything, because that is the file's to know.

--- a/apps/macos/Sources/Koan/KoanApp.swift
+++ b/apps/macos/Sources/Koan/KoanApp.swift
@@ -51,6 +51,8 @@ final class AppState {
         library.activity = activity
         library.art = art
         library.mirror = mirror
+        playlists.mirror = mirror
+        nav.playlists = playlists
         player.activity = activity
         organize.activity = activity
         playlists.activity = activity
@@ -139,7 +141,7 @@ struct KoanApp: App {
                 do {
                     let created = try await AppState()
                     await created.player.start()
-                    created.player.restoreSession()
+                    await created.player.restoreSession()
                     state = created
                 } catch {
                     startupError = String(describing: error)

--- a/apps/macos/Sources/Koan/Support/LibraryModel.swift
+++ b/apps/macos/Sources/Koan/Support/LibraryModel.swift
@@ -27,26 +27,59 @@ final class LibraryModel {
     /// library follows where you are, it does not decide it.
     private(set) var section: Section = .queue
 
-    /// The navigator moved. Catch up.
-    func showing(_ section: Section) {
-        guard section != self.section else { return }
-        self.section = section
-        // A filter you left behind on another view is invisible here, and an
-        // apparently empty library is the result. Clearing it reloads by
-        // itself; if there was nothing to clear, ask outright.
-        let hadFilter = !filter.isEmpty
+    /// A section and everything it shows, as one value.
+    ///
+    /// Read before the navigator moves — see `prepare(section:)`. A section
+    /// that arrives first and asks afterwards draws itself empty, and the empty
+    /// state of a listing is the word "No albums yet" over a page that has
+    /// albums.
+    struct Listing {
+        let section: Section
+        fileprivate let rows: Rows
+    }
+
+    /// What a section will be showing, without touching what is on screen.
+    ///
+    /// `nil` when it is already showing: the rows are in hand and the filter
+    /// over them is somebody's, so a move back onto a section is not a reason
+    /// to re-read it or to throw their narrowing away. A library change reloads
+    /// it where it is drawn instead.
+    func prepare(section: Section) async -> Listing? {
+        guard section != self.section else { return nil }
+        // Nothing carries over: a filter you left behind on another view is
+        // invisible here, and an apparently empty library is the result.
+        return await Listing(
+            section: section,
+            rows: Request(
+                section: section, filter: "", sort: albumSort, seed: shuffleSeed, engine: engine
+            ).detached()
+        )
+    }
+
+    /// Adopt a listing, at the moment the navigator moves to it.
+    func show(_ listing: Listing) {
+        loading?.cancel()
+        section = listing.section
+        // Quietly: the rows for this section are already in hand, so emptying
+        // the filter it arrives with is not a reason to ask for them again.
+        adopting = true
         filter = ""
-        if !hadFilter { reload() }
+        adopting = false
+        show(listing.rows)
+        isLoading = false
     }
 
     /// Substring filter over whatever the current section is showing. It
     /// narrows the query, not the answer.
     var filter: String = "" {
         didSet {
-            guard filter != oldValue else { return }
+            guard filter != oldValue, !adopting else { return }
             reload(debounced: true)
         }
     }
+
+    /// True while a prepared listing is being adopted — see `show(_:)`.
+    private var adopting = false
 
     /// Long enough that a burst of typing is one round trip, short enough not
     /// to read as lag.
@@ -142,63 +175,11 @@ final class LibraryModel {
                 try? await Task.sleep(for: Self.filterDebounce)
                 guard !Task.isCancelled else { return }
             }
-            let rows = await request.rows()
+            let rows = await request.detached()
             guard !Task.isCancelled else { return }
             show(rows)
             isLoading = false
         }
-    }
-
-    /// Everything a section's query depends on, captured off the model so the
-    /// answer that lands belongs to the question that was asked. Anything that
-    /// changes one cancels the task holding it.
-    private struct Request {
-        let section: Section
-        let filter: String
-        let sort: AlbumSort
-        let seed: Int64
-        let engine: KoanEngine
-
-        var search: String? { filter.isEmpty ? nil : filter }
-
-        /// Everything this section is showing.
-        func rows() async -> Rows {
-            switch section {
-            case .queue, .searchResults, .playlist, .downloads:
-                // Owned by the player, search, playlist and downloads models
-                // respectively.
-                return .none
-            case .albums:
-                return .albums(
-                    (try? await engine.albums(
-                        artistId: nil, sort: sort, seed: seed, search: search
-                    )) ?? []
-                )
-            case .artists:
-                return .artists((try? await engine.artists(search: search)) ?? [])
-            case .favourites:
-                // Three questions, asked at once — they are answers to the same
-                // one and the page shows them together.
-                async let tracks = engine.favourites(search: search)
-                async let albums = engine.favouriteAlbums(search: search)
-                async let artists = engine.favouriteArtists(search: search)
-                return .favourites(
-                    tracks: (try? await tracks) ?? [],
-                    albums: (try? await albums) ?? [],
-                    artists: (try? await artists) ?? []
-                )
-            case .playHistory:
-                return .history((try? await engine.playHistory(search: search)) ?? [])
-            }
-        }
-    }
-
-    private enum Rows {
-        case none
-        case albums([Album])
-        case artists([Artist])
-        case favourites(tracks: [Track], albums: [Album], artists: [Artist])
-        case history([PlayHistoryEntry])
     }
 
     private var request: Request {
@@ -318,6 +299,48 @@ final class LibraryModel {
             }.value
         }
         detailRecord = loaded
+    }
+
+    /// An artist, their records and who they sound like, as one value.
+    ///
+    /// The record's shape, for the other page that is about one thing. Loaded
+    /// before the page appears — see `Navigator.open(artist:)`.
+    private(set) var detailArtist: ArtistRecord?
+
+    struct ArtistRecord: Sendable {
+        let artistId: Int64
+        /// The library version it was read at, so asking again for the artist
+        /// already on screen is free and asking after a scan is a real read.
+        let stamp: UInt64
+        var artist: Artist?
+        var albums: [Album]
+        var similar: [SimilarArtist]
+    }
+
+    /// Read an artist and everything their page draws, at once and off the main
+    /// actor. Three independent queries, so three at once: one after another
+    /// each waited on the one before for no reason.
+    func prepare(artist id: Int64) async {
+        let stamp = mirror?.libraryVersion ?? 0
+        if let held = detailArtist, held.artistId == id, held.stamp == stamp { return }
+
+        let engine = self.engine
+        detailArtist = await Trace.region("engine-reads") {
+            await Task.detached(priority: .userInitiated) {
+                async let artist = try? await engine.artist(artistId: id)
+                async let albums = try? await engine.albums(
+                    artistId: id, sort: .year, seed: 0, search: nil
+                )
+                async let similar = try? await engine.similarArtists(artistId: id)
+                return ArtistRecord(
+                    artistId: id,
+                    stamp: stamp,
+                    artist: await artist ?? nil,
+                    albums: await albums ?? [],
+                    similar: await similar ?? []
+                )
+            }.value
+        }
     }
 
     // MARK: - Mutations
@@ -475,4 +498,66 @@ final class LibraryModel {
         refreshFavourites()
         reload()
     }
+}
+
+/// Everything a section's query depends on, captured off the model so the
+/// answer that lands belongs to the question that was asked. Anything that
+/// changes one cancels the task holding it.
+private struct Request: Sendable {
+    let section: Navigator.Section
+    let filter: String
+    let sort: AlbumSort
+    let seed: Int64
+    let engine: KoanEngine
+
+    var search: String? { filter.isEmpty ? nil : filter }
+
+    /// Everything this section is showing, read off the main actor.
+    ///
+    /// Detached because isolation is inherited by every suspension point: await
+    /// the engine from a main-actor task and the *answer* waits for a
+    /// main-actor slot to be delivered, behind whatever the state mirror is
+    /// applying. The read is microseconds; the wait for the hop was not.
+    func detached() async -> Rows {
+        await Task.detached(priority: .userInitiated) { await self.rows() }.value
+    }
+
+    /// Everything this section is showing.
+    private func rows() async -> Rows {
+        switch section {
+        case .queue, .searchResults, .playlist, .downloads:
+            // Owned by the player, search, playlist and downloads models
+            // respectively.
+            return .none
+        case .albums:
+            return .albums(
+                (try? await engine.albums(
+                    artistId: nil, sort: sort, seed: seed, search: search
+                )) ?? []
+            )
+        case .artists:
+            return .artists((try? await engine.artists(search: search)) ?? [])
+        case .favourites:
+            // Three questions, asked at once — they are answers to the same
+            // one and the page shows them together.
+            async let tracks = engine.favourites(search: search)
+            async let albums = engine.favouriteAlbums(search: search)
+            async let artists = engine.favouriteArtists(search: search)
+            return .favourites(
+                tracks: (try? await tracks) ?? [],
+                albums: (try? await albums) ?? [],
+                artists: (try? await artists) ?? []
+            )
+        case .playHistory:
+            return .history((try? await engine.playHistory(search: search)) ?? [])
+        }
+    }
+}
+
+private enum Rows: Sendable {
+    case none
+    case albums([Album])
+    case artists([Artist])
+    case favourites(tracks: [Track], albums: [Album], artists: [Artist])
+    case history([PlayHistoryEntry])
 }

--- a/apps/macos/Sources/Koan/Support/Navigator.swift
+++ b/apps/macos/Sources/Koan/Support/Navigator.swift
@@ -81,8 +81,13 @@ final class Navigator {
     /// levels of anything.
     private var history: [Page] = [.section(.queue)]
     private var cursor = 0
+    /// The move being loaded, if there is one.
+    private var moving: Task<Void, Never>?
 
     private let library: LibraryModel
+    /// Set by `AppState`. A playlist is a page like any other, and its rows are
+    /// read before the move like any other page's.
+    weak var playlists: PlaylistsModel?
 
     init(library: LibraryModel) {
         self.library = library
@@ -98,21 +103,11 @@ final class Navigator {
         go(to: .section(section))
     }
 
-    /// Load the record, *then* move to it.
-    ///
-    /// Nothing draws until there is something to draw. Arriving first and
-    /// fetching afterwards means a frame of the word "Album" over an empty
-    /// list, and then the real page flickering in underneath it — which is the
-    /// same partial render a web page does and reads exactly as badly. The read
-    /// is two indexed queries; there is no reason to show anybody the gap.
     func open(album id: Int64, highlighting trackId: Int64? = nil) {
-        Task {
-            await Trace.region("click-to-album") {
-                await Trace.region("prepare") { await library.prepare(album: id) }
-                highlightedTrackId = trackId
-                Trace.region("apply") { go(to: .album(id)) }
-            }
-        }
+        // Set before the move rather than on arrival: the page that reads it is
+        // not on screen yet, and this is the same click.
+        highlightedTrackId = trackId
+        go(to: .album(id))
     }
 
     func open(artist id: Int64) {
@@ -126,34 +121,73 @@ final class Navigator {
     func goBack() {
         guard canGoBack else { return }
         cursor -= 1
-        step(to: history[cursor])
+        move(to: history[cursor], recording: false)
     }
 
     func goForward() {
         guard canGoForward else { return }
         cursor += 1
-        step(to: history[cursor])
-    }
-
-    /// Back and forward land on record pages too, and they want what `open`
-    /// wants: the page ready before it is shown.
-    private func step(to page: Page) {
-        guard case .album(let id) = page else { return apply(page) }
-        Task {
-            await library.prepare(album: id)
-            apply(page)
-        }
+        move(to: history[cursor], recording: false)
     }
 
     /// Go to a page, recording it. The only way anything moves.
     func go(to next: Page) {
         guard next != current else { return }
-        apply(next)
+        move(to: next, recording: true)
+    }
+
+    /// Load the page, *then* move to it.
+    ///
+    /// Nothing draws until there is something to draw. Arriving first and
+    /// fetching afterwards means a frame of the word "Album" over an empty
+    /// list, and then the real page flickering in underneath it — the same
+    /// partial render a web page does, and it reads exactly as badly. These are
+    /// indexed queries answered in-process; there is no reason to show anybody
+    /// the gap.
+    ///
+    /// One task at a time, so a second click while the first page is still
+    /// being read wins: the older move is cancelled before it can apply, rather
+    /// than landing on top of the newer one.
+    private func move(to next: Page, recording: Bool) {
+        moving?.cancel()
+        moving = Task {
+            await Trace.region("click-to-page") {
+                let listing = await Trace.region("prepare") { await prepared(for: next) }
+                guard !Task.isCancelled else { return }
+                Trace.region("apply") {
+                    apply(next, showing: listing)
+                    if recording { record(next) }
+                }
+            }
+        }
+    }
+
+    /// Everything the page draws, in hand before it is shown. A listing when
+    /// the page is a section that has rows of its own; the pages about one
+    /// thing hold theirs on the model that read them.
+    private func prepared(for page: Page) async -> LibraryModel.Listing? {
+        switch page {
+        case .album(let id):
+            await library.prepare(album: id)
+            return nil
+        case .artist(let id):
+            await library.prepare(artist: id)
+            return nil
+        case .section(.playlist(let id)):
+            await playlists?.prepare(id: id)
+            return await library.prepare(section: .playlist(id))
+        case .section(let section):
+            return await library.prepare(section: section)
+        }
+    }
+
+    /// Record where we just went, the way a browser does.
+    private func record(_ next: Page) {
         // The cursor can already point here: `forget` prunes history without
         // moving the screen, and what follows is usually a move back onto the
         // entry it left the cursor on.
         guard history[cursor] != next else { return }
-        // A new move discards anything ahead, the way a browser does.
+        // A new move discards anything ahead.
         if cursor < history.count - 1 {
             history.removeSubrange((cursor + 1)...)
         }
@@ -175,13 +209,14 @@ final class Navigator {
         cursor = min(surviving, history.count - 1)
     }
 
-    private func apply(_ next: Page) {
+    /// The move itself: the page and the rows it draws, in one change. Two
+    /// changes would be two renders, and the first of them would be the page
+    /// without its rows.
+    private func apply(_ next: Page, showing listing: LibraryModel.Listing?) {
         current = next
-        // Only a section decides what the library loads; arriving at a record
+        // Only a section decides what the library shows; arriving at a record
         // is not a reason to throw away the filter behind it.
-        if let section = next.section, section != library.section {
-            library.showing(section)
-        }
+        if let listing { library.show(listing) }
     }
 
     // MARK: - Bindings

--- a/apps/macos/Sources/Koan/Support/PlayerModel.swift
+++ b/apps/macos/Sources/Koan/Support/PlayerModel.swift
@@ -470,10 +470,18 @@ final class PlayerModel {
     }
 
     /// Restore the queue from the last session without starting playback.
-    func restoreSession() {
-        let engine = self.engine
-        Task {
-            _ = try? await engine.restoreSession()
+    ///
+    /// Waited on rather than fired off: the first frame of the queue should be
+    /// the queue you left, not an empty list that fills in behind the window.
+    /// The engine says how many rows it restored and the player thread applies
+    /// them, so this holds until the mirror shows them — and never for long,
+    /// because a restore slow enough to notice is not a reason to keep the
+    /// window shut.
+    func restoreSession() async {
+        guard let restored = try? await engine.restoreSession(), restored > 0 else { return }
+        let deadline = ContinuousClock.now + .milliseconds(500)
+        while mirror.queue.count < Int(restored), ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(5))
         }
     }
 

--- a/apps/macos/Sources/Koan/Support/PlaylistsModel.swift
+++ b/apps/macos/Sources/Koan/Support/PlaylistsModel.swift
@@ -49,6 +49,9 @@ final class PlaylistsModel {
 
     /// Set by `AppState`, so a slow reload shows up alongside everything else.
     weak var activity: ActivityModel?
+    /// Set by `AppState`. Read for the library version a playlist's rows were
+    /// loaded at.
+    weak var mirror: EngineMirror?
     /// Somewhere to report a failure the user should see. Set by `AppState`.
     var report: ((String) -> Void)?
 
@@ -78,29 +81,36 @@ final class PlaylistsModel {
         }
     }
 
-    /// Open a playlist and load its rows. Asking for the one already open is
-    /// how a library change reaches this page — the rows are re-read without
-    /// blanking first, so nothing flashes empty for the length of a query.
-    func open(id: Int64) {
-        if openId != id {
-            openId = id
-            entries = []
-        }
-        reloadTracks()
+    /// Read a playlist's rows *before* the navigator moves to it.
+    ///
+    /// The record's shape — see `LibraryModel.prepare(album:)`. Rows and the
+    /// mosaic over them land as one value, so the page cannot draw its header
+    /// above an empty list. Asking again for the playlist already open is how a
+    /// library change reaches this page: free when nothing has moved under it,
+    /// and a re-read that replaces the rows in place rather than blanking them
+    /// when something has.
+    func prepare(id: Int64) async {
+        let stamp = mirror?.libraryVersion ?? 0
+        if openId == id, openStamp == stamp { return }
+
+        isLoading = true
+        let engine = self.engine
+        // Detached: awaiting the engine from the main actor means the answer
+        // waits for a main-actor slot behind whatever the mirror is applying.
+        let loaded = await Task.detached(priority: .userInitiated) {
+            async let rows = engine.playlistTracks(playlistId: id)
+            async let covers = engine.playlistCoverAlbumIds(playlistId: id)
+            return ((try? await rows) ?? [], (try? await covers) ?? [])
+        }.value
+        openId = id
+        openStamp = stamp
+        entries = loaded.0
+        covers[id] = loaded.1.map { .album($0) }
+        isLoading = false
     }
 
-    func reloadTracks() {
-        guard let id = openId else { return }
-        let engine = self.engine
-        isLoading = true
-        Task {
-            let rows = (try? await engine.playlistTracks(playlistId: id)) ?? []
-            // The page moved on while we were reading.
-            guard openId == id else { return }
-            entries = rows
-            isLoading = false
-        }
-    }
+    /// The library version the open playlist's rows were read at.
+    private var openStamp: UInt64?
 
     private func loadCovers(for id: Int64) async {
         let ids = (try? await engine.playlistCoverAlbumIds(playlistId: id)) ?? []
@@ -141,6 +151,7 @@ final class PlaylistsModel {
     func delete(id: Int64) {
         if openId == id {
             openId = nil
+            openStamp = nil
             entries = []
         }
         act { _ = try await $0.deletePlaylist(playlistId: id) }

--- a/apps/macos/Sources/Koan/Support/SearchModel.swift
+++ b/apps/macos/Sources/Koan/Support/SearchModel.swift
@@ -97,9 +97,10 @@ final class SearchModel {
             return
         }
 
+        // Where to put them back, captured now — the move itself waits for
+        // results, and by then this is no longer where they were.
         if nav.section != .searchResults {
             locationBeforeSearch = nav.current
-            nav.show(.searchResults)
         }
 
         isSearching = true
@@ -121,6 +122,11 @@ final class SearchModel {
             albums = found.1
             artists = found.2
             isSearching = false
+            // Moved once there is something to show. Navigating on the first
+            // keystroke put an empty results page up and filled it in a query
+            // later — the page you were on is a better thing to look at while
+            // the answer is being read than a page with nothing on it.
+            nav.show(.searchResults)
         }
     }
 

--- a/apps/macos/Sources/Koan/Views/ArtistBrowser.swift
+++ b/apps/macos/Sources/Koan/Views/ArtistBrowser.swift
@@ -96,11 +96,17 @@ struct ArtistDetailView: View {
     @Environment(Navigator.self) private var nav
     @Environment(PlayerModel.self) private var player
 
-    /// Fetched, not looked up: the browser holds the page it is showing, and
-    /// this artist may well not be on it.
-    @State private var artist: Artist?
-    @State private var albums: [Album] = []
-    @State private var similar: [SimilarArtist] = []
+    /// Whatever the navigator loaded before it brought us here, so the first
+    /// body evaluation already has the whole page. Guarded on the id because
+    /// history can move faster than a read.
+    private var record: LibraryModel.ArtistRecord? {
+        let held = library.detailArtist
+        return held?.artistId == artistId ? held : nil
+    }
+
+    private var artist: Artist? { record?.artist }
+    private var albums: [Album] { record?.albums ?? [] }
+    private var similar: [SimilarArtist] { record?.similar ?? [] }
 
     private let columns = [GridItem(.adaptive(minimum: 150, maximum: 210), spacing: 18)]
 
@@ -161,41 +167,8 @@ struct ArtistDetailView: View {
             }
             .padding(22)
         }
-        .reloading(on: artistId) { await load() }
-    }
-
-    /// Three independent reads, all at once and off the main actor.
-    ///
-    /// One after another they each waited on the one before for no reason, and
-    /// awaiting from a view callback means the *answer* waits for a main-actor
-    /// slot to be delivered — behind the state mirror's batch, which lands every
-    /// hundred milliseconds. Landed as one value, so the name cannot appear
-    /// ahead of the records.
-    private func load() async {
-        let engine = library.engine
-        let id = artistId
-        let loaded = await Task.detached(priority: .userInitiated) {
-            async let artist = try? await engine.artist(artistId: id)
-            async let albums = try? await engine.albums(
-                artistId: id, sort: .year, seed: 0, search: nil
-            )
-            async let similar = try? await engine.similarArtists(artistId: id)
-            return Loaded(
-                artist: await artist ?? nil,
-                albums: await albums ?? [],
-                similar: await similar ?? []
-            )
-        }.value
-        guard !Task.isCancelled else { return }
-        artist = loaded.artist
-        albums = loaded.albums
-        similar = loaded.similar
-    }
-
-    private struct Loaded: Sendable {
-        var artist: Artist?
-        var albums: [Album]
-        var similar: [SimilarArtist]
+        // Only for a library change — the artist arrived before the page did.
+        .reloading(on: artistId) { await library.prepare(artist: artistId) }
     }
 
     private func shufflePlay() {

--- a/apps/macos/Sources/Koan/Views/PlaylistView.swift
+++ b/apps/macos/Sources/Koan/Views/PlaylistView.swift
@@ -86,8 +86,9 @@ struct PlaylistView: View {
             playlists.add(dropped: dropped, to: playlistId)
             return true
         }
+        // Only for a library change — the rows arrived before the page did.
         .reloading(on: playlistId) {
-            playlists.open(id: playlistId)
+            await playlists.prepare(id: playlistId)
         }
         .onChange(of: playlistId) { selection = [] }
         .alert("Rename Playlist", isPresented: $renaming) {


### PR DESCRIPTION
Opening a record already loaded before it navigated. Every other page arrived empty and filled in a query later — an artist's records, a playlist's rows, favourites, history, search results, and the queue you left behind when koan reopened.

`Navigator` now loads whatever a page draws and only then moves to it, for every page rather than one of them. The move and the rows are one change: two changes are two renders, and the first of them is the page without its rows.

## The shape

- **A page about one thing** holds what it is about as one value, stamped with the library version it was read at — `LibraryModel.AlbumRecord` already did this, and `ArtistRecord` is the same thing for the artist page. The stamp is what makes asking again for the page on screen free, and asking after a scan a real read, so `.reloading(on:)` on each page still catches a download landing or a sync without re-reading what it already has.
- **A section** hands its rows to the navigator as a `Listing`, read with the filter it will arrive with. `LibraryModel.showing(_:)` is gone: the navigator adopts the section and its rows together instead of setting the section and letting a reload catch up.
- **Every read is detached.** Isolation is inherited by every suspension point, so awaiting the engine from a main-actor task means the *answer* queues for a main-actor slot behind whatever the mirror is applying. This is what the album path already did and why it is fast.
- **The queue** is restored before the window content exists rather than behind it: the engine says how many rows it restored and this waits, briefly and with a deadline, for the mirror to show them.
- **Search** stays where you are until there are results. Navigating on the first keystroke put an empty results page up and filled it in a query later.

## Load-then-move and the moves that race

One task at a time. A second click while the first page is still being read cancels the first, so the older move cannot land on top of the newer one — and Back/Forward go through the same path as a click, since they arrive at the same pages.

## Confirming it

Build and run: the pages to look at are an artist from the artist list, a playlist from the sidebar, favourites and history from a section switch, typing in the search field, and relaunching with a queue in place. None of them should show a heading over an empty list.

The measurement is the signposts: `click-to-page` around the whole move, `prepare` around the reads, `apply` around the change. `xcrun xctrace record --template 'SwiftUI' --attach koan-app` and read the Points of Interest track.

Closes #379

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WJ7RbCNdMXLKRRQA44Y6mn