### PR TITLE
release: v0.33.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Changelog
 
-## Unreleased
+## v0.33.1 (2026-08-28)
+
+### Added
+
+- **A graphics step below Plain.** The setting reached koan's own chrome and nothing else: the toolbar floated over live content and the transport kept its soft scroll edge at every step, including the one whose description says it is "the only step that stands the glass down". `Bare` stands both down — an opaque toolbar ground and a hard scroll edge. Measured no faster on an M1 Pro, and it is here because what the setting said and what it did disagreed, not as a speed-up.
 
 ### Changed
+
+- **A record opens in one commit rather than three.** The page was one; the wash was a second and the tint a third, both landing after it because both were held in view state written by a task, which cannot run until the body already has. The tint's was the worse of the two — it eased over two seconds, and a tint is a value every control reads rather than a property of a layer, so that is a hundred and twenty renders of the whole window for one colour. Both are read straight through the artwork cache now, the way a cover has been read since koan#284, so a colour and a sleeve the app already holds land in the same frame as the record that wanted them. Tap to first frame goes from 144–432ms to 101–208ms on a large library, and the spread goes with it — much of what looked like a slow database was the read's answer queued behind that animation.
 
 - **Opening a record says how long it took.** A signpost in a view says when SwiftUI worked out what to draw, which on this gesture is a few milliseconds and nowhere near when you see anything — layout, the CoreAnimation commit and the render server all come after the last line any view gets to run. `FrameTimer` times the tap against the display link instead, and reports the body, the frame that could carry it, and every stall after that. See CONTRIBUTING.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2483,7 +2483,7 @@ dependencies = [
 
 [[package]]
 name = "koan-cli"
-version = "0.33.0"
+version = "0.33.1"
 dependencies = [
  "chrono",
  "clap",
@@ -2507,7 +2507,7 @@ dependencies = [
 
 [[package]]
 name = "koan-core"
-version = "0.33.0"
+version = "0.33.1"
 dependencies = [
  "argon2",
  "bliss-audio",
@@ -2549,7 +2549,7 @@ dependencies = [
 
 [[package]]
 name = "koan-ffi"
-version = "0.33.0"
+version = "0.33.1"
 dependencies = [
  "chrono",
  "crossbeam-channel",
@@ -2569,7 +2569,7 @@ dependencies = [
 
 [[package]]
 name = "koan-server"
-version = "0.33.0"
+version = "0.33.1"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",
@@ -2602,7 +2602,7 @@ dependencies = [
 
 [[package]]
 name = "koan-tui"
-version = "0.33.0"
+version = "0.33.1"
 dependencies = [
  "core-foundation 0.10.1",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/koan-core", "crates/koan-ffi", "crates/koan-server", "crates/koan-tui", "crates/koan-cli"]
 
 [workspace.package]
-version = "0.33.0"
+version = "0.33.1"
 edition = "2024"
 rust-version = "1.89"
 homepage = "https://github.com/radiosilence/koan"
@@ -13,9 +13,9 @@ license = "MIT"
 [workspace.dependencies]
 # Internal crates. Keep the version in step with [workspace.package] above —
 # a stale pin here publishes members that resolve against the wrong sibling.
-koan-core = { path = "crates/koan-core", version = "0.33.0" }
-koan-server = { path = "crates/koan-server", version = "0.33.0" }
-koan-tui = { path = "crates/koan-tui", version = "0.33.0" }
+koan-core = { path = "crates/koan-core", version = "0.33.1" }
+koan-server = { path = "crates/koan-server", version = "0.33.1" }
+koan-tui = { path = "crates/koan-tui", version = "0.33.1" }
 # Feature set is the union every member needs; `default-tls` is an alias for
 # `rustls`, so there is exactly one TLS stack.
 reqwest = { version = "0.13", default-features = false, features = [


### PR DESCRIPTION
Patch release. Version bumped across the workspace, `Cargo.lock` refreshed, changelog dated.

Everything merged since v0.33.0 — #374 through #389, plus #388 today.

## Changelog

### Added

- **A graphics step below Plain.** The setting reached koan's own chrome and nothing else: the toolbar floated over live content and the transport kept its soft scroll edge at every step, including the one whose description says it is "the only step that stands the glass down". `Bare` stands both down — an opaque toolbar ground and a hard scroll edge. Measured no faster on an M1 Pro, and it is here because what the setting said and what it did disagreed, not as a speed-up.

### Changed

- **A record opens in one commit rather than three.** The page was one; the wash was a second and the tint a third, both landing after it because both were held in view state written by a task, which cannot run until the body already has. The tint's was the worse of the two — it eased over two seconds, and a tint is a value every control reads rather than a property of a layer, so that is a hundred and twenty renders of the whole window for one colour. Both are read straight through the artwork cache now, the way a cover has been read since koan#284, so a colour and a sleeve the app already holds land in the same frame as the record that wanted them. Tap to first frame goes from 144–432ms to 101–208ms on a large library, and the spread goes with it — much of what looked like a slow database was the read's answer queued behind that animation.

- **Opening a record says how long it took.** A signpost in a view says when SwiftUI worked out what to draw, which on this gesture is a few milliseconds and nowhere near when you see anything — layout, the CoreAnimation commit and the render server all come after the last line any view gets to run. `FrameTimer` times the tap against the display link instead, and reports the body, the frame that could carry it, and every stall after that. See CONTRIBUTING.

- **Every page arrives complete.** A record already loaded before it navigated; everywhere else arrived empty and filled in a query later — an artist's records, a playlist's rows, favourites, history, search results, and the queue you left behind when koan reopened. `Navigator` now loads whatever a page draws and only then moves to it, so the first frame of a page is the finished page. There is no partial render to see and no second render a frame later putting the rows under a heading that was already up.

  A page about one thing holds what it is about as one value, read whole and stamped with the library version it was read at — so asking again for the page on screen costs nothing, and asking after a scan is a real read. Sections hand their rows to the navigator, which adopts the page and its rows in one change rather than two. Typing in the search field no longer jumps to an empty results page on the first keystroke: it stays where you are until there is something to show.

- **A browse listing is only redrawn when it has actually changed.** Albums, artists, favourites and history are each read whole and handed to SwiftUI whole — 5,610 records and 7,138 artists on a large library — and assigning that array again is a mutation whether or not a single row moved, so the grid was diffed end to end, laid out and committed for it. It was assigned again on every library version bump, which is every download landing and every playlist edit, and on every return to a section already visited. The rows are now compared before they are published, and the same answer as last time is dropped. The favourite id sets get the same treatment, for the sharper version of the same problem: every cell and every row reads them to draw its heart.

  Nothing about how a listing is read has changed. It still arrives whole, so the scrollbar still tells the truth about how long the library is and one flick still reaches the end of it.

- **A track row no longer copies the whole track list to itself.** Each row carries the ids of the list it belongs to, so playing it keeps the rest queued behind it — and that list was rebuilt inside the row's own body, once per row. It is built once per pass now.

### Fixed

- **The room changes colour by fading again, not by cutting.** The wash installs a two second dissolve when the record changes, and the drift installs itself by clearing every animation on the same layers first — which took the dissolve with it. The drift is reinstalled from `layout()`, which a page switch triggers, so the fade was wiped a frame or two after it started and the new cover snapped in. The drift is removed by name now, and leaves alone what it did not put there.

- **Back moves on the first press.** The cursor stepped on the click and left the page to catch up, so pressing Back while a record was still being read cancelled that record — which then never applied and never recorded — and stepped off a page nobody had arrived at. The screen stayed where it was and it took a second press to go anywhere. Where you are now changes beside the page rather than ahead of it.

- **The transport no longer sits on the lyrics.** It floats over the window rather than inside the stage, and it already stepped aside for the sidebar — but not for the lyrics panel, so the last few lines of a song were behind the glass whenever the panel was open. The panel measures itself the way the sidebar does and the bar stops at its edge, tracking it as it is dragged.

- **Organize no longer offers to move files into nowhere.** With no library folder configured the macOS sheet took the empty string as its destination, so every path the pattern produced was relative — and a relative path resolves against whatever directory the process happens to be sitting in, which for an app bundle is `/`. The preview was flawless: nothing occupied those destinations, so every file came back as a clean move. Pressing the button then failed on the first `mkdir` of every single file, and because a failed move comes back as a failed *row* rather than a thrown error, and the sheet re-read the library afterwards instead of reading its own result, the table came back identical and the button re-armed. It could be pressed all afternoon.

  An empty destination is now refused where it is resolved, so the CLI and TUI get the same answer. The sheet says there is no library folder instead of drawing a plan, a move that fails is written to the log with its reason, and a run that fails keeps its own report — every row that did not make it says why, where its destination used to be.

- **A track no longer leaves its album when its download finishes.** A track that streams starts on the partial tags symphonia can read, so when the file lands koan re-reads it properly and fills the queue item in. It filled in tracks that needed nothing — ones that came out of the library and already carried the record's own title. Where a file's tags disagree with the server's, and on a rip they often do, the item quietly changed album halfway down the queue and its record split in two: ten tracks under one heading, the one that had played under another. The file's word now only counts for a queue item with no library row behind it. Its duration still counts for everything, because that is the file's to know.

## Verifying

`just check` is green (989 tests, clippy clean) and `just macos-build` builds. The diff is three files: `CHANGELOG.md`, `Cargo.toml`, `Cargo.lock`.

No tag is created here — that is yours to cut once this is on main.
