### PR TITLE
perf(ffi): wake the state watcher instead of ticking it

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -216,6 +216,7 @@ A download that gives up sends `TrackFailed` instead, and the parked cursor adva
 | `device.rs` | CoreAudio device enumeration, sample rate get/set/watch (macOS only) |
 | `buffer.rs` | `PlaybackTimeline` — track boundaries, `current_playback()` position query (binary search), decode thread entry points (`start_decode`, `decode_single`, `decode_queue_loop`) |
 | `replaygain.rs` | EBU R128 loudness scanning, gain application, tag read/write via lofty |
+| `signal.rs` | `Wake` — a generation counter a reader can wait on, and the process-wide one every front end waits on. What lets koan hold state in versions and atomics without anyone having to look again |
 | `viz.rs` | `VizBuffer` (lock-protected ring of f32 samples for analyzer), `VizSnapshot` (atomic snapshot for UI thread), `VizLevels` (spectrum reduced to low/mid/high, cloning no waveform) |
 | `analyzer.rs` | FFT analysis thread — 48-band spectrum, VU meters, peak hold, beat detection (low-band transient). Runs at whatever rate a client sets, decays to flat when the play head stops, and parks when nothing is reading. Publishes to `VizSnapshot`. |
 | `streaming.rs` | `PartialFileSource` — reads a download in progress off disk, blocking at the write head |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Changed
 
+- **The engine stops polling itself.** A thread woke ten times a second for as long as koan was open, rebuilt what is playing, sampled every transfer's byte count, compared three version counters and published whatever had moved. The interface was reactive — the app has read events rather than asking since v0.32 — but the events were manufactured by a clock.
+
+  The writers say so now. Every setter on the player's shared state, the download store and the library version bump a wake; the watcher waits on it and reads the versions when it comes round, so a burst is still one pass and one message per slice. A koan with nothing happening does not schedule that thread at all.
+
+  Transfer rates go the same way: a reading is taken as the bytes land, held to one every 250ms, rather than by whoever happened to be watching. A transfer that settles zeroes its own figure rather than waiting to be sampled again — a row that finished used to keep the rate it managed on its last chunk until something looked.
+
 - **The playhead is an anchor, not a reading.** Position was published ten times a second, which is a stream that can never go quiet while music plays and a seek bar redrawn ten times a second to move it a pixel. It is the one number in koan that changes without anything happening — and a playhead advancing at one second per second is exactly what a client can work out for itself. The engine now says where the playhead is when your own reckoning would go wrong: a seek, a pause, a track boundary, a stall. Nothing in between.
 
   What draws it derives it. The seek bar is handed to Core Animation once per anchor with the rest of the track as its duration, so it moves without this process being woken at all; the elapsed figure is a system-drawn timer for the same reason; the lyrics panel sleeps until the next line's timestamp rather than checking where the song is. Media Remote gets told exactly when the system's own extrapolation would drift, which is what its elapsed-and-rate pair was always asking for.

--- a/crates/koan-core/src/helpers.rs
+++ b/crates/koan-core/src/helpers.rs
@@ -1244,6 +1244,9 @@ pub fn download_track(
     let announced_total = AtomicU64::new(u64::MAX);
     let result = client.download_with_progress(&remote_id, &dest, move |downloaded, total| {
         bytes_written_progress.store(downloaded, Ordering::Release);
+        // What knows a transfer moved is the code moving it. Held to a reading
+        // every 250ms inside, so a chunk landing costs an atomic and a compare.
+        store.progressed();
         if announced_total.swap(total, Ordering::Relaxed) != total {
             // The store, and only the store. The item's state says whether its
             // file can be played, which a transfer in flight has not changed.

--- a/crates/koan-core/src/lib.rs
+++ b/crates/koan-core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod player;
 pub mod playlists;
 pub mod radio;
 pub mod remote;
+pub mod signal;
 
 #[cfg(test)]
 pub mod test_utils;

--- a/crates/koan-core/src/player/state.rs
+++ b/crates/koan-core/src/player/state.rs
@@ -302,6 +302,7 @@ impl SharedPlayerState {
     }
 
     pub fn set_playback_state(&self, state: PlaybackState) {
+        self.changed();
         self.state.store(state as u8, Ordering::Release);
     }
 
@@ -311,6 +312,11 @@ impl SharedPlayerState {
 
     pub fn set_position_ms(&self, pos: u64) {
         self.position_ms.store(pos, Ordering::Release);
+        // Deliberately silent. The playhead advances on its own and is
+        // published as an anchor rather than as a reading — a wake per
+        // position would be the tick this whole arrangement removes. A seek, a
+        // pause and a track change all move something else here as well, and
+        // those are exactly the ones a client has to be told about.
     }
 
     pub fn track_info(&self) -> Option<TrackInfo> {
@@ -318,6 +324,7 @@ impl SharedPlayerState {
     }
 
     pub fn set_track_info(&self, info: Option<TrackInfo>) {
+        self.changed();
         *self.track_info.write() = info;
     }
 
@@ -469,6 +476,7 @@ impl SharedPlayerState {
     }
 
     pub fn set_radio_mode(&self, enabled: bool) {
+        self.changed();
         self.radio_mode.store(enabled, Ordering::Release);
     }
 
@@ -483,6 +491,7 @@ impl SharedPlayerState {
     }
 
     pub fn set_output_sample_rate(&self, rate: u32) {
+        self.changed();
         self.output_sample_rate
             .store(u64::from(rate), Ordering::Release);
     }
@@ -503,6 +512,16 @@ impl SharedPlayerState {
 
     fn bump_version(&self) {
         self.playlist_version.fetch_add(1, Ordering::AcqRel);
+        self.changed();
+    }
+
+    /// Say that something here moved, without saying what.
+    ///
+    /// Every version and atomic in this struct stays exactly as it was — they
+    /// are what a watcher consults to find out what changed. This is what
+    /// spares it looking when nothing did. See `crate::signal`.
+    pub fn changed(&self) {
+        crate::signal::engine_changed().bump();
     }
 
     // --- Playlist mutations (called from player thread via commands) ---

--- a/crates/koan-core/src/remote/downloads.rs
+++ b/crates/koan-core/src/remote/downloads.rs
@@ -107,6 +107,14 @@ pub struct DownloadStore {
     /// Separate from the entries so taking a sample does not touch the list
     /// every client is reading.
     samples: parking_lot::Mutex<HashMap<QueueItemId, Sample>>,
+    /// When the last reading was taken, and the count that goes with it.
+    ///
+    /// Readings are taken as bytes land rather than on a timer — the thing
+    /// that knows a transfer moved is the code moving it — and a chunk lands
+    /// far more often than a figure needs redrawing, so this is what holds
+    /// them to `MIN_SAMPLE_GAP`.
+    last_sample: parking_lot::Mutex<Option<Instant>>,
+    figures: AtomicU64,
     /// How many settled entries to keep. This is a view of now, not an archive,
     /// and old rows would push the live ones off the end of it.
     settled_limit: usize,
@@ -118,6 +126,8 @@ impl DownloadStore {
             entries: parking_lot::RwLock::new(Vec::new()),
             version: AtomicU64::new(0),
             samples: parking_lot::Mutex::new(HashMap::new()),
+            last_sample: parking_lot::Mutex::new(None),
+            figures: AtomicU64::new(0),
             settled_limit: 50,
         })
     }
@@ -127,6 +137,13 @@ impl DownloadStore {
     /// counters every frame regardless.
     pub fn version(&self) -> u64 {
         self.version.load(Ordering::Acquire)
+    }
+
+    /// Bumped whenever a byte count or a rate here moved. What a client
+    /// redraws a figure on, as against `version`, which is the list itself
+    /// changing shape.
+    pub fn figures(&self) -> u64 {
+        self.figures.load(Ordering::Acquire)
     }
 
     /// Everything, running first, then whatever settled most recently.
@@ -223,8 +240,15 @@ impl DownloadStore {
         let mut entries = self.entries.write();
         if let Some(entry) = entries.iter_mut().find(|d| d.id == id) {
             entry.state = state;
+            // Said here rather than at the next reading: a transfer that has
+            // finished takes no more readings, and a row left showing the rate
+            // it managed on its last chunk is a row that never stops.
+            entry.bytes_per_second = 0;
         }
         drop(entries);
+        self.samples.lock().remove(&id);
+        self.figures.fetch_add(1, Ordering::Release);
+        // `settle` bumps the version, which says so for both.
         self.settle();
     }
 
@@ -242,6 +266,7 @@ impl DownloadStore {
 
     fn bump(&self) {
         self.version.fetch_add(1, Ordering::Release);
+        crate::signal::engine_changed().bump();
     }
 }
 
@@ -264,13 +289,31 @@ const RATE_SMOOTHING: f64 = 0.3;
 const MIN_SAMPLE_GAP: Duration = Duration::from_millis(250);
 
 impl DownloadStore {
-    /// Take a rate reading. Called on a timer by whoever is watching.
+    /// Take a rate reading, if one is due.
+    ///
+    /// Called by the downloader as bytes land, not by a timer: what knows a
+    /// transfer moved is the code moving it, and what knows it stopped is the
+    /// absence of the next call. Chunks arrive far faster than a figure needs
+    /// redrawing, so this is gated to `MIN_SAMPLE_GAP` before it touches the
+    /// list every client is reading.
+    ///
+    /// Every running transfer is sampled, not just the one that moved: a
+    /// transfer that has stalled has nothing to report by definition, and its
+    /// figure decaying to zero is the one worth noticing.
     ///
     /// Rates live here rather than in each front end because every one of them
     /// would otherwise keep its own last-reading map and get a different
     /// answer.
-    pub fn sample_rates(&self) {
-        self.sample_rates_at(Instant::now());
+    pub fn progressed(&self) {
+        let now = Instant::now();
+        {
+            let mut last = self.last_sample.lock();
+            if last.is_some_and(|at| now.saturating_duration_since(at) < MIN_SAMPLE_GAP) {
+                return;
+            }
+            *last = Some(now);
+        }
+        self.sample_rates_at(now);
     }
 
     fn sample_rates_at(&self, now: Instant) {
@@ -315,6 +358,11 @@ impl DownloadStore {
         // A transfer that left the list leaves its reading behind with it.
         let live: std::collections::HashSet<QueueItemId> = entries.iter().map(|e| e.id).collect();
         samples.retain(|id, _| live.contains(id));
+
+        // Said once for the whole reading, so a client redraws every figure
+        // from one moment rather than a row at a time.
+        self.figures.fetch_add(1, Ordering::Release);
+        crate::signal::engine_changed().bump();
     }
 }
 

--- a/crates/koan-core/src/signal.rs
+++ b/crates/koan-core/src/signal.rs
@@ -1,0 +1,122 @@
+//! Saying that something changed, rather than being asked.
+//!
+//! koan's shared state is versions and atomics: the cheapest thing to read on
+//! a hot path, and the cheapest thing to *miss* — a reader had to look again to
+//! find out. This is the other half. A writer says so, a reader waits, and a
+//! koan with nothing happening schedules nothing at all.
+//!
+//! The versions stay exactly as they were. They are what a reader consults on
+//! waking to find out *what* moved, which is a handful of relaxed loads; this
+//! only answers *whether* anything did.
+
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use parking_lot::{Condvar, Mutex};
+
+/// A generation counter that can be waited on.
+pub struct Wake {
+    generation: Mutex<u64>,
+    changed: Condvar,
+}
+
+impl Wake {
+    pub fn new() -> Self {
+        Self {
+            generation: Mutex::new(0),
+            changed: Condvar::new(),
+        }
+    }
+
+    /// Something moved. Cheap, and cheapest of all when nobody is waiting.
+    pub fn bump(&self) {
+        let mut generation = self.generation.lock();
+        *generation = generation.wrapping_add(1);
+        self.changed.notify_all();
+    }
+
+    /// The generation now, to be handed back to `wait`.
+    pub fn generation(&self) -> u64 {
+        *self.generation.lock()
+    }
+
+    /// Wait until the generation leaves `seen`.
+    ///
+    /// Taken under the lock a bump takes, so one landing between a reader
+    /// deciding to wait and waiting is not slept through.
+    pub fn wait(&self, seen: u64) -> u64 {
+        let mut generation = self.generation.lock();
+        while *generation == seen {
+            self.changed.wait(&mut generation);
+        }
+        *generation
+    }
+
+    /// The same, giving up after `timeout`. For a caller that has something
+    /// else to check on — an engine that may have been dropped, a flag it does
+    /// not own — and cannot be woken for it.
+    pub fn wait_until(&self, seen: u64, timeout: Duration) -> u64 {
+        let mut generation = self.generation.lock();
+        if *generation == seen {
+            self.changed.wait_for(&mut generation, timeout);
+        }
+        *generation
+    }
+}
+
+impl Default for Wake {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// The one every front end waits on.
+///
+/// Process-wide, like the download store beside it, and for the same reason: a
+/// writer deep in the player or in a download worker has to be able to say so
+/// without having been handed anything. Two engines in one process would share
+/// it, which costs a spurious wake and nothing else — what actually moved is
+/// decided by the version counters afterwards, not by this.
+pub fn engine_changed() -> &'static Wake {
+    static WAKE: OnceLock<Wake> = OnceLock::new();
+    WAKE.get_or_init(Wake::new)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    #[test]
+    fn a_waiter_sleeps_until_something_moves() {
+        let wake = Arc::new(Wake::new());
+        let seen = wake.generation();
+        let woken = Arc::new(AtomicBool::new(false));
+
+        let waiter = {
+            let (wake, woken) = (Arc::clone(&wake), Arc::clone(&woken));
+            std::thread::spawn(move || {
+                wake.wait(seen);
+                woken.store(true, Ordering::Relaxed);
+            })
+        };
+
+        std::thread::sleep(Duration::from_millis(50));
+        assert!(
+            !woken.load(Ordering::Relaxed),
+            "woke with nothing to wake for"
+        );
+        wake.bump();
+        waiter.join().unwrap();
+    }
+
+    #[test]
+    fn a_bump_before_the_wait_is_not_slept_through() {
+        let wake = Wake::new();
+        let seen = wake.generation();
+        wake.bump();
+        // Would block for ever if the generation were not what says so.
+        assert_ne!(wake.wait(seen), seen);
+    }
+}

--- a/crates/koan-ffi/src/lib.rs
+++ b/crates/koan-ffi/src/lib.rs
@@ -134,6 +134,17 @@ fn init_logging() {
     }
 }
 
+impl Drop for KoanEngine {
+    /// Wake the state watcher so it notices there is nothing left to watch.
+    ///
+    /// It waits with no timeout, holding a weak reference precisely so it does
+    /// not keep the engine alive — and a thread parked for ever would never
+    /// find out that it had gone.
+    fn drop(&mut self) {
+        koan_core::signal::engine_changed().bump();
+    }
+}
+
 /// One client's subscription to the analyser.
 ///
 /// A cursor over the published frame, in the shape `StateStream` already uses:
@@ -2193,17 +2204,25 @@ impl OrganizeSelection {
 impl KoanEngine {
     /// Watch shared state and publish what changed.
     ///
-    /// Polls, but in Rust and over atomics, which is nothing — and the client
-    /// sees changes rather than asking for them. The alternative, notifying
-    /// from the player's own mutation points, would put foreign calls on the
-    /// decode thread.
+    /// Woken rather than timed. It used to look at every version and atomic in
+    /// the engine ten times a second for as long as koan was open, which is a
+    /// scheduled thread and a rebuilt `NowPlaying` per tick to find, nearly
+    /// always, that nothing had moved. The writers say so now — every setter on
+    /// `SharedPlayerState`, the download store, the library version — and this
+    /// waits in between. A koan with nothing happening does not run this thread
+    /// at all.
     ///
-    /// The loop's period is the batch window: whatever moved inside one tick
-    /// leaves as at most one message per slice, so a client's cost is set by
-    /// how many slices changed and never by how many times they changed. The
-    /// expensive snapshots are built only when the version behind them moved —
-    /// deriving the whole queue ten times a second to find it unchanged is the
-    /// waste this guard exists to avoid.
+    /// What the wake does *not* say is which of them moved: that is still read
+    /// off the versions here, on waking, because they are cheap and because a
+    /// single wake covers a burst. So a pass batches: whatever moved between
+    /// two wakes leaves as at most one message per slice, and a client's cost
+    /// is set by how many slices changed and never by how many times they
+    /// changed. The expensive snapshots are built only when the version behind
+    /// them moved — deriving the whole queue to find it unchanged is the waste
+    /// that guard exists to avoid.
+    ///
+    /// The playhead is the one thing no writer can announce, because it moves
+    /// on its own. It is published as an anchor instead: see `state::Anchor`.
     fn spawn_watcher(self: &Arc<Self>) {
         let engine = Arc::downgrade(self);
         std::thread::Builder::new()
@@ -2211,20 +2230,32 @@ impl KoanEngine {
             .spawn(move || {
                 let mut last_queue = u64::MAX;
                 let mut last_store = u64::MAX;
+                let mut last_figures = u64::MAX;
                 let mut last_library = u64::MAX;
                 // The playhead as a client last heard it, and when. What it
                 // would believe now is derived from these two, which is what
                 // makes publishing again unnecessary until it would be wrong.
                 let mut anchor: Option<state::Anchor> = None;
                 let mut last_seekable = u64::MAX;
-                // Which transfers were running last tick. A transfer leaving
+                // Which transfers were running last pass. A transfer leaving
                 // this set has landed on disk, which wrote a cached path onto a
                 // library row — and nothing else says so, because the download
                 // ran in koan-core, which has no notion of that version.
                 let mut running: HashSet<String> = HashSet::new();
 
+                // Where this thread spends the whole of a quiet koan. Every
+                // slice below is derived from a version or an atomic, all of
+                // them cheap to read and none of them able to say when they
+                // moved — so this used to look at the lot of them ten times a
+                // second for as long as the app was open. The writers say so
+                // now, and this is not scheduled at all in between.
+                let wake = koan_core::signal::engine_changed();
+                // Read before the first pass, not after it: anything that moves
+                // while a pass is publishing leaves the generation past this,
+                // and the wait at the foot of the loop returns at once rather
+                // than sleeping through it.
+                let mut seen = wake.generation();
                 loop {
-                    std::thread::sleep(std::time::Duration::from_millis(100));
                     let Some(engine) = engine.upgrade() else {
                         return; // Engine dropped; so is the app.
                     };
@@ -2278,31 +2309,46 @@ impl KoanEngine {
                         });
                     }
 
-                    // Ten a second, which is this loop's rate and fast enough
-                    // that a figure on screen reacts as a transfer changes pace.
-                    koan_core::remote::downloads::store().sample_rates();
-                    let store_version = koan_core::remote::downloads::store().version();
-                    let transfers = koan_core::remote::downloads::store().all();
-                    // Structural and volatile from one reading of one list, so
-                    // a row and its figure can never describe different moments.
-                    out.publish(StateSlice::Figures {
-                        figures: transfers.iter().map(TransferFigure::from).collect(),
-                    });
-                    if store_version != last_store {
-                        last_store = store_version;
-                        out.publish(StateSlice::Transfers {
-                            transfers: transfers.iter().map(Transfer::from).collect(),
-                        });
+                    // Taken as the bytes land rather than here — see
+                    // `DownloadStore::progressed`. This asks whether a reading
+                    // has been taken since the last one it published, which for
+                    // a koan with nothing downloading is never.
+                    // Readings are taken as the bytes land rather than here —
+                    // see `DownloadStore::progressed` — so this asks whether
+                    // one has been taken since the last it published, which for
+                    // a koan with nothing downloading is never. The list is
+                    // read once and only when one of the two has moved: it is a
+                    // clone of every transfer koan knows about.
+                    let store = koan_core::remote::downloads::store();
+                    let store_version = store.version();
+                    let figures_version = store.figures();
+                    if figures_version != last_figures || store_version != last_store {
+                        // Structural and volatile from one reading of one list,
+                        // so a row and its figure can never describe different
+                        // moments.
+                        let transfers = store.all();
+                        if figures_version != last_figures {
+                            last_figures = figures_version;
+                            out.publish(StateSlice::Figures {
+                                figures: transfers.iter().map(TransferFigure::from).collect(),
+                            });
+                        }
+                        if store_version != last_store {
+                            last_store = store_version;
+                            out.publish(StateSlice::Transfers {
+                                transfers: transfers.iter().map(Transfer::from).collect(),
+                            });
+                        }
+                        let now_running: HashSet<String> = transfers
+                            .iter()
+                            .filter(|d| !d.state.is_settled())
+                            .map(|d| d.id.0.to_string())
+                            .collect();
+                        if running.difference(&now_running).next().is_some() {
+                            engine.bump_library();
+                        }
+                        running = now_running;
                     }
-                    let now_running: HashSet<String> = transfers
-                        .iter()
-                        .filter(|d| !d.state.is_settled())
-                        .map(|d| d.id.0.to_string())
-                        .collect();
-                    if running.difference(&now_running).next().is_some() {
-                        engine.bump_library();
-                    }
-                    running = now_running;
 
                     let library = engine
                         .library_version
@@ -2331,6 +2377,12 @@ impl KoanEngine {
                             lock: engine.queue_lock_blocking(),
                         });
                     }
+
+                    // Dropped before the wait: this thread holds the engine
+                    // only for as long as it is reading it, so parking here
+                    // cannot be what keeps koan open.
+                    drop(engine);
+                    seen = wake.wait(seen);
                 }
             })
             .ok();
@@ -2501,6 +2553,7 @@ impl KoanEngine {
     fn bump_library(&self) {
         self.library_version
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        koan_core::signal::engine_changed().bump();
     }
 
     fn scan_blocking(
@@ -2705,7 +2758,10 @@ impl KoanEngine {
         std::thread::Builder::new()
             .name("koan-session-restore".into())
             .spawn(move || {
-                for _ in 0..600 {
+                let wake = koan_core::signal::engine_changed();
+                let mut seen = wake.generation();
+                let deadline = Instant::now() + std::time::Duration::from_secs(60);
+                loop {
                     // The user may have started playing something in the
                     // meantime; restoring a position over that would be rude.
                     if state.playback_state() != PlaybackState::Stopped
@@ -2730,7 +2786,13 @@ impl KoanEngine {
                         }
                         return;
                     }
-                    std::thread::sleep(std::time::Duration::from_millis(100));
+                    let Some(left) = deadline.checked_duration_since(Instant::now()) else {
+                        break;
+                    };
+                    // A track becoming ready moves the queue, which is a change
+                    // like any other. The timeout is the giving-up clock rather
+                    // than a look-again one: this wakes when the item does.
+                    seen = wake.wait_until(seen, left);
                 }
                 log::info!("session restore: track never became ready, leaving position at 0");
             })


### PR DESCRIPTION
Stacked on #394, which is stacked on #393.

The last clock in the engine. A thread woke ten times a second for as long as koan was open, rebuilt `NowPlaying`, cloned every transfer, sampled their byte counts, compared three version counters, and published whatever moved. #378 made the *interface* reactive — the app has read events rather than asked since v0.32 — but the events were manufactured by a poll.

## The wake

`koan_core::signal::Wake` is a generation counter with a condvar: `bump()` from a writer, `wait(seen)` from a reader, taken under the same lock so a bump landing between the decision to wait and the wait itself is not slept through.

Every setter on `SharedPlayerState`, the download store and the library version bumps it. The watcher waits on it and *then* reads the versions to find out what actually moved — a wake says "something", the versions say "what", and one wake covers a burst, so a pass still batches to at most one message per slice.

Process-wide, like `downloads::store()` beside it and for the same reason: a writer deep in a download worker has to be able to say so without having been handed anything.

## Transfer rates

Sampled as the bytes land — `DownloadStore::progressed()` from the download's own progress callback — gated to one reading every 250ms so a chunk costs an atomic and a compare. Every running transfer is sampled on any reading, so a stalled one still decays to zero.

A settled transfer zeroes its own figure. It used to keep the rate it managed on its last chunk until something looked at it again, which with no poll would have been never.

## What is deliberately still not signalled

`set_position_ms`. It moves on its own and a wake per position is exactly the tick this removes — it's published as an anchor (#394). A seek, a pause and a track change each move something else here too, and those are the ones a client must be told about.

## Verifying

- Idle koan, nothing playing: `sample` the process — no `koan-state` frames at all.
- Play, pause, seek, reorder the queue, favourite something: the UI keeps up.
- Start a download: rows appear, figures move, rates read sensibly, and the row zeroes when it lands.
- Quit: `Drop for KoanEngine` bumps the wake so the parked watcher finds the engine gone and exits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WAbe522TUhqe7K6QD4dnS2