### PR TITLE
perf(viz): publish the spectrum instead of being polled for it

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -91,8 +91,10 @@ Five threads at steady state during playback:
 ┌─────────────────────────────────────────────────┐
 │ Analyzer Thread ("viz-analyzer")               │
 │ Always spawned. Reads VizBuffer, runs FFT,      │
-│ writes VizSnapshot. Configurable fps (default   │
-│ 60). Never blocks audio or UI.                  │
+│ publishes VizSnapshot. Runs at the rate a       │
+│ client asks for — the macOS app sets its        │
+│ display's. Parks when nothing reads and nothing │
+│ plays. Never blocks audio or UI.                │
 └─────────────────────────────────────────────────┘
 ```
 
@@ -110,7 +112,7 @@ Five threads at steady state during playback:
 | Track boundaries | Decode | TUI, Player | `parking_lot::RwLock` |
 | `running` flag | Player (start/stop) | Audio RT | `AtomicBool` (Relaxed) |
 | Viz samples | Decode | Analyzer | `VizBuffer` (`parking_lot::Mutex` ring) |
-| Analysis output | Analyzer | TUI | `VizSnapshot` (`parking_lot::Mutex`) |
+| Analysis output | Analyzer | TUI, FFI clients | `VizSnapshot` (`parking_lot::RwLock` + `tokio::sync::watch` for subscribers) |
 
 **The golden rule: nothing on the audio render thread may allocate or lock.** It only touches atomics and the ring buffer consumer. This applies to both the CoreAudio callback (macOS) and the cpal callback (Linux).
 
@@ -215,7 +217,7 @@ A download that gives up sends `TrackFailed` instead, and the parked cursor adva
 | `buffer.rs` | `PlaybackTimeline` — track boundaries, `current_playback()` position query (binary search), decode thread entry points (`start_decode`, `decode_single`, `decode_queue_loop`) |
 | `replaygain.rs` | EBU R128 loudness scanning, gain application, tag read/write via lofty |
 | `viz.rs` | `VizBuffer` (lock-protected ring of f32 samples for analyzer), `VizSnapshot` (atomic snapshot for UI thread), `VizLevels` (spectrum reduced to low/mid/high, cloning no waveform) |
-| `analyzer.rs` | FFT analysis thread — 48-band spectrum, VU meters, peak hold, beat detection (low-band transient). Configurable fps. Writes to `VizSnapshot`. |
+| `analyzer.rs` | FFT analysis thread — 48-band spectrum, VU meters, peak hold, beat detection (low-band transient). Runs at whatever rate a client sets, decays to flat when the play head stops, and parks when nothing is reading. Publishes to `VizSnapshot`. |
 | `streaming.rs` | `PartialFileSource` — reads a download in progress off disk, blocking at the write head |
 
 ### `player/`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 ### Changed
 
-- **The playing indicator is a spectrum analyser, three columns wide.** It was a pair of sine waves the music modulated — the bands set how far the bars swung, never how high they stood — which meant a track that opens on ten seconds of silence got the full dance, because a carrier with nothing to scale it is still a carrier. The bars are the low, mid and high bands now, drawn at the height the analyser reports. Silence is flat. Pausing lets them fall away rather than freezing them mid-swing, which is what the TUI's spectrum has always done.
+- **The spectrum is published, not polled.** The playing indicator asked the engine for levels on a clock — a timer at first, then the display link — because there was no event to react to. There is one now: the analyser sends a frame when it has one, the app wakes on it, and the bars are drawn from what arrived. No timer, no tick, and no frame read twice or missed.
 
-  Bands are still measured against their own recent ceiling, so a quiet master is not a limp indicator, and the fall is the law the TUI's bars draw on: up on the frame it happens, down on a half-life so nothing snaps to zero between beats.
+  What falls out of that is the idle cost. The analyser decays the bars to flat when the play head stops rather than holding the last chord, and once they are flat it publishes nothing at all — so a paused koan wakes nothing. The thread itself parks on a wait instead of standing down to a quarter-second look-again loop: with no reader and nothing playing it is not scheduled at all, until a reader arrives or playback starts. That last one cannot be signalled from the play head, which the audio render callback writes and which may never take a lock, so the player says so on the two edges where silence ends.
 
-- **The analyser runs at the refresh rate of the display it is drawn on.** Its rate was a config figure and the macOS indicator sampled it on a timer of its own, so a 120Hz panel got 60 analyses drawn at 30, and two clocks decided between them which frames a bar was allowed to move on. The window knows what it is drawn on: koan sets the rate from the screen the window is on and again when it is dragged to another one or a display is reconfigured under it. The indicators read on the frame they draw, so a frame is one new set of numbers and there is no timer anywhere in it — nothing on screen means nothing read, and the analyser stands itself down a second later. The TUI is unchanged: its rate is still `visualizer.fps`, which is what the analyser starts at.
+  `koan-core` takes `tokio` for `sync` only — `watch` is the analyser telling its subscribers a frame is ready. No runtime, no reactor.
 
 ## v0.33.1 (2026-08-28)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2541,6 +2541,7 @@ dependencies = [
  "symphonia",
  "tempfile",
  "thiserror 2.0.20",
+ "tokio",
  "toml 1.1.4+spec-1.1.0",
  "toml_edit 0.25.13+spec-1.1.0",
  "unicode-normalization",

--- a/apps/macos/Sources/Koan/Support/PlayingLevels.swift
+++ b/apps/macos/Sources/Koan/Support/PlayingLevels.swift
@@ -4,18 +4,16 @@ import KoanFFI
 
 /// The audio behind the playing indicators.
 ///
-/// One source for the whole app: the queue and a track list can both have a
-/// current row on screen, and they are watching the same music. There is no
-/// timer here and nothing polls — an indicator asks for the bands as it draws
-/// a frame, and the first to ask on a given frame is the one that reads the
-/// analyser. Nothing on screen means nothing read, and the analyser stands
-/// itself down a second after the last read.
+/// One subscription for the whole app: the queue and a track list can both
+/// have a current row on screen, and they are watching the same music. Nothing
+/// here is polled and nothing is timed — the analyser publishes a frame and
+/// this wakes on it. When the play head stops and the bars have fallen, it
+/// publishes nothing, so this loop is asleep and costs exactly nothing until
+/// there is music again.
 ///
-/// The bands themselves are not observed. They move at the refresh rate of the
-/// display and an observer would invalidate a view for each one; the
-/// indicators redraw off their own display-linked timeline and take the value
-/// as they go. `settled` is observed, because it is the one thing a view has
-/// to be told rather than ask: it is what stops the timeline.
+/// The rate is the refresh rate of the display the window is on, which is
+/// something only the window knows: koan sets it here and follows it across
+/// screens.
 @MainActor
 @Observable
 final class PlayingLevels {
@@ -24,14 +22,13 @@ final class PlayingLevels {
     /// How high each bar stands, 0...1, low band to high. The spectrum in
     /// three columns: what the analyser says is coming out of the speakers,
     /// and nothing else. Silence is zero and reads flat.
-    @ObservationIgnored private(set) var bands = [0.0, 0.0, 0.0]
+    ///
+    /// Observed, and mutated once per published frame — which is the only
+    /// reason an indicator ever redraws.
+    private(set) var bands = [0.0, 0.0, 0.0]
 
-    /// Whether the bars have come to rest with nothing playing. False while
-    /// they still have somewhere to fall, which is what keeps the timeline
-    /// ticking through the decay after a pause and stops it after.
-    private(set) var settled = true
-
-    @ObservationIgnored private var stamp = 0.0
+    @ObservationIgnored private var stamp = Date().timeIntervalSinceReferenceDate
+    @ObservationIgnored private var follow: Task<Void, Never>?
 
     /// The loudest each band has been lately. Each band is judged against its
     /// own recent range rather than against full scale, which is what stops a
@@ -44,17 +41,18 @@ final class PlayingLevels {
     /// what a silent passage is measured against, so silence stays flat rather
     /// than being normalised back up into a dance.
     private static let quietest = 0.12
-    /// How long a band takes to fall away. Rises are not damped at all: this
-    /// is the law the TUI's spectrum runs on — up on the frame it happens,
-    /// down on a half-life so nothing snaps to zero between beats.
-    private static let release = 0.15
     /// How long a band takes to forget a loud passage.
     private static let forget = 4.0
-    /// Below a tenth of a point of bar there is nothing left to draw.
-    private static let flat = 0.01
 
     init(engine: KoanEngine) {
         self.engine = engine
+        let stream = engine.vizStream()
+        follow = Task { [weak self] in
+            while let levels = await stream.next() {
+                guard let self else { return }
+                take(levels)
+            }
+        }
         // The rate the analyser should run at is the refresh rate of the
         // display it is drawn on, which changes when the window is dragged to
         // another screen and when a screen is reconfigured under it.
@@ -72,59 +70,30 @@ final class PlayingLevels {
         matchDisplay()
     }
 
-    /// The bands as of `now`, brought forward from the last frame that asked.
-    ///
-    /// Every indicator on screen calls this on every frame it draws and the
-    /// first one does the work: the rest are the same frame, and a spectrum
-    /// sampled twice in one frame would be two different answers to the same
-    /// question.
-    func bands(at now: TimeInterval, playing: Bool) -> [Double] {
-        guard now > stamp else { return bands }
+    deinit { follow?.cancel() }
+
+    /// A frame, as it arrives. The only smoothing left here is the ceiling
+    /// each band is measured against — the fall is the analyser's, which is
+    /// also what decays the bars to flat when the music stops.
+    private func take(_ levels: VizLevels) {
+        let now = Date().timeIntervalSinceReferenceDate
         // Clamped: a machine that slept owes the bars nothing.
-        let elapsed = min(now - stamp, 0.25)
+        let elapsed = min(max(now - stamp, 0), 0.25)
         stamp = now
-        let fall = Self.remaining(halfLife: Self.release, over: elapsed)
+        let hold = pow(0.5, elapsed / Self.forget)
 
-        guard playing else {
-            // Nothing is coming out of the speakers, so nothing is read: the
-            // bars fall away on their own and the analyser, with no reader,
-            // stands down while they do.
-            for band in bands.indices { bands[band] *= fall }
-            if bands.allSatisfy({ $0 < Self.flat }) {
-                bands = [0, 0, 0]
-                rest(true)
-            }
-            return bands
+        let heard = [Double(levels.low), Double(levels.mid), Double(levels.high)]
+        var next = bands
+        for band in heard.indices {
+            ceiling[band] = max(heard[band], max(ceiling[band] * hold, Self.quietest))
+            next[band] = min(heard[band] / ceiling[band], 1)
         }
-
-        rest(false)
-        let hold = Self.remaining(halfLife: Self.forget, over: elapsed)
-        let frame = engine.vizLevels()
-        let levels = [Double(frame.low), Double(frame.mid), Double(frame.high)]
-        for band in levels.indices {
-            ceiling[band] = max(levels[band], max(ceiling[band] * hold, Self.quietest))
-            let level = min(levels[band] / ceiling[band], 1)
-            bands[band] = max(level, bands[band] * fall)
-        }
-        return bands
-    }
-
-    /// Flip the one observed property from outside the body that noticed. It
-    /// changes twice a pause rather than once a frame, and a view is midway
-    /// through drawing when the change is spotted.
-    private func rest(_ value: Bool) {
-        guard settled != value else { return }
-        Task { @MainActor in self.settled = value }
+        bands = next
     }
 
     private func matchDisplay() {
         let main = NSApp.windows.first { $0.identifier?.rawValue == MainWindow.id }
         let screen = main?.screen ?? NSApp.keyWindow?.screen ?? NSScreen.main
         engine.setVizFps(fps: UInt8(clamping: screen?.maximumFramesPerSecond ?? 60))
-    }
-
-    /// What is left of a distance after `elapsed` at the given half-life.
-    private static func remaining(halfLife: Double, over elapsed: Double) -> Double {
-        pow(0.5, elapsed / halfLife)
     }
 }

--- a/apps/macos/Sources/Koan/Views/PlayingIndicator.swift
+++ b/apps/macos/Sources/Koan/Views/PlayingIndicator.swift
@@ -4,16 +4,19 @@ import SwiftUI
 /// nine points tall. Heights are the low, mid and high bands as the analyser
 /// reports them, so the row says both "this one" and what it sounds like — and
 /// a silent passage is flat, because that is what is coming out of the
-/// speakers. Pausing lets them fall rather than freezing them, the way the
-/// TUI's spectrum settles.
+/// speakers. Pausing lets them fall rather than freezing them mid-swing.
+///
+/// There is no timeline and no clock. A published frame moves `bands`, which
+/// invalidates this and nothing else; no frame means no redraw. An indicator
+/// that is off stage or holding still never reads them, which is what
+/// unsubscribes it.
 struct PlayingIndicator: View {
     let isPlaying: Bool
 
     @Environment(PlayingLevels.self) private var levels
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     /// The queue stays mounted while you are elsewhere, so an indicator can be
-    /// off screen without ever disappearing. Off stage it stops drawing, which
-    /// is also what stops it reading the analyser.
+    /// off screen without ever disappearing.
     @Environment(\.onStage) private var onStage
     @AppStorage("graphics") private var graphics = Graphics.full
 
@@ -33,39 +36,30 @@ struct PlayingIndicator: View {
     /// ladder.
     private var still: Bool { reduceMotion || !graphics.animatesIndicators }
 
-    /// Whether there is anything left to draw. A pause keeps the timeline
-    /// running until the bars have fallen, and nothing runs after that: no
-    /// frame, no read, no analyser.
-    private var live: Bool { onStage && !still && (isPlaying || !levels.settled) }
-
     var body: some View {
-        // The display's own cadence. Each tick is a SwiftUI graph update and
-        // the analyser is told to run at the same rate, so a tick is one new
-        // set of numbers rather than a redraw of numbers that have not changed.
-        TimelineView(.animation(paused: !live)) { timeline in
-            let bands = levels.bands(
-                at: timeline.date.timeIntervalSinceReferenceDate, playing: isPlaying)
-            // Drawn rather than sized. Heights driven through `frame(height:)`
-            // invalidated layout on every frame, and AppKit answered each one
-            // with a full window Auto Layout pass — a third of a core to move
-            // nine points of bar, whether or not the window was on screen. The
-            // canvas is a fixed box; only its pixels change.
-            Canvas { context, size in
-                for band in Self.resting.indices {
-                    // Clamped because a bar is a drawn rectangle: the level
-                    // keeps itself inside 0...1 today, but one that ever
-                    // stepped outside it would become a capsule with a
-                    // negative height rather than a wrong one.
-                    let level = still ? Self.resting[band] : bands[band].clamped()
-                    let height = Self.minHeight + level * (Self.maxHeight - Self.minHeight)
-                    let rect = CGRect(
-                        x: Double(band) * (Self.barWidth + Self.spacing),
-                        y: size.height - height,
-                        width: Self.barWidth,
-                        height: height
-                    )
-                    context.fill(Capsule(style: .continuous).path(in: rect), with: .foreground)
-                }
+        // Read only where it is drawn: not reading `bands` is what keeps an
+        // off-stage or still indicator out of the redraws entirely.
+        let bands = still || !onStage ? Self.resting : levels.bands
+        // Drawn rather than sized. Heights driven through `frame(height:)`
+        // invalidated layout on every frame, and AppKit answered each one with
+        // a full window Auto Layout pass — a third of a core to move nine
+        // points of bar, whether or not the window was on screen. The canvas
+        // is a fixed box; only its pixels change.
+        Canvas { context, size in
+            for band in Self.resting.indices {
+                // Clamped because a bar is a drawn rectangle: the level keeps
+                // itself inside 0...1 today, but one that ever stepped outside
+                // it would become a capsule with a negative height rather than
+                // a wrong one.
+                let height =
+                    Self.minHeight + bands[band].clamped() * (Self.maxHeight - Self.minHeight)
+                let rect = CGRect(
+                    x: Double(band) * (Self.barWidth + Self.spacing),
+                    y: size.height - height,
+                    width: Self.barWidth,
+                    height: height
+                )
+                context.fill(Capsule(style: .continuous).path(in: rect), with: .foreground)
             }
         }
         .frame(width: Self.width, height: Self.maxHeight)

--- a/crates/koan-core/Cargo.toml
+++ b/crates/koan-core/Cargo.toml
@@ -32,6 +32,9 @@ getrandom = "0.4"
 md5 = "0.8"
 # Async/threading
 parking_lot = "0.12"
+# Only `sync`: `watch` is the analyser telling its subscribers a frame is
+# ready. No runtime, no reactor — koan-core stays threads and channels.
+tokio = { version = "1", default-features = false, features = ["sync"] }
 rayon = "1"
 reqwest = { workspace = true }
 realfft = "3"

--- a/crates/koan-core/src/audio/analyzer.rs
+++ b/crates/koan-core/src/audio/analyzer.rs
@@ -48,8 +48,9 @@ const DB_CEIL: f32 = 0.0;
 /// Generous enough that a reader drawing slower than we analyse never trips it.
 const IDLE_AFTER: Duration = Duration::from_secs(1);
 
-/// How often a stood-down analyser looks for a reader coming back.
-const IDLE_POLL: Duration = Duration::from_millis(250);
+/// Below this a band is off. Reached by decay, which is asymptotic — without
+/// a floor the last frame is never quite the flat one.
+const SILENT: f32 = 0.001;
 
 // ── Frequency scale ──────────────────────────────────────────────────────────
 
@@ -482,6 +483,25 @@ impl AnalysisState {
         }
     }
 
+    /// Whether everything this publishes has decayed away. Nothing to say and
+    /// nothing to publish: the pass is skipped and, with no reader kept alive
+    /// by it, the thread parks.
+    fn is_silent(&self) -> bool {
+        self.spectrum.iter().all(|&v| v < SILENT)
+            && self.peaks.iter().all(|&v| v < SILENT)
+            && self.vu_levels.iter().all(|&v| v < SILENT)
+            && self.beat_energy < SILENT
+    }
+
+    /// Snap what is left to zero, so the last frame published is the flat one
+    /// rather than a hundredth of a bar that never quite arrives.
+    fn silence(&mut self) {
+        self.spectrum.fill(0.0);
+        self.peaks.fill(0.0);
+        self.vu_levels = [0.0, 0.0];
+        self.beat_energy = 0.0;
+    }
+
     /// Apply decay-to-silence (called when paused or no audio).
     fn decay_silence(&mut self) {
         let (bar_decay, peak_decay) = self.decay_factors();
@@ -539,6 +559,9 @@ impl AnalysisState {
 /// shutdown; the thread exits within one analysis interval.
 pub struct VizAnalyzer {
     running: Arc<AtomicBool>,
+    /// Kept for shutdown alone: a parked thread is waiting on this, and
+    /// clearing `running` under it would never be read.
+    snapshot: Arc<VizSnapshot>,
     handle: Option<thread::JoinHandle<()>>,
 }
 
@@ -567,13 +590,14 @@ impl VizAnalyzer {
         snapshot.set_fps(cfg.fps);
 
         let running_clone = Arc::clone(&running);
+        let snapshot_clone = Arc::clone(&snapshot);
 
         let handle = thread::Builder::new()
             .name("viz-analyzer".into())
             .spawn(move || {
                 analysis_loop(
                     viz_buffer,
-                    snapshot,
+                    snapshot_clone,
                     samples_played,
                     running_clone,
                     scale,
@@ -586,6 +610,7 @@ impl VizAnalyzer {
 
         Self {
             running,
+            snapshot,
             handle: Some(handle),
         }
     }
@@ -593,6 +618,9 @@ impl VizAnalyzer {
     /// Signal the background thread to stop and wait for it to exit.
     pub fn shutdown(&mut self) {
         self.running.store(false, Ordering::Relaxed);
+        // It may be parked with nothing to analyse for, which is a wait with
+        // no timeout on it: the flag alone would never be looked at again.
+        self.snapshot.wake();
         if let Some(h) = self.handle.take() {
             let _ = h.join();
         }
@@ -630,6 +658,7 @@ fn analysis_loop(
     let mut snap = RawVizSnapshot::default();
     let mut last_reads = u64::MAX;
     let mut last_read_at = Instant::now();
+    let mut last_played = u64::MAX;
 
     while running.load(Ordering::Relaxed) {
         let start = Instant::now();
@@ -639,25 +668,51 @@ fn analysis_loop(
         // per-frame waveform allocation and the delay-line copy all go away
         // until a visualiser opens, which is the whole cost of this thread in
         // a client that never opens one.
+        //
+        // Parked rather than slowed: a thread that looks again every quarter
+        // second is a thread the scheduler still runs, four times a second,
+        // for as long as koan is open. It waits instead, and a reader arriving
+        // or playback starting wakes it — see `VizSnapshot::park_while_idle`.
         let reads = snapshot.reads();
         if reads != last_reads {
             last_reads = reads;
             last_read_at = start;
         } else if start.duration_since(last_read_at) > IDLE_AFTER {
-            thread::sleep(IDLE_POLL);
+            snapshot.park_while_idle(|| snapshot.reads() == last_reads);
+            last_read_at = Instant::now();
             continue;
         }
 
         // ── Phase 1: read the delay line at the play head (lock held briefly) ─
+        // A play head that has not moved means nothing has been heard since
+        // the last pass, whatever the delay line still holds — paused, stopped,
+        // or starved. The bars fall away rather than holding the last chord,
+        // and once they have fallen there is nothing left to publish.
         let played = samples_played.load(Ordering::Relaxed);
-        viz_buffer.snapshot_at(played, WINDOW_FRAMES, &mut snap);
+        let heard = played != last_played;
+        last_played = played;
 
-        // ── Phase 2: compute (no lock held) ──────────────────────────────────
-        state.analyze(
-            &snap.samples,
-            snap.channels.max(1) as usize,
-            snap.sample_rate as f32,
-        );
+        if !heard {
+            if state.is_silent() {
+                // Nothing to say. No frame is published, so no subscriber
+                // wakes, and with nothing reading, the next pass parks.
+                thread::sleep(snapshot.interval());
+                continue;
+            }
+            state.decay_silence();
+            if state.is_silent() {
+                state.silence();
+            }
+        } else {
+            viz_buffer.snapshot_at(played, WINDOW_FRAMES, &mut snap);
+
+            // ── Phase 2: compute (no lock held) ──────────────────────────────
+            state.analyze(
+                &snap.samples,
+                snap.channels.max(1) as usize,
+                snap.sample_rate as f32,
+            );
+        }
 
         // ── Phase 3: publish to VizSnapshot (RwLock write, <1us) ─────────────
         // The tail of the window is the newest audible audio, which is what the

--- a/crates/koan-core/src/audio/viz.rs
+++ b/crates/koan-core/src/audio/viz.rs
@@ -1,7 +1,8 @@
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
-use parking_lot::{Mutex, RwLock};
+use parking_lot::{Condvar, Mutex, RwLock};
+use tokio::sync::watch;
 
 /// Number of spectrum bars produced by the analyzer.
 pub const NUM_BARS: usize = 48;
@@ -76,6 +77,25 @@ pub struct VizSnapshot {
     /// ever opening a visualiser, and an FFT sixty times a second for nobody
     /// is a percent of a core.
     reads: AtomicU64,
+    /// Bumped by every published frame, and the thing a subscriber waits on.
+    /// Nothing is sent through the channel but the count: a frame is a whole
+    /// snapshot behind a lock, so a waiter that misses two publishes wants the
+    /// newest one, not the two it slept through.
+    published: watch::Sender<u64>,
+    /// Where the analyser waits when there is nothing to analyse for, and how
+    /// it is woken. Parking rather than looking again on a timer is what makes
+    /// an idle koan cost nothing at all: the thread is not scheduled until a
+    /// reader arrives or playback starts.
+    ///
+    /// The flag under the lock is a wake that has already happened. It is what
+    /// makes a wake arriving in the moment before the thread parks — the whole
+    /// width of the race, and playback starting is exactly when it would land
+    /// — a park that returns immediately rather than one nothing will end.
+    park: Mutex<bool>,
+    unpark: Condvar,
+    /// Read on every frame read, so waking a parked analyser costs nothing on
+    /// the path that does not need it.
+    parked: AtomicBool,
     /// Microseconds between analysis passes.
     ///
     /// It lives beside the frame because the party who knows the right rate is
@@ -93,14 +113,65 @@ impl VizSnapshot {
         Arc::new(Self {
             inner: RwLock::new(VizFrame::default()),
             reads: AtomicU64::new(0),
+            published: watch::Sender::new(0),
+            park: Mutex::new(false),
+            unpark: Condvar::new(),
+            parked: AtomicBool::new(false),
             interval_us: AtomicU64::new(Self::interval_us(DEFAULT_FPS)),
         })
     }
 
     /// Read the latest frame. Acquires read lock, clones, releases — <1us.
     pub fn read(&self) -> VizFrame {
-        self.reads.fetch_add(1, Ordering::Relaxed);
+        self.touch();
         self.inner.read().clone()
+    }
+
+    /// Say that someone wants frames: counted, and enough to wake an analyser
+    /// that had parked for want of a reader.
+    ///
+    /// A subscriber calls this before it waits. Waiting for a frame is wanting
+    /// one, and an analyser that stood down because nobody was reading would
+    /// otherwise never produce the frame being waited for.
+    pub fn touch(&self) {
+        self.reads.fetch_add(1, Ordering::Relaxed);
+        if self.parked.load(Ordering::Relaxed) {
+            self.wake();
+        }
+    }
+
+    /// Wake the analysis thread if it is parked.
+    ///
+    /// Called when playback starts: the play head is the one input the
+    /// analyser cannot be signalled from, because it is written by the audio
+    /// render callback, which may never take a lock.
+    pub fn wake(&self) {
+        let mut pending = self.park.lock();
+        *pending = true;
+        self.unpark.notify_all();
+    }
+
+    /// Park until something wants a frame again, or until `still_idle` is no
+    /// longer true at the moment the lock is held.
+    ///
+    /// The condition is checked under the same lock `wake` takes, so a reader
+    /// arriving between the check and the wait cannot be missed.
+    pub fn park_while_idle(&self, still_idle: impl Fn() -> bool) {
+        let mut pending = self.park.lock();
+        if std::mem::take(&mut pending) || !still_idle() {
+            return;
+        }
+        self.parked.store(true, Ordering::Relaxed);
+        while !*pending {
+            self.unpark.wait(&mut pending);
+        }
+        *pending = false;
+        self.parked.store(false, Ordering::Relaxed);
+    }
+
+    /// A receiver that wakes on each published frame. See `published`.
+    pub fn subscribe(&self) -> watch::Receiver<u64> {
+        self.published.subscribe()
     }
 
     /// How many times the frame has been looked at, by either route. Only the
@@ -137,6 +208,9 @@ impl VizSnapshot {
     /// MUST only be called after all FFT computation is finished (never hold lock during FFT).
     pub fn write(&self, frame: VizFrame) {
         *self.inner.write() = frame;
+        // After the frame is in place, so a woken subscriber reads the frame
+        // it was told about rather than the one before it.
+        self.published.send_modify(|version| *version += 1);
     }
 
     /// Reduce the latest frame to three bands.
@@ -145,7 +219,7 @@ impl VizSnapshot {
     /// expensive part of a frame by an order of magnitude, and a caller drawing
     /// three bars would only average it away.
     pub fn levels(&self) -> VizLevels {
-        self.reads.fetch_add(1, Ordering::Relaxed);
+        self.touch();
         let frame = self.inner.read();
         VizLevels::of(&frame.spectrum)
     }
@@ -436,6 +510,43 @@ mod tests {
         // A rate from outside koan: zero would be a division and a spin.
         snap.set_fps(0);
         assert_eq!(snap.fps(), 1);
+    }
+
+    #[test]
+    fn a_wake_landing_before_the_park_is_not_slept_through() {
+        let snap = VizSnapshot::new();
+        // Playback starting is a wake with no read behind it, and it can land
+        // in the moment between the analyser deciding to park and parking.
+        snap.wake();
+        // Would block forever if the wake had been missed.
+        snap.park_while_idle(|| true);
+
+        // And it is not sticky beyond the one park it was meant for.
+        let woken = Arc::new(AtomicBool::new(false));
+        let flag = Arc::clone(&woken);
+        let snapshot = Arc::clone(&snap);
+        let waiter = std::thread::spawn(move || {
+            snapshot.park_while_idle(|| true);
+            flag.store(true, Ordering::Relaxed);
+        });
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        assert!(
+            !woken.load(Ordering::Relaxed),
+            "parked thread woke on its own"
+        );
+        snap.wake();
+        waiter.join().unwrap();
+    }
+
+    #[test]
+    fn a_read_wakes_a_parked_analyser() {
+        let snap = VizSnapshot::new();
+        let snapshot = Arc::clone(&snap);
+        let waiter = std::thread::spawn(move || snapshot.park_while_idle(|| true));
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        // What a subscriber does before it waits for a frame.
+        snap.touch();
+        waiter.join().unwrap();
     }
 
     #[test]

--- a/crates/koan-core/src/player/mod.rs
+++ b/crates/koan-core/src/player/mod.rs
@@ -389,6 +389,7 @@ impl Player {
         if result.is_err() {
             self.stop_playback_and_clear_state();
         }
+        self.wake_analyzer();
         result
     }
 
@@ -945,7 +946,18 @@ impl Player {
                 return;
             }
             self.shared_state.set_playback_state(PlaybackState::Playing);
+            self.wake_analyzer();
         }
+    }
+
+    /// Tell the analyser there is about to be something to hear.
+    ///
+    /// It parks when nothing is playing and nothing is reading, and the one
+    /// thing it cannot be signalled from is the play head — that counter is
+    /// written by the audio render callback, which may never take a lock. So
+    /// the player says so instead, on the two edges where silence ends.
+    fn wake_analyzer(&self) {
+        self.viz_snapshot.wake();
     }
 
     /// Stop playback and clear playlist.

--- a/crates/koan-ffi/src/lib.rs
+++ b/crates/koan-ffi/src/lib.rs
@@ -18,7 +18,7 @@
 
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 
 use crossbeam_channel::Sender;
 use koan_core::audio::viz::VizSnapshot;
@@ -133,6 +133,48 @@ fn init_logging() {
     }
 }
 
+/// One client's subscription to the analyser.
+///
+/// A cursor over the published frame, in the shape `StateStream` already uses:
+/// the value is a whole snapshot, so a subscriber that slept through two
+/// publishes wants the newest frame rather than the two it missed.
+#[derive(uniffi::Object)]
+pub struct VizStream {
+    /// Weak, so a client's loop ends when the engine goes rather than holding
+    /// the analyser up. The loop *is* the subscription.
+    viz: Weak<VizSnapshot>,
+    inner: tokio::sync::Mutex<tokio::sync::watch::Receiver<u64>>,
+}
+
+impl VizStream {
+    fn new(viz: &Arc<VizSnapshot>) -> Arc<Self> {
+        // Counted as a reader from here rather than at the first frame: an
+        // analyser parked for want of one would otherwise never publish the
+        // frame this is about to wait for.
+        viz.touch();
+        Arc::new(Self {
+            viz: Arc::downgrade(viz),
+            inner: tokio::sync::Mutex::new(viz.subscribe()),
+        })
+    }
+}
+
+#[uniffi::export]
+impl VizStream {
+    /// The next frame, as three band energies. Waits until there is one.
+    ///
+    /// `None` once the engine is gone, which ends the caller's loop.
+    pub async fn next(&self) -> Option<VizLevels> {
+        let mut cursor = self.inner.lock().await;
+        // Marked seen *before* the wait, so a frame published between the last
+        // answer and this call is returned rather than slept through.
+        cursor.borrow_and_update();
+        cursor.changed().await.ok()?;
+        let viz = self.viz.upgrade()?;
+        Some(viz.levels().into())
+    }
+}
+
 #[derive(uniffi::Object)]
 pub struct KoanEngine {
     state: Arc<SharedPlayerState>,
@@ -226,6 +268,17 @@ impl KoanEngine {
     /// `queue()`, which allocates the whole list.
     pub fn playlist_version(&self) -> u64 {
         self.state.playlist_version()
+    }
+
+    /// Follow the spectrum, one message per analysed frame.
+    ///
+    /// The analyser is the clock. It runs at the rate the display asks for
+    /// (see `set_viz_fps`), publishes a frame when it has one, and publishes
+    /// nothing at all when the play head has stopped and the bars have fallen
+    /// — so a paused koan delivers no messages, wakes nothing, and the thread
+    /// that would have produced them is parked rather than looping.
+    pub fn viz_stream(&self) -> Arc<VizStream> {
+        VizStream::new(&self.viz)
     }
 
     /// What is coming out of the speakers right now, as three band energies.


### PR DESCRIPTION
Follow-up to #392, which left one clock behind: the indicator read the analyser on the display link because there was no event to react to. There is one now.

## The chain

```
analyser publishes a frame
  → watch channel  (VizSnapshot)
  → VizStream.next()  (koan-ffi, async)
  → PlayingLevels.bands  (observed)
  → the Canvas redraws
```

No timer at any step. A frame is never read twice and never missed, and an indicator that is off stage or holding still doesn't read `bands` at all — which is what unsubscribes it from the redraws.

## Idle costs nothing

- **A stalled play head decays.** If `samples_played` hasn't moved since the last pass, nothing has been heard — paused, stopped or starved — so the bars fall away instead of holding the last chord. Same law the TUI's spectrum draws.
- **A flat frame isn't published.** Once everything is below `SILENT` the pass is skipped entirely: no FFT, no allocation, no message. A paused koan wakes nobody.
- **The thread parks.** It used to stand down to a 250ms look-again loop, which is still four wakeups a second for as long as koan is open. It now waits on a condvar. A reader arriving wakes it (`touch()`, which every read and every new subscriber calls); playback starting wakes it from the player, because the play head is written by the audio render callback and that thread may never take a lock.

The wake is sticky under the park lock, so one landing in the moment between the idle check and the park is not slept through — `a_wake_landing_before_the_park_is_not_slept_through` is that race.

## Dependency

`koan-core` takes `tokio` with `default-features = false, features = ["sync"]` — `watch` only, no runtime and no reactor. koan-ffi already links tokio, so the tree doesn't grow in practice.

## Verifying

- Play: bars follow the music, one redraw per published frame.
- Pause: bars fall to flat, then everything goes quiet — `sample` the process and the analyser thread has no frames.
- Resume: wakes on the player's edge, not on a poll.
- `cargo test --workspace` green; new tests cover the park/wake handshake and the fps clamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WAbe522TUhqe7K6QD4dnS2