### PR TITLE
fix(organize): refuse a destination that is nowhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 ### Fixed
 
+- **Organize no longer offers to move files into nowhere.** With no library folder configured the macOS sheet took the empty string as its destination, so every path the pattern produced was relative — and a relative path resolves against whatever directory the process happens to be sitting in, which for an app bundle is `/`. The preview was flawless: nothing occupied those destinations, so every file came back as a clean move. Pressing the button then failed on the first `mkdir` of every single file, and because a failed move comes back as a failed *row* rather than a thrown error, and the sheet re-read the library afterwards instead of reading its own result, the table came back identical and the button re-armed. It could be pressed all afternoon.
+
+  An empty destination is now refused where it is resolved, so the CLI and TUI get the same answer. The sheet says there is no library folder instead of drawing a plan, a move that fails is written to the log with its reason, and a run that fails keeps its own report — every row that did not make it says why, where its destination used to be.
+
 - **A track no longer leaves its album when its download finishes.** A track that streams starts on the partial tags symphonia can read, so when the file lands koan re-reads it properly and fills the queue item in. It filled in tracks that needed nothing — ones that came out of the library and already carried the record's own title. Where a file's tags disagree with the server's, and on a rip they often do, the item quietly changed album halfway down the queue and its record split in two: ten tracks under one heading, the one that had played under another. The file's word now only counts for a queue item with no library row behind it. Its duration still counts for everything, because that is the file's to know.
 
 ## v0.33.0 (2026-08-26)

--- a/apps/macos/Sources/Koan/Support/OrganizeModel.swift
+++ b/apps/macos/Sources/Koan/Support/OrganizeModel.swift
@@ -92,8 +92,16 @@ final class OrganizeModel {
         patternName = patterns.first(where: \.isDefault)?.name ?? patterns.first?.name
         draft = stored(patternName) ?? ""
         configuring = false
+        // Without a library folder the pattern's relative paths hang off
+        // nothing, and a preview of them would look entirely convincing right
+        // up to the point where every move fails. Say so instead.
+        guard hasDestination else { return }
         resolveSelection(trackIds: trackIds)
     }
+
+    /// Whether there is anywhere to move files *to*. A library folder is the
+    /// only thing that makes a destination out of a pattern.
+    var hasDestination: Bool { !baseDir.isEmpty }
 
     func dismiss() {
         subject = nil
@@ -242,6 +250,15 @@ final class OrganizeModel {
             guard requested == generation else { return }
             running = false
             switch result {
+            case .success(let report) where report.errorCount > 0:
+                // A move that fails comes back as a failed *row*, not a thrown
+                // error, so a run where nothing moved otherwise looks exactly
+                // like a run that never happened — press the button, see the
+                // same table, press it again. Keep the run's own plan: every
+                // row that didn't make it says why, where the destination was.
+                previewing = false
+                error = nil
+                self.plan = report
             case .success:
                 // Re-*resolve*, not just re-generate. The selection was read
                 // when the sheet opened and still holds the paths the files had

--- a/apps/macos/Sources/Koan/Views/OrganizeSheet.swift
+++ b/apps/macos/Sources/Koan/Views/OrganizeSheet.swift
@@ -119,7 +119,7 @@ struct OrganizeSheet: View {
 
                 // Destinations are relative to this, so it has to be visible
                 // even when there was nothing to choose.
-                Text("relative to \(organize.baseDir)")
+                Text(organize.hasDestination ? "relative to \(organize.baseDir)" : "no destination")
                 // An edited pattern previews and moves without being saved, so
                 // say which state you are looking at.
                 if organize.isModified {
@@ -142,7 +142,14 @@ struct OrganizeSheet: View {
 
     @ViewBuilder
     private var table: some View {
-        if let error = organize.error {
+        if !organize.hasDestination {
+            EmptyState(
+                icon: "folder.badge.questionmark",
+                title: "No library folder",
+                detail: "koan has nowhere to move these to. Add a folder in Settings › Library."
+            )
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if let error = organize.error {
             EmptyState(
                 icon: "exclamationmark.triangle",
                 title: "That pattern won't work",

--- a/crates/koan-core/src/organize.rs
+++ b/crates/koan-core/src/organize.rs
@@ -39,6 +39,8 @@ pub enum OrganizeError {
     Io(#[from] std::io::Error),
     #[error("no tracks with local paths found")]
     NoLocalTracks,
+    #[error("no destination folder: add a library folder, or pass --base-dir")]
+    NoDestination,
     #[error("no organize batches to undo")]
     NothingToUndo,
     #[error("destination already exists: {0}")]
@@ -793,6 +795,11 @@ fn run(
             Err(e) => Some(e.to_string()),
         };
         let Some(reason) = failure else { continue };
+        log::warn!(
+            "organize: {} → {} failed: {reason}",
+            file_move.from.display(),
+            file_move.to.display()
+        );
         if let Some(entry) = result.entries.iter_mut().find(|e| e.from == file_move.from) {
             entry.outcome = PlanOutcome::Error(reason);
         }
@@ -1442,20 +1449,29 @@ fn available_bytes(_path: &Path) -> Option<u64> {
     None
 }
 
+/// Where the pattern's relative paths hang off. `None` uses the first
+/// configured library folder.
+///
+/// An empty path is refused rather than accepted as "here". It makes every
+/// destination relative to the process's working directory — `/` for an app
+/// bundle — so the plan formats and previews perfectly and every single move
+/// then fails at `create_dir_all`.
 fn resolve_base_dir(base_dir: Option<&Path>) -> Result<PathBuf, OrganizeError> {
-    if let Some(dir) = base_dir {
-        return Ok(dir.to_path_buf());
+    let dir = match base_dir {
+        Some(dir) => dir.to_path_buf(),
+        None => crate::config::Config::load()
+            .map_err(|e| OrganizeError::Io(std::io::Error::other(e.to_string())))?
+            .library
+            .folders
+            .into_iter()
+            .find(|folder| !folder.as_os_str().is_empty())
+            .ok_or(OrganizeError::NoDestination)?,
+    };
+
+    if dir.as_os_str().is_empty() {
+        return Err(OrganizeError::NoDestination);
     }
-
-    // Use first configured library folder.
-    let config = crate::config::Config::load()
-        .map_err(|e| OrganizeError::Io(std::io::Error::other(e.to_string())))?;
-
-    config.library.folders.into_iter().next().ok_or_else(|| {
-        OrganizeError::Io(std::io::Error::other(
-            "no library folders configured; use --base-dir",
-        ))
-    })
+    Ok(dir)
 }
 
 /// Whether cover art and cue sheets travel with the music. A preference, so it
@@ -1846,6 +1862,22 @@ mod tests {
         assert_eq!(result.moved_count(), 0);
         assert_eq!(result.conflicts().count(), 1);
         assert_eq!(result.conflicts().next().unwrap().dest(), occupied);
+    }
+
+    /// A caller with no library folder configured passes an empty base dir.
+    /// Taken literally it means "relative to wherever this process happens to
+    /// be", which plans and previews cleanly and then fails on every file, so
+    /// it is refused before a plan exists to confirm.
+    #[test]
+    fn an_empty_base_dir_is_not_a_destination() {
+        let db = test_db();
+        add_track(&db, Path::new("/tmp/src/a.flac"), "Airbag", 1);
+
+        let err = preview(&db, "%title%", Some(Path::new("")), false).unwrap_err();
+        assert!(matches!(err, OrganizeError::NoDestination));
+
+        let err = execute(&db, "%title%", Some(Path::new(""))).unwrap_err();
+        assert!(matches!(err, OrganizeError::NoDestination));
     }
 
     /// Resolving once and generating many times must agree with planning from

--- a/docs/guide/file-organization.md
+++ b/docs/guide/file-organization.md
@@ -48,6 +48,8 @@ For example, with `folders = ["/Volumes/Music/library"]` and the `standard` patt
 /Volumes/Music/library/Aphex Twin/(1999) Windowlicker EP/01. Windowlicker.flac
 ```
 
+With no library folder configured there is nowhere to organize *into*, and koan says so rather than offering a plan — a pattern on its own produces a relative path, which is not a place.
+
 ## Configuring patterns
 
 The macOS app edits them in place: **Edit** next to the pattern picker turns it into a field, the preview follows what you type, and **Save** writes it back to `config.toml` under its name. A pattern you have edited but not saved still previews and still runs, so trying one out costs nothing.


### PR DESCRIPTION
Organize on macOS looked like it did nothing: the plan was perfect, the button moved no files, said nothing, and could be pressed again immediately.

## What went wrong

`library.folders` was empty, so the sheet's `folders.first ?? ""` made the destination the empty string. `resolve_base_dir` took that literally and every path the pattern produced was **relative** — resolved against the process's working directory, which for an app bundle is `/`.

The preview passes on a relative path: nothing occupies those destinations and `starts_with("")` is true for everything, so eleven clean moves. Executing fails on the first `create_dir_all` of every file, and:

- a failed move is demoted to a failed **row**, not thrown, so the FFI returns `Ok`
- `OrganizeModel.run()` discarded that result and re-read the library instead
- nothing on the failing path logged anything

so the table came back identical, the button re-armed, and `organize_log` stayed empty.

## What changed

- `resolve_base_dir` refuses an empty path (`OrganizeError::NoDestination`) and skips empty strings when falling back to configured folders — the CLI and TUI go through the same function, so they get the same answer.
- Failed moves are `log::warn!`ed with source, destination and reason.
- The sheet has `hasDestination`: with no library folder it declines to resolve or preview and says so, rather than drawing a convincing plan.
- A run that comes back with failed rows keeps **its own** plan instead of re-resolving, so each row shows its reason where the destination would have been.

## Verifying

- `an_empty_base_dir_is_not_a_destination` covers preview and execute.
- The silent-failure half is the interesting one to eyeball: with `folders = []` the sheet should now show "No library folder", and with a folder set it should move the files.
- `cargo test -p koan-core` (52 organize tests), `cargo clippy --workspace --all-targets -- -D warnings`, `just macos-build` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014aFsR3yPhbaAcoAuPUvxox