### PR TITLE
fix(macos): the transport stops at the lyrics panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### Fixed
 
+- **The transport no longer sits on the lyrics.** It floats over the window rather than inside the stage, and it already stepped aside for the sidebar — but not for the lyrics panel, so the last few lines of a song were behind the glass whenever the panel was open. The panel measures itself the way the sidebar does and the bar stops at its edge, tracking it as it is dragged.
+
 - **Organize no longer offers to move files into nowhere.** With no library folder configured the macOS sheet took the empty string as its destination, so every path the pattern produced was relative — and a relative path resolves against whatever directory the process happens to be sitting in, which for an app bundle is `/`. The preview was flawless: nothing occupied those destinations, so every file came back as a clean move. Pressing the button then failed on the first `mkdir` of every single file, and because a failed move comes back as a failed *row* rather than a thrown error, and the sheet re-read the library afterwards instead of reading its own result, the table came back identical and the button re-armed. It could be pressed all afternoon.
 
   An empty destination is now refused where it is resolved, so the CLI and TUI get the same answer. The sheet says there is no library folder instead of drawing a plan, a move that fails is written to the log with its reason, and a run that fails keeps its own report — every row that did not make it says why, where its destination used to be.

--- a/apps/macos/Sources/Koan/Support/UIState.swift
+++ b/apps/macos/Sources/Koan/Support/UIState.swift
@@ -26,6 +26,10 @@ final class UIState {
     /// only place a `NavigationStack` push cannot drop it — so it needs to know
     /// where the sidebar ends in order not to sit on it.
     var sidebarWidth: CGFloat = 0
+    /// How far in from the trailing edge the lyrics panel starts, for the same
+    /// reason — zero while it is closed. Floating over it would cut off the
+    /// last lines of a song, which is the part you are usually reading.
+    var lyricsWidth: CGFloat = 0
 
     /// Where the queue can be sent. Two ends and the row the music is on.
     enum Jump { case top, bottom, playing }

--- a/apps/macos/Sources/Koan/Views/LyricsPanel.swift
+++ b/apps/macos/Sources/Koan/Views/LyricsPanel.swift
@@ -9,6 +9,7 @@ struct LyricsPanel: View {
     @Environment(PlayerModel.self) private var player
     @Environment(EngineMirror.self) private var mirror
     @Environment(LibraryModel.self) private var library
+    @Environment(UIState.self) private var ui
 
     @State private var lyrics: Lyrics?
     @State private var loadedTrackId: Int64?
@@ -37,6 +38,8 @@ struct LyricsPanel: View {
         }
         .background(.background.secondary)
         .task(id: player.currentTrackId) { await load() }
+        .onGeometryChange(for: CGFloat.self) { $0.size.width } action: { ui.lyricsWidth = $0 }
+        .onDisappear { ui.lyricsWidth = 0 }
     }
 
     @ViewBuilder

--- a/apps/macos/Sources/Koan/Views/RootView.swift
+++ b/apps/macos/Sources/Koan/Views/RootView.swift
@@ -173,11 +173,13 @@ struct RootView: View {
         .onChange(of: search.query) { _, _ in search.schedule() }
         .onSubmit(of: .search) { handleSubmit() }
         // On the window rather than inside the detail column, padded clear of
-        // the sidebar: glass floating on glass reads as neither. The page makes
-        // its own room with `clearsTransport`.
+        // both columns: glass floating on glass reads as neither, and over the
+        // lyrics it hides the last lines of the song. The page makes its own
+        // room with `clearsTransport`.
         .overlay(alignment: .bottom) {
             TransportBar()
                 .padding(.leading, columns == .detailOnly ? 0 : ui.sidebarWidth)
+                .padding(.trailing, showLyrics ? ui.lyricsWidth : 0)
                 .background(
                     GeometryReader { proxy in
                         Color.clear.preference(


### PR DESCRIPTION
The transport bar floats over the *window* rather than inside the detail column — the only place a page change can't drop it. It insets by the sidebar's measured width so it doesn't sit on it, but nothing did the same for the inspector, so with lyrics open the bar covered the last few lines of the song.

`LyricsPanel` now measures its own width into `UIState.lyricsWidth` the way `SidebarView` does, and the transport pads trailing by it while the panel is shown. Measured rather than a constant, so it tracks the inspector across its 260–460 drag range and follows it back to zero when closed.

## Verifying

Open lyrics (⌥⌘L) on a track with a long synced set and scroll to the end — the final lines clear the bar. Drag the inspector divider; the bar's trailing edge follows. Close it and the bar returns to full width. Collapsing the sidebar still works as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CEYdq4rv7ZRH41TcVQZPu3