### PR TITLE
fix(macos): the playing indicator is a spectrum, at the display's rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- **The playing indicator stops lying about silence.** The bars ran their full dance through a track's silent opening, because the analyser reporting zeros was read as "nothing to go on yet" — which is what a track still buffering looks like too, and dancing was the safer guess for that one. The play head tells the two apart: it advances only as audio leaves the engine, so once it moves the analyser is believed, silence included, and the bars settle onto their resting heights until there is something to move them. Until it moves they run the plain carrier, as before.
+
+  They also react on the frame the music does. The analyser's own bars rise instantly and fall on a 50ms half-life; the indicator was smoothing that a second time over a third of a second, which is what made a beat land visibly late.
+
 ## v0.33.1 (2026-08-28)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## Unreleased
 
-### Fixed
+### Changed
 
-- **The playing indicator stops lying about silence.** The bars ran their full dance through a track's silent opening, because the analyser reporting zeros was read as "nothing to go on yet" — which is what a track still buffering looks like too, and dancing was the safer guess for that one. The play head tells the two apart: it advances only as audio leaves the engine, so once it moves the analyser is believed, silence included, and the bars settle onto their resting heights until there is something to move them. Until it moves they run the plain carrier, as before.
+- **The playing indicator is a spectrum analyser, three columns wide.** It was a pair of sine waves the music modulated — the bands set how far the bars swung, never how high they stood — which meant a track that opens on ten seconds of silence got the full dance, because a carrier with nothing to scale it is still a carrier. The bars are the low, mid and high bands now, drawn at the height the analyser reports. Silence is flat.
 
-  They also react on the frame the music does. The analyser's own bars rise instantly and fall on a 50ms half-life; the indicator was smoothing that a second time over a third of a second, which is what made a beat land visibly late.
+  Bands are still measured against their own recent ceiling, so a quiet master is not a limp indicator, and the fall is the law the TUI's spectrum draws on: up on the frame it happens, down on a 150ms half-life. Reduce Motion and the bottom of the graphics ladder still get three still bars, and pausing still freezes them where they stand.
 
 ## v0.33.1 (2026-08-28)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,11 @@
 
 ### Changed
 
-- **The playing indicator is a spectrum analyser, three columns wide.** It was a pair of sine waves the music modulated — the bands set how far the bars swung, never how high they stood — which meant a track that opens on ten seconds of silence got the full dance, because a carrier with nothing to scale it is still a carrier. The bars are the low, mid and high bands now, drawn at the height the analyser reports. Silence is flat.
+- **The playing indicator is a spectrum analyser, three columns wide.** It was a pair of sine waves the music modulated — the bands set how far the bars swung, never how high they stood — which meant a track that opens on ten seconds of silence got the full dance, because a carrier with nothing to scale it is still a carrier. The bars are the low, mid and high bands now, drawn at the height the analyser reports. Silence is flat. Pausing lets them fall away rather than freezing them mid-swing, which is what the TUI's spectrum has always done.
 
-  Bands are still measured against their own recent ceiling, so a quiet master is not a limp indicator, and the fall is the law the TUI's spectrum draws on: up on the frame it happens, down on a 150ms half-life. Reduce Motion and the bottom of the graphics ladder still get three still bars, and pausing still freezes them where they stand.
+  Bands are still measured against their own recent ceiling, so a quiet master is not a limp indicator, and the fall is the law the TUI's bars draw on: up on the frame it happens, down on a half-life so nothing snaps to zero between beats.
 
-- **A clean security audit no longer reports itself as a failed build.** The audit job reports through a GitHub check run, which is an API write, and this repository hands workflows a read-only token by default — so the job found nothing, tried to say so, and failed with "Resource not accessible by integration" on every push to main. It asks for the one permission it needs now.
-
-- **Dependencies refreshed.** Seventeen packages moved to their latest compatible release — `h2`, `hyper`, `flate2`, `log`, `uuid`, `rand` and the rest — with no version requirement changed and nothing to see from outside.
-
-- **`chacha20` moves off a yanked release.** 0.10.0 and 0.10.1 called an SSE4.1 intrinsic from inside the SSE2 backend, so on an x86 processor with SSE2 and not SSE4.1 the instruction is illegal and the process dies. Upstream yanked both and shipped 0.10.2. Not a weakness in the cipher — a crash, and only on hardware old enough to matter to the Linux builds.
+- **The analyser runs at the refresh rate of the display it is drawn on.** Its rate was a config figure and the macOS indicator sampled it on a timer of its own, so a 120Hz panel got 60 analyses drawn at 30, and two clocks decided between them which frames a bar was allowed to move on. The window knows what it is drawn on: koan sets the rate from the screen the window is on and again when it is dragged to another one or a display is reconfigured under it. The indicators read on the frame they draw, so a frame is one new set of numbers and there is no timer anywhere in it — nothing on screen means nothing read, and the analyser stands itself down a second later. The TUI is unchanged: its rate is still `visualizer.fps`, which is what the analyser starts at.
 
 ## v0.33.1 (2026-08-28)
 

--- a/apps/macos/Sources/Koan/KoanApp.swift
+++ b/apps/macos/Sources/Koan/KoanApp.swift
@@ -47,7 +47,7 @@ final class AppState {
         self.playlists = playlists
         let activity = ActivityModel()
         self.activity = activity
-        self.levels = PlayingLevels(engine: engine, mirror: mirror)
+        self.levels = PlayingLevels(engine: engine)
         library.activity = activity
         library.art = art
         library.mirror = mirror

--- a/apps/macos/Sources/Koan/KoanApp.swift
+++ b/apps/macos/Sources/Koan/KoanApp.swift
@@ -47,7 +47,7 @@ final class AppState {
         self.playlists = playlists
         let activity = ActivityModel()
         self.activity = activity
-        self.levels = PlayingLevels(engine: engine)
+        self.levels = PlayingLevels(engine: engine, mirror: mirror)
         library.activity = activity
         library.art = art
         library.mirror = mirror

--- a/apps/macos/Sources/Koan/Support/PlayingLevels.swift
+++ b/apps/macos/Sources/Koan/Support/PlayingLevels.swift
@@ -15,24 +15,15 @@ import KoanFFI
 @Observable
 final class PlayingLevels {
     private let engine: KoanEngine
-    private let mirror: EngineMirror
 
-    /// How far each bar should swing from where it rests, 0...1, low band to
-    /// high. The music sets this and nothing else — it never reaches a height
-    /// directly, so there is no path from a transient to a jump.
-    @ObservationIgnored private(set) var travel = idle
-
-    /// The carrier's phase at `stamp`, and how fast it is advancing. Read it
-    /// through `phase(at:)` rather than directly: a frame and a poll are on
-    /// separate clocks even at the same nominal rate, and winding the phase on
-    /// to the moment being drawn keeps the motion continuous rather than
-    /// stepped at whatever rate the frames actually arrive.
-    @ObservationIgnored private var phase = 0.0
-    @ObservationIgnored private var stamp = Date().timeIntervalSinceReferenceDate
-    @ObservationIgnored private var rate = 1.0
+    /// How high each bar stands, 0...1, low band to high. The spectrum, in
+    /// three columns: what the analyser says is coming out of the speakers and
+    /// nothing else. Silence is zero and reads flat.
+    @ObservationIgnored private(set) var bands = [0.0, 0.0, 0.0]
 
     private var watchers = 0
     private var poll: Task<Void, Never>?
+    private var stamp = Date().timeIntervalSinceReferenceDate
 
     /// The loudest each band has been lately. Each band is judged against its
     /// own recent range rather than against full scale, which is what stops a
@@ -41,49 +32,22 @@ final class PlayingLevels {
     /// leaves the bass bar permanently the sluggish one.
     private var ceiling = [quietest, quietest, quietest]
 
-    /// Where the play head was last look, and when it last moved.
-    ///
-    /// Silence and a stall reach the analyser as the same thing — zeros — and
-    /// they mean opposite things: a track still buffering has nothing to say
-    /// yet, while a track that opens on ten seconds of silence is saying it.
-    /// The play head advances only as audio leaves the engine, so it is what
-    /// tells the two apart. Until it moves the bars run the plain carrier;
-    /// once it does, the analyser is believed, silence included.
-    private var seen: UInt64 = 0
-    private var movedAt = 0.0
-
-    /// Full travel — the motion the bars had before any of this. Where they go
-    /// when there is nothing to go on.
-    private static let idle = [1.0, 1.0, 1.0]
-    /// A band below this is room tone, and never sets a ceiling.
+    /// A band below this is room tone, and never sets a ceiling. It is also
+    /// what a silent passage is measured against, so silence stays flat rather
+    /// than being normalised back up into a dance.
     private static let quietest = 0.12
     /// How long a band takes to fall away. Rises are not damped at all: this
     /// is the law the TUI's spectrum runs on — up on the frame it happens,
-    /// down on a half-life so nothing snaps to zero between beats. The
-    /// analyser has already smoothed the bars at 50ms, and a second slow
-    /// filter here only made the indicator late to its own music.
+    /// down on a half-life so nothing snaps to zero between beats.
     private static let release = 0.15
     /// How long a band takes to forget a loud passage.
     private static let forget = 4.0
-    /// How long the play head may sit still before it counts as stalled. The
-    /// engine publishes it ten times a second, so a couple of missed updates
-    /// are ordinary and only a real stall lasts past this.
-    private static let stall = 0.5
-    /// How much of the bars' rate the music gets to move.
-    private static let rateSwing = 0.4
     /// How often the levels are resampled — and, since new numbers are the
     /// only reason to redraw, the rate the indicators run at too.
     static let interval = 1.0 / 30.0
 
-    init(engine: KoanEngine, mirror: EngineMirror) {
+    init(engine: KoanEngine) {
         self.engine = engine
-        self.mirror = mirror
-    }
-
-    /// The carrier's phase now, wound on from the last sample at the rate the
-    /// music last set.
-    func phase(at now: TimeInterval) -> Double {
-        phase + (now - stamp) * rate
     }
 
     func watch() {
@@ -98,10 +62,6 @@ final class PlayingLevels {
 
     private func start() {
         stamp = Date().timeIntervalSinceReferenceDate
-        // Where the play head stands, not that it has moved: a track that is
-        // still buffering when the first indicator appears has told us nothing.
-        seen = mirror.positionMs
-        movedAt = 0
         poll = Task { [weak self] in
             while !Task.isCancelled {
                 try? await Task.sleep(for: .seconds(Self.interval))
@@ -114,49 +74,27 @@ final class PlayingLevels {
     private func stop() {
         poll?.cancel()
         poll = nil
-        // Travel is left where it stands: the bars freeze mid-swing when the
-        // transport stops, and a redraw while paused should not move them.
+        // The bars are left where they stand: they freeze at their last
+        // heights when the transport pauses, and a redraw while paused should
+        // not move them.
     }
 
     private func sample() {
         let now = Date().timeIntervalSinceReferenceDate
         // Clamped: a machine that slept owes the bars nothing.
         let elapsed = min(max(now - stamp, 0), 0.25)
-        let wound = phase(at: now)
-        let position = mirror.positionMs
-        if position != seen {
-            seen = position
-            movedAt = now
-        }
+        stamp = now
+
         let frame = engine.vizLevels()
-        let bands = [Double(frame.low), Double(frame.mid), Double(frame.high)]
-
-        defer {
-            phase = wound
-            stamp = now
-        }
-
-        guard now - movedAt < Self.stall else {
-            travel = Self.idle
-            rate = 1
-            return
-        }
-
+        let levels = [Double(frame.low), Double(frame.mid), Double(frame.high)]
         let hold = Self.remaining(halfLife: Self.forget, over: elapsed)
-        var next = travel
-        for band in bands.indices {
-            ceiling[band] = max(bands[band], max(ceiling[band] * hold, Self.quietest))
-            // Silence is a level like any other: the bars settle onto their
-            // resting heights and stay there until there is something to move
-            // them. Still bars on a playing row are the truth, and the row is
-            // still legible as the one playing — three bars at three heights.
-            let target = min(bands[band] / ceiling[band], 1)
-            let fallen = travel[band] * Self.remaining(halfLife: Self.release, over: elapsed)
-            next[band] = max(target, fallen)
-        }
-        travel = next
+        let fall = Self.remaining(halfLife: Self.release, over: elapsed)
 
-        rate = 1 + Self.rateSwing * next.reduce(0, +) / Double(next.count)
+        for band in levels.indices {
+            ceiling[band] = max(levels[band], max(ceiling[band] * hold, Self.quietest))
+            let level = min(levels[band] / ceiling[band], 1)
+            bands[band] = max(level, bands[band] * fall)
+        }
     }
 
     /// What is left of a distance after `elapsed` at the given half-life.

--- a/apps/macos/Sources/Koan/Support/PlayingLevels.swift
+++ b/apps/macos/Sources/Koan/Support/PlayingLevels.swift
@@ -1,36 +1,44 @@
+import AppKit
 import Foundation
 import KoanFFI
 
 /// The audio behind the playing indicators.
 ///
 /// One source for the whole app: the queue and a track list can both have a
-/// current row on screen, and they are watching the same music. Views take a
-/// subscription while they need one, so with nothing on screen — or nothing
-/// playing — nothing runs.
+/// current row on screen, and they are watching the same music. There is no
+/// timer here and nothing polls — an indicator asks for the bands as it draws
+/// a frame, and the first to ask on a given frame is the one that reads the
+/// analyser. Nothing on screen means nothing read, and the analyser stands
+/// itself down a second after the last read.
 ///
-/// Nothing here is observed. These values move thirty times a second and an
-/// observer would re-render at that rate; the indicators redraw off their own
-/// display-linked timeline and read this when they do.
+/// The bands themselves are not observed. They move at the refresh rate of the
+/// display and an observer would invalidate a view for each one; the
+/// indicators redraw off their own display-linked timeline and take the value
+/// as they go. `settled` is observed, because it is the one thing a view has
+/// to be told rather than ask: it is what stops the timeline.
 @MainActor
 @Observable
 final class PlayingLevels {
     private let engine: KoanEngine
 
-    /// How high each bar stands, 0...1, low band to high. The spectrum, in
-    /// three columns: what the analyser says is coming out of the speakers and
-    /// nothing else. Silence is zero and reads flat.
+    /// How high each bar stands, 0...1, low band to high. The spectrum in
+    /// three columns: what the analyser says is coming out of the speakers,
+    /// and nothing else. Silence is zero and reads flat.
     @ObservationIgnored private(set) var bands = [0.0, 0.0, 0.0]
 
-    private var watchers = 0
-    private var poll: Task<Void, Never>?
-    private var stamp = Date().timeIntervalSinceReferenceDate
+    /// Whether the bars have come to rest with nothing playing. False while
+    /// they still have somewhere to fall, which is what keeps the timeline
+    /// ticking through the decay after a pause and stops it after.
+    private(set) var settled = true
+
+    @ObservationIgnored private var stamp = 0.0
 
     /// The loudest each band has been lately. Each band is judged against its
     /// own recent range rather than against full scale, which is what stops a
     /// track mastered quiet getting a limper indicator than a loud one — and
     /// incidentally undoes the analyser's A-weighting tilt, which otherwise
     /// leaves the bass bar permanently the sluggish one.
-    private var ceiling = [quietest, quietest, quietest]
+    @ObservationIgnored private var ceiling = [quietest, quietest, quietest]
 
     /// A band below this is room tone, and never sets a ceiling. It is also
     /// what a silent passage is measured against, so silence stays flat rather
@@ -42,59 +50,77 @@ final class PlayingLevels {
     private static let release = 0.15
     /// How long a band takes to forget a loud passage.
     private static let forget = 4.0
-    /// How often the levels are resampled — and, since new numbers are the
-    /// only reason to redraw, the rate the indicators run at too.
-    static let interval = 1.0 / 30.0
+    /// Below a tenth of a point of bar there is nothing left to draw.
+    private static let flat = 0.01
 
     init(engine: KoanEngine) {
         self.engine = engine
-    }
-
-    func watch() {
-        watchers += 1
-        if watchers == 1 { start() }
-    }
-
-    func unwatch() {
-        watchers -= 1
-        if watchers == 0 { stop() }
-    }
-
-    private func start() {
-        stamp = Date().timeIntervalSinceReferenceDate
-        poll = Task { [weak self] in
-            while !Task.isCancelled {
-                try? await Task.sleep(for: .seconds(Self.interval))
-                guard let self else { return }
-                sample()
+        // The rate the analyser should run at is the refresh rate of the
+        // display it is drawn on, which changes when the window is dragged to
+        // another screen and when a screen is reconfigured under it.
+        for name in [
+            NSWindow.didChangeScreenNotification,
+            NSWindow.didBecomeKeyNotification,
+            NSApplication.didChangeScreenParametersNotification,
+        ] {
+            NotificationCenter.default.addObserver(
+                forName: name, object: nil, queue: .main
+            ) { [weak self] _ in
+                MainActor.assumeIsolated { self?.matchDisplay() }
             }
         }
+        matchDisplay()
     }
 
-    private func stop() {
-        poll?.cancel()
-        poll = nil
-        // The bars are left where they stand: they freeze at their last
-        // heights when the transport pauses, and a redraw while paused should
-        // not move them.
-    }
-
-    private func sample() {
-        let now = Date().timeIntervalSinceReferenceDate
+    /// The bands as of `now`, brought forward from the last frame that asked.
+    ///
+    /// Every indicator on screen calls this on every frame it draws and the
+    /// first one does the work: the rest are the same frame, and a spectrum
+    /// sampled twice in one frame would be two different answers to the same
+    /// question.
+    func bands(at now: TimeInterval, playing: Bool) -> [Double] {
+        guard now > stamp else { return bands }
         // Clamped: a machine that slept owes the bars nothing.
-        let elapsed = min(max(now - stamp, 0), 0.25)
+        let elapsed = min(now - stamp, 0.25)
         stamp = now
-
-        let frame = engine.vizLevels()
-        let levels = [Double(frame.low), Double(frame.mid), Double(frame.high)]
-        let hold = Self.remaining(halfLife: Self.forget, over: elapsed)
         let fall = Self.remaining(halfLife: Self.release, over: elapsed)
 
+        guard playing else {
+            // Nothing is coming out of the speakers, so nothing is read: the
+            // bars fall away on their own and the analyser, with no reader,
+            // stands down while they do.
+            for band in bands.indices { bands[band] *= fall }
+            if bands.allSatisfy({ $0 < Self.flat }) {
+                bands = [0, 0, 0]
+                rest(true)
+            }
+            return bands
+        }
+
+        rest(false)
+        let hold = Self.remaining(halfLife: Self.forget, over: elapsed)
+        let frame = engine.vizLevels()
+        let levels = [Double(frame.low), Double(frame.mid), Double(frame.high)]
         for band in levels.indices {
             ceiling[band] = max(levels[band], max(ceiling[band] * hold, Self.quietest))
             let level = min(levels[band] / ceiling[band], 1)
             bands[band] = max(level, bands[band] * fall)
         }
+        return bands
+    }
+
+    /// Flip the one observed property from outside the body that noticed. It
+    /// changes twice a pause rather than once a frame, and a view is midway
+    /// through drawing when the change is spotted.
+    private func rest(_ value: Bool) {
+        guard settled != value else { return }
+        Task { @MainActor in self.settled = value }
+    }
+
+    private func matchDisplay() {
+        let main = NSApp.windows.first { $0.identifier?.rawValue == MainWindow.id }
+        let screen = main?.screen ?? NSApp.keyWindow?.screen ?? NSScreen.main
+        engine.setVizFps(fps: UInt8(clamping: screen?.maximumFramesPerSecond ?? 60))
     }
 
     /// What is left of a distance after `elapsed` at the given half-life.

--- a/apps/macos/Sources/Koan/Support/PlayingLevels.swift
+++ b/apps/macos/Sources/Koan/Support/PlayingLevels.swift
@@ -15,6 +15,7 @@ import KoanFFI
 @Observable
 final class PlayingLevels {
     private let engine: KoanEngine
+    private let mirror: EngineMirror
 
     /// How far each bar should swing from where it rests, 0...1, low band to
     /// high. The music sets this and nothing else — it never reaches a height
@@ -40,32 +41,43 @@ final class PlayingLevels {
     /// leaves the bass bar permanently the sluggish one.
     private var ceiling = [quietest, quietest, quietest]
 
-    /// Set once the analyser has shown us any audio at all. Until then the bars
-    /// run the plain carrier: a track still buffering is not a quiet one.
-    private var heard = false
+    /// Where the play head was last look, and when it last moved.
+    ///
+    /// Silence and a stall reach the analyser as the same thing — zeros — and
+    /// they mean opposite things: a track still buffering has nothing to say
+    /// yet, while a track that opens on ten seconds of silence is saying it.
+    /// The play head advances only as audio leaves the engine, so it is what
+    /// tells the two apart. Until it moves the bars run the plain carrier;
+    /// once it does, the analyser is believed, silence included.
+    private var seen: UInt64 = 0
+    private var movedAt = 0.0
 
     /// Full travel — the motion the bars had before any of this. Where they go
     /// when there is nothing to go on.
     private static let idle = [1.0, 1.0, 1.0]
     /// A band below this is room tone, and never sets a ceiling.
     private static let quietest = 0.12
-    /// Fast up so a transient lands, slow down so nothing snaps to zero between
-    /// beats. Sluggish and legible beats accurate and spiky at eleven points.
-    private static let attack = 0.05
-    private static let release = 0.35
+    /// How long a band takes to fall away. Rises are not damped at all: this
+    /// is the law the TUI's spectrum runs on — up on the frame it happens,
+    /// down on a half-life so nothing snaps to zero between beats. The
+    /// analyser has already smoothed the bars at 50ms, and a second slow
+    /// filter here only made the indicator late to its own music.
+    private static let release = 0.15
     /// How long a band takes to forget a loud passage.
     private static let forget = 4.0
-    /// The least the bars ever move. A state marker first: whatever the music
-    /// is doing, the row that is playing has to still say so at a glance.
-    private static let floor = 0.3
+    /// How long the play head may sit still before it counts as stalled. The
+    /// engine publishes it ten times a second, so a couple of missed updates
+    /// are ordinary and only a real stall lasts past this.
+    private static let stall = 0.5
     /// How much of the bars' rate the music gets to move.
     private static let rateSwing = 0.4
     /// How often the levels are resampled — and, since new numbers are the
     /// only reason to redraw, the rate the indicators run at too.
     static let interval = 1.0 / 30.0
 
-    init(engine: KoanEngine) {
+    init(engine: KoanEngine, mirror: EngineMirror) {
         self.engine = engine
+        self.mirror = mirror
     }
 
     /// The carrier's phase now, wound on from the last sample at the rate the
@@ -86,6 +98,10 @@ final class PlayingLevels {
 
     private func start() {
         stamp = Date().timeIntervalSinceReferenceDate
+        // Where the play head stands, not that it has moved: a track that is
+        // still buffering when the first indicator appears has told us nothing.
+        seen = mirror.positionMs
+        movedAt = 0
         poll = Task { [weak self] in
             while !Task.isCancelled {
                 try? await Task.sleep(for: .seconds(Self.interval))
@@ -100,7 +116,6 @@ final class PlayingLevels {
         poll = nil
         // Travel is left where it stands: the bars freeze mid-swing when the
         // transport stops, and a redraw while paused should not move them.
-        heard = false
     }
 
     private func sample() {
@@ -108,16 +123,20 @@ final class PlayingLevels {
         // Clamped: a machine that slept owes the bars nothing.
         let elapsed = min(max(now - stamp, 0), 0.25)
         let wound = phase(at: now)
+        let position = mirror.positionMs
+        if position != seen {
+            seen = position
+            movedAt = now
+        }
         let frame = engine.vizLevels()
         let bands = [Double(frame.low), Double(frame.mid), Double(frame.high)]
-        heard = heard || bands.contains { $0 > Self.quietest }
 
         defer {
             phase = wound
             stamp = now
         }
 
-        guard heard else {
+        guard now - movedAt < Self.stall else {
             travel = Self.idle
             rate = 1
             return
@@ -127,16 +146,17 @@ final class PlayingLevels {
         var next = travel
         for band in bands.indices {
             ceiling[band] = max(bands[band], max(ceiling[band] * hold, Self.quietest))
-            let energy = min(bands[band] / ceiling[band], 1)
-            let target = Self.floor + (1 - Self.floor) * energy
-            let halfLife = target > travel[band] ? Self.attack : Self.release
-            next[band] =
-                target + (travel[band] - target) * Self.remaining(halfLife: halfLife, over: elapsed)
+            // Silence is a level like any other: the bars settle onto their
+            // resting heights and stay there until there is something to move
+            // them. Still bars on a playing row are the truth, and the row is
+            // still legible as the one playing — three bars at three heights.
+            let target = min(bands[band] / ceiling[band], 1)
+            let fallen = travel[band] * Self.remaining(halfLife: Self.release, over: elapsed)
+            next[band] = max(target, fallen)
         }
         travel = next
 
-        let mean = next.reduce(0, +) / Double(next.count)
-        rate = 1 + Self.rateSwing * (mean - Self.floor) / (1 - Self.floor)
+        rate = 1 + Self.rateSwing * next.reduce(0, +) / Double(next.count)
     }
 
     /// What is left of a distance after `elapsed` at the given half-life.

--- a/apps/macos/Sources/Koan/Views/PlayingIndicator.swift
+++ b/apps/macos/Sources/Koan/Views/PlayingIndicator.swift
@@ -4,18 +4,18 @@ import SwiftUI
 /// nine points tall. Heights are the low, mid and high bands as the analyser
 /// reports them, so the row says both "this one" and what it sounds like — and
 /// a silent passage is flat, because that is what is coming out of the
-/// speakers. They hold their last heights when the transport pauses.
+/// speakers. Pausing lets them fall rather than freezing them, the way the
+/// TUI's spectrum settles.
 struct PlayingIndicator: View {
     let isPlaying: Bool
 
     @Environment(PlayingLevels.self) private var levels
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     /// The queue stays mounted while you are elsewhere, so an indicator can be
-    /// off screen without ever disappearing. Off stage it stops asking the
-    /// analyser for levels and its timeline stops ticking.
+    /// off screen without ever disappearing. Off stage it stops drawing, which
+    /// is also what stops it reading the analyser.
     @Environment(\.onStage) private var onStage
     @AppStorage("graphics") private var graphics = Graphics.full
-    @State private var watching = false
 
     /// The shape a still indicator holds — staggered, so it reads as bars
     /// rather than as a broken one. Nothing moving needs an analyser.
@@ -33,17 +33,18 @@ struct PlayingIndicator: View {
     /// ladder.
     private var still: Bool { reduceMotion || !graphics.animatesIndicators }
 
-    /// Whether there is anything to follow. Still bars need no analyser, so
-    /// this is also what decides whether anything polls it.
-    private var live: Bool { isPlaying && !still && onStage }
+    /// Whether there is anything left to draw. A pause keeps the timeline
+    /// running until the bars have fallen, and nothing runs after that: no
+    /// frame, no read, no analyser.
+    private var live: Bool { onStage && !still && (isPlaying || !levels.settled) }
 
     var body: some View {
-        // At the rate the levels arrive, not the rate the display can manage.
-        // Every tick is a SwiftUI graph update, and in this window each of
-        // those costs a whole-window Auto Layout pass and a re-render of the
-        // transport's glass — so a frame that redraws numbers that have not
-        // changed is not free, it is the expensive half of the work.
-        TimelineView(.animation(minimumInterval: PlayingLevels.interval, paused: !live)) { _ in
+        // The display's own cadence. Each tick is a SwiftUI graph update and
+        // the analyser is told to run at the same rate, so a tick is one new
+        // set of numbers rather than a redraw of numbers that have not changed.
+        TimelineView(.animation(paused: !live)) { timeline in
+            let bands = levels.bands(
+                at: timeline.date.timeIntervalSinceReferenceDate, playing: isPlaying)
             // Drawn rather than sized. Heights driven through `frame(height:)`
             // invalidated layout on every frame, and AppKit answered each one
             // with a full window Auto Layout pass — a third of a core to move
@@ -51,7 +52,12 @@ struct PlayingIndicator: View {
             // canvas is a fixed box; only its pixels change.
             Canvas { context, size in
                 for band in Self.resting.indices {
-                    let height = height(of: band)
+                    // Clamped because a bar is a drawn rectangle: the level
+                    // keeps itself inside 0...1 today, but one that ever
+                    // stepped outside it would become a capsule with a
+                    // negative height rather than a wrong one.
+                    let level = still ? Self.resting[band] : bands[band].clamped()
+                    let height = Self.minHeight + level * (Self.maxHeight - Self.minHeight)
                     let rect = CGRect(
                         x: Double(band) * (Self.barWidth + Self.spacing),
                         y: size.height - height,
@@ -65,26 +71,5 @@ struct PlayingIndicator: View {
         .frame(width: Self.width, height: Self.maxHeight)
         .foregroundStyle(.tint)
         .accessibilityLabel(isPlaying ? "Playing" : "Paused")
-        .onAppear { watch(live) }
-        .onDisappear { watch(false) }
-        .onChange(of: live) { _, wanted in watch(wanted) }
-    }
-
-    private func watch(_ wanted: Bool) {
-        guard wanted != watching else { return }
-        watching = wanted
-        if wanted {
-            levels.watch()
-        } else {
-            levels.unwatch()
-        }
-    }
-
-    private func height(of band: Int) -> Double {
-        // Clamped because a bar is a drawn rectangle: the level keeps itself
-        // inside 0...1 today, but one that ever stepped outside it would
-        // become a capsule with a negative height rather than a wrong one.
-        let level = still ? Self.resting[band] : levels.bands[band].clamped()
-        return Self.minHeight + level * (Self.maxHeight - Self.minHeight)
     }
 }

--- a/apps/macos/Sources/Koan/Views/PlayingIndicator.swift
+++ b/apps/macos/Sources/Koan/Views/PlayingIndicator.swift
@@ -6,8 +6,9 @@ import SwiftUI
 ///
 /// The dance is a pair of sine waves and the music modulates them rather than
 /// driving them: a chorus makes the bars swell, a quiet passage settles them
-/// low and slow. Heights come from the carrier, which cannot spike, so the
-/// indicator says *what* is playing without ever reading as jitter.
+/// low and slow, and silence stops them where they rest. Heights come from the
+/// carrier, which cannot spike, so the indicator says *what* is playing
+/// without ever reading as jitter.
 struct PlayingIndicator: View {
     let isPlaying: Bool
 

--- a/apps/macos/Sources/Koan/Views/PlayingIndicator.swift
+++ b/apps/macos/Sources/Koan/Views/PlayingIndicator.swift
@@ -1,14 +1,10 @@
 import SwiftUI
 
-/// The bars that mark whatever is playing. They dance while the transport
-/// runs and freeze where they stand when it pauses, so the row says both
-/// "this one" and "still going" without a second glyph.
-///
-/// The dance is a pair of sine waves and the music modulates them rather than
-/// driving them: a chorus makes the bars swell, a quiet passage settles them
-/// low and slow, and silence stops them where they rest. Heights come from the
-/// carrier, which cannot spike, so the indicator says *what* is playing
-/// without ever reading as jitter.
+/// The bars that mark whatever is playing: a three-column spectrum analyser,
+/// nine points tall. Heights are the low, mid and high bands as the analyser
+/// reports them, so the row says both "this one" and what it sounds like — and
+/// a silent passage is flat, because that is what is coming out of the
+/// speakers. They hold their last heights when the transport pauses.
 struct PlayingIndicator: View {
     let isPlaying: Bool
 
@@ -21,31 +17,20 @@ struct PlayingIndicator: View {
     @AppStorage("graphics") private var graphics = Graphics.full
     @State private var watching = false
 
-    private struct Bar {
-        let speed: Double
-        let phase: Double
-        /// Where a still bar sits, so a frozen indicator still reads as bars —
-        /// and, once the music is driving them, what the swing narrows toward.
-        let rest: Double
-    }
-
-    /// One per band, low to high: three bars means three bands, and bars that
-    /// rise and fall in lockstep read instantly as fake.
-    private static let bars = [
-        Bar(speed: 5.1, phase: 0.0, rest: 0.75),
-        Bar(speed: 7.3, phase: 1.7, rest: 0.35),
-        Bar(speed: 6.2, phase: 3.4, rest: 0.6),
-    ]
+    /// The shape a still indicator holds — staggered, so it reads as bars
+    /// rather than as a broken one. Nothing moving needs an analyser.
+    private static let resting = [0.75, 0.35, 0.6]
 
     private static let minHeight = 3.0
     private static let maxHeight = 11.0
     private static let barWidth = 2.0
     private static let spacing = 2.0
     private static let width =
-        Double(bars.count) * barWidth + Double(bars.count - 1) * spacing
+        Double(resting.count) * barWidth + Double(resting.count - 1) * spacing
 
-    /// Whether the bars hold their shape instead of dancing. Reduce Motion asks
-    /// for it, and so does the bottom of the graphics ladder.
+    /// Whether the bars hold their shape instead of following the music.
+    /// Reduce Motion asks for it, and so does the bottom of the graphics
+    /// ladder.
     private var still: Bool { reduceMotion || !graphics.animatesIndicators }
 
     /// Whether there is anything to follow. Still bars need no analyser, so
@@ -58,16 +43,15 @@ struct PlayingIndicator: View {
         // those costs a whole-window Auto Layout pass and a re-render of the
         // transport's glass — so a frame that redraws numbers that have not
         // changed is not free, it is the expensive half of the work.
-        TimelineView(.animation(minimumInterval: PlayingLevels.interval, paused: !live)) { timeline in
-            let now = timeline.date.timeIntervalSinceReferenceDate
+        TimelineView(.animation(minimumInterval: PlayingLevels.interval, paused: !live)) { _ in
             // Drawn rather than sized. Heights driven through `frame(height:)`
             // invalidated layout on every frame, and AppKit answered each one
             // with a full window Auto Layout pass — a third of a core to move
             // nine points of bar, whether or not the window was on screen. The
             // canvas is a fixed box; only its pixels change.
             Canvas { context, size in
-                for (band, bar) in Self.bars.enumerated() {
-                    let height = height(of: bar, band: band, at: now)
+                for band in Self.resting.indices {
+                    let height = height(of: band)
                     let rect = CGRect(
                         x: Double(band) * (Self.barWidth + Self.spacing),
                         y: size.height - height,
@@ -96,23 +80,11 @@ struct PlayingIndicator: View {
         }
     }
 
-    private func height(of bar: Bar, band: Int, at now: Double) -> Double {
-        guard !still else {
-            return Self.minHeight + bar.rest * (Self.maxHeight - Self.minHeight)
-        }
-        // Two frequencies with an irrational ratio: the bars never fall back
-        // into a loop the eye can catch. The phase comes from the shared clock,
-        // so every indicator on screen moves as one and the music can lean on
-        // the rate without the argument jumping.
-        let phase = levels.phase(at: now)
-        let wave = sin(phase * bar.speed + bar.phase) * 0.6
-            + sin(phase * bar.speed * 1.618 + bar.phase * 2) * 0.4
-        let carrier = (wave + 1) / 2
-        // The band pulls the swing in toward rest rather than setting a height.
-        // Clamped because a bar is a drawn rectangle: the arithmetic keeps
-        // itself inside 0...1 today, but a level that ever stepped outside it
-        // would become a capsule with a negative height rather than a wrong one.
-        let level = (bar.rest + (carrier - bar.rest) * levels.travel[band]).clamped()
+    private func height(of band: Int) -> Double {
+        // Clamped because a bar is a drawn rectangle: the level keeps itself
+        // inside 0...1 today, but one that ever stepped outside it would
+        // become a capsule with a negative height rather than a wrong one.
+        let level = still ? Self.resting[band] : levels.bands[band].clamped()
         return Self.minHeight + level * (Self.maxHeight - Self.minHeight)
     }
 }

--- a/crates/koan-core/src/audio/analyzer.rs
+++ b/crates/koan-core/src/audio/analyzer.rs
@@ -562,7 +562,9 @@ impl VizAnalyzer {
         let amplitude_scale = AmplitudeScale::parse(&cfg.amplitude_scale);
         let bar_half_life = cfg.bar_decay_ms as f32 / 1000.0;
         let peak_half_life = cfg.peak_decay_ms as f32 / 1000.0;
-        let interval = Duration::from_millis(1000 / cfg.fps.max(1) as u64);
+        // The configured rate is the starting one. A client drawing on a
+        // display can set its own — see `VizSnapshot::set_fps`.
+        snapshot.set_fps(cfg.fps);
 
         let running_clone = Arc::clone(&running);
 
@@ -578,7 +580,6 @@ impl VizAnalyzer {
                     amplitude_scale,
                     bar_half_life,
                     peak_half_life,
-                    interval,
                 );
             })
             .expect("failed to spawn viz-analyzer thread");
@@ -624,7 +625,6 @@ fn analysis_loop(
     amplitude_scale: AmplitudeScale,
     bar_half_life: f32,
     peak_half_life: f32,
-    interval: Duration,
 ) {
     let mut state = AnalysisState::new(scale, bar_half_life, peak_half_life, amplitude_scale);
     let mut snap = RawVizSnapshot::default();
@@ -674,6 +674,9 @@ fn analysis_loop(
         });
 
         // ── Sleep for the remainder of the interval ───────────────────────────
+        // Read each pass, so a window moving to a 120Hz display is followed on
+        // the next one rather than at the next track.
+        let interval = snapshot.interval();
         let elapsed = start.elapsed();
         if elapsed < interval {
             thread::sleep(interval - elapsed);

--- a/crates/koan-core/src/audio/viz.rs
+++ b/crates/koan-core/src/audio/viz.rs
@@ -6,6 +6,10 @@ use parking_lot::{Mutex, RwLock};
 /// Number of spectrum bars produced by the analyzer.
 pub const NUM_BARS: usize = 48;
 
+/// Where the analyser runs until something tells it otherwise. A snapshot is
+/// created before any client has said what display it draws on.
+const DEFAULT_FPS: u8 = 60;
+
 /// Number of waveform frames carried in each VizFrame for oscilloscope/lissajous modes.
 /// 2048 frames (~46ms at 44.1kHz) matches the FFT window size — enough for smooth waveform display.
 pub const WAVEFORM_SAMPLES: usize = 2048;
@@ -72,6 +76,15 @@ pub struct VizSnapshot {
     /// ever opening a visualiser, and an FFT sixty times a second for nobody
     /// is a percent of a core.
     reads: AtomicU64,
+    /// Microseconds between analysis passes.
+    ///
+    /// It lives beside the frame because the party who knows the right rate is
+    /// the party reading frames: bars are drawn on a display, and the rate
+    /// worth running at is that display's — 60 on one panel, 120 on another,
+    /// and it changes when a window is dragged between them. The analyser
+    /// reads it when it next wakes, so setting it costs one store and wakes
+    /// nothing.
+    interval_us: AtomicU64,
 }
 
 impl VizSnapshot {
@@ -80,6 +93,7 @@ impl VizSnapshot {
         Arc::new(Self {
             inner: RwLock::new(VizFrame::default()),
             reads: AtomicU64::new(0),
+            interval_us: AtomicU64::new(Self::interval_us(DEFAULT_FPS)),
         })
     }
 
@@ -94,6 +108,29 @@ impl VizSnapshot {
     /// and there is nothing to analyse for.
     pub fn reads(&self) -> u64 {
         self.reads.load(Ordering::Relaxed)
+    }
+
+    /// Run the analyser at `fps` passes a second from its next wake.
+    ///
+    /// Clamped to something a display could plausibly ask for: the rate is set
+    /// from outside koan, and a zero here would be a division and a spin.
+    pub fn set_fps(&self, fps: u8) {
+        self.interval_us
+            .store(Self::interval_us(fps), Ordering::Relaxed);
+    }
+
+    /// How long the analyser sleeps between passes.
+    pub fn interval(&self) -> std::time::Duration {
+        std::time::Duration::from_micros(self.interval_us.load(Ordering::Relaxed))
+    }
+
+    /// Passes a second, as last set.
+    pub fn fps(&self) -> u8 {
+        (1_000_000 / self.interval_us.load(Ordering::Relaxed).max(1)) as u8
+    }
+
+    fn interval_us(fps: u8) -> u64 {
+        1_000_000 / fps.clamp(1, 240) as u64
     }
 
     /// Write a new frame. Acquires write lock, swaps, releases — <1us.
@@ -385,6 +422,20 @@ mod tests {
         assert_eq!(snap.channels, 1);
         assert_eq!(snap.sample_rate, 96000);
         assert_eq!(snap.samples, vec![1.0, 2.0]);
+    }
+
+    #[test]
+    fn fps_sets_the_analysis_interval_and_clamps() {
+        let snap = VizSnapshot::new();
+        assert_eq!(snap.fps(), DEFAULT_FPS);
+
+        snap.set_fps(120);
+        assert_eq!(snap.fps(), 120);
+        assert_eq!(snap.interval(), std::time::Duration::from_micros(8_333));
+
+        // A rate from outside koan: zero would be a division and a spin.
+        snap.set_fps(0);
+        assert_eq!(snap.fps(), 1);
     }
 
     #[test]

--- a/crates/koan-ffi/src/lib.rs
+++ b/crates/koan-ffi/src/lib.rs
@@ -238,6 +238,16 @@ impl KoanEngine {
         self.viz.levels().into()
     }
 
+    /// Run the analyser at the refresh rate of the display it is drawn on.
+    ///
+    /// koan cannot know that rate and a window can: 60 on one panel, 120 on
+    /// another, and it changes when the window is dragged between them. One
+    /// atomic store — the analyser picks it up on its next pass, and nothing
+    /// wakes for it.
+    pub fn set_viz_fps(&self, fps: u8) {
+        self.viz.set_fps(fps);
+    }
+
     // --- Queue mutation ----------------------------------------------------
 
     /// Append tracks. Starts playback if the player was stopped, and kicks off


### PR DESCRIPTION
The indicator danced through the silent opening of a track — ten seconds of nothing, three bars swinging.

## It was never drawing the music

The bars were two sine waves at fixed speeds, and the bands only scaled how far each swung around a resting height. A carrier with nothing to scale it is still a carrier, so silence got the full dance.

They are the spectrum now: three columns, heights straight from the analyser's low, mid and high bands. Silence is flat. Pausing lets them fall rather than freezing them mid-swing, which is what the TUI's bars have always done.

- Bands are measured against their own recent ceiling (4s half-life, floored at room tone), so a quiet master doesn't get a limp indicator and the analyser's A-weighting tilt doesn't leave the bass bar permanently sluggish. That floor is also what keeps silence flat instead of normalising it back up into motion.
- The fall is the law the TUI's spectrum draws on — up on the frame it happens, down on a 150ms half-life. The old code smoothed the analyser's already-smoothed bars a second time over 0.35s, which made a beat land late.

## One clock, and it is the display's

The analyser ran at `visualizer.fps` and the indicator sampled it on a 30Hz timer of its own — so on a 120Hz panel, 60 analyses drawn at 30, with two clocks deciding between them which frames a bar was allowed to move on.

The rate now lives on `VizSnapshot` as an atomic the analysis loop reads at the end of each pass: setting it is one store and wakes nothing. The window is what knows the answer, so the macOS app sets it from the screen it is on and follows it across `didChangeScreen`, `didBecomeKey` and `didChangeScreenParameters`. The TUI is untouched — its rate is `visualizer.fps`, which is what the analyser starts at.

On the Swift side nothing polls at all. An indicator asks for the bands as it draws a frame and the first to ask on a given frame does the read, so a frame is one new set of numbers rather than a redraw of numbers that have not changed. Off stage, still (Reduce Motion / low graphics) or settled after a pause, no frame is drawn, nothing is read, and the analyser stands itself down a second later.

## Verifying

- A track that opens on silence: flat.
- Anything with a beat: the columns follow it, on the frame.
- Pause: the bars fall to flat and the timeline stops.
- Drag the window between a 60Hz and a 120Hz display: the analyser follows.
- Reduce Motion, or graphics below Full: three still staggered bars, no analyser polled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WAbe522TUhqe7K6QD4dnS2