### PR TITLE
fix(macos): give the columns the room they draw at, and let the transport shed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- **The transport sheds what will not fit rather than squashing it.** The centre zone held `maxWidth: 560` at the highest layout priority, so it claimed 560 points of any bar wide enough to offer them and left the two sides to share the remainder — about thirty points each at the smallest window. The format badge and the output device were drawn a few points wide, and the track's name got three letters. The centre is handed a share of the bar now and the sides split what is left equally, which is what keeps the transport centred; a side that runs short drops things in order — the radio toggle's word, then the sleeve, then the format badge — instead of compressing all of them.
+
+- **The window is wide enough for the columns it has.** `NavigationSplitView` does not refuse to go below a column's declared minimum: it lays the column out at its *ideal* width and clips whatever does not fit. With the lyrics panel open there was nothing left to take, so the sidebar's rows and half the lyrics hung outside their own panes — and with no slack to move through, the split view stopped animating and started clamping, which is why the panel arrived whole in one frame instead of sliding. The floor is now the sum of what the columns actually draw at: the widest page's stage, the sidebar, and the panel. It is one number rather than one per column count, because a floor that moved when the panel opened resized the window under you.
+
+- **The lyrics panel slides open.** Its state was `@AppStorage`, and a `UserDefaults` write publishes on its own after the transaction that caused it has gone — so the pane had no animation to expand with while everything around it was still moving. It is observable state that writes through to defaults now, so the change happens inside the transaction and the pane and the stage move together.
+
 ## v0.33.1 (2026-08-28)
 
 ### Added

--- a/apps/macos/Sources/Koan/KoanApp.swift
+++ b/apps/macos/Sources/Koan/KoanApp.swift
@@ -107,7 +107,6 @@ struct KoanApp: App {
     private var isTyping: Bool { state?.textFocus.isEditing == true }
     @Environment(\.scenePhase) private var scenePhase
     @State private var startupError: String?
-    @AppStorage("showLyrics") private var showLyrics = false
 
     var body: some Scene {
         Window("koan", id: MainWindow.id) {
@@ -135,7 +134,23 @@ struct KoanApp: App {
                     ProgressView().controlSize(.small)
                 }
             }
-            .frame(minWidth: 940, minHeight: 620)
+            // Room for all three columns at the width each one draws itself
+            // at, whether or not the third is open.
+            //
+            // `NavigationSplitView` does not refuse to go below a column's
+            // declared minimum. It lays the column out at its *ideal* width and
+            // clips whatever does not fit, and with no slack left it stops
+            // animating and starts clamping — which is one cause behind two
+            // symptoms: the sidebar's rows hanging off the side of the window,
+            // and the lyrics panel arriving in a single frame instead of
+            // sliding. So the floor is the sum of what the columns draw at:
+            // the widest page's stage (the record and playlist headers, ~760)
+            // plus the sidebar's 215 and the inspector's 320.
+            //
+            // One number rather than one per column count: a floor that moved
+            // when the lyrics panel opened resized the window under you, and a
+            // window that jumps is worse than a window that is wide.
+            .frame(minWidth: 1320, minHeight: 620)
             .task {
                 guard state == nil, startupError == nil else { return }
                 do {
@@ -174,7 +189,7 @@ struct KoanApp: App {
                 ShortcutButton(.forward) { state?.nav.goForward() }
                     .disabled(isTyping)
                 Divider()
-                ShortcutButton(.lyrics) { showLyrics.toggle() }
+                ShortcutButton(.lyrics) { state?.ui.toggleLyrics() }
                 Divider()
             }
 

--- a/apps/macos/Sources/Koan/Support/UIState.swift
+++ b/apps/macos/Sources/Koan/Support/UIState.swift
@@ -62,11 +62,28 @@ final class UIState {
         queueJumpToken += 1
     }
 
-    /// The panel's state is `@AppStorage`, so it survives a launch and there is
-    /// no second copy of it here to disagree with.
+    /// Whether the lyrics panel is open.
+    ///
+    /// Observable state that writes through to defaults, rather than
+    /// `@AppStorage` on each view that reads it. A `UserDefaults` write
+    /// publishes on its own, after the transaction that caused it has gone —
+    /// so the inspector had no animation to expand with and arrived at full
+    /// width in a single frame while everything around it was still sliding.
+    /// An observed property changes *inside* the transaction, which is what
+    /// hands the pane AppKit's own slide.
+    ///
+    /// Still one copy, and still where you left it across a launch.
+    var showLyrics: Bool = UserDefaults.standard.bool(forKey: UIState.lyricsKey) {
+        didSet { UserDefaults.standard.set(showLyrics, forKey: UIState.lyricsKey) }
+    }
+
+    private static let lyricsKey = "showLyrics"
+
+    /// Explicitly animated, because that is now possible: the transaction this
+    /// opens reaches the inspector's split view, so the pane slides and the
+    /// stage and transport resize with it instead of after it.
     func toggleLyrics() {
-        let defaults = UserDefaults.standard
-        defaults.set(!defaults.bool(forKey: "showLyrics"), forKey: "showLyrics")
+        withAnimation(.smooth(duration: 0.28)) { showLyrics.toggle() }
     }
 }
 

--- a/apps/macos/Sources/Koan/Views/RootView.swift
+++ b/apps/macos/Sources/Koan/Views/RootView.swift
@@ -33,7 +33,6 @@ struct RootView: View {
     /// record in it, since a playlist has no cover of its own.
     @Environment(PlaylistsModel.self) private var playlists
 
-    @AppStorage("showLyrics") private var showLyrics = false
     /// Read for the window's own glass — the toolbar and the transport's soft
     /// edge, which are the platform's rather than koan's and which no step of
     /// this setting used to reach.
@@ -114,9 +113,13 @@ struct RootView: View {
                 // and the scroll edges sized to it.
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
-        .inspector(isPresented: $showLyrics) {
+        .inspector(isPresented: $ui.showLyrics) {
             LyricsPanel()
                 .inspectorColumnWidth(min: 260, ideal: 320, max: 460)
+                // The column animates on its own; its contents do not come
+                // with it. Without this the stage slides over and the pane
+                // then appears whole in one frame, a fifth of a second later.
+                .transition(.move(edge: .trailing))
                 // The toggle belongs to the inspector rather than the window, so
                 // it sits at the pane's leading edge and moves with it. In the
                 // window's trailing group the pane opened out from underneath
@@ -124,7 +127,7 @@ struct RootView: View {
                 .toolbar {
                     ToolbarItem(placement: .primaryAction) {
                         Button {
-                            showLyrics.toggle()
+                            ui.toggleLyrics()
                         } label: {
                             Label("Lyrics", systemImage: Icon.lyrics)
                         }
@@ -193,7 +196,7 @@ struct RootView: View {
         .overlay(alignment: .bottom) {
             TransportBar()
                 .padding(.leading, columns == .detailOnly ? 0 : ui.sidebarWidth)
-                .padding(.trailing, showLyrics ? ui.lyricsWidth : 0)
+                .padding(.trailing, ui.showLyrics ? ui.lyricsWidth : 0)
                 .background(
                     GeometryReader { proxy in
                         Color.clear.preference(

--- a/apps/macos/Sources/Koan/Views/TransportBar.swift
+++ b/apps/macos/Sources/Koan/Views/TransportBar.swift
@@ -20,65 +20,109 @@ struct TransportBar: View {
     @State private var backSkips = 0
     @State private var forwardSkips = 0
 
+    /// The bar's outer width, so it can shed rather than squash. The sidebar
+    /// and the lyrics panel both take their room out of this, so the window
+    /// being wide is no promise that the bar is.
+    @State private var barWidth: CGFloat = 0
+
     /// Wide enough to read as a slab rather than a pill at this height.
     private static let radius: CGFloat = 26
     /// One height for all three zones, so the bar is a bar and not a stack of
     /// controls that happen to be near each other.
     private static let zoneHeight: CGFloat = 46
+    private static let zoneGap: CGFloat = 18
+    private static let inset: CGFloat = 16
 
     var body: some View {
-        // Three equal-weight columns so the transport stays centred as the
-        // window grows, rather than the centre pinning at a fixed width and
-        // everything bunching to the left.
-        HStack(spacing: 18) {
+        // Three columns: a centre sized to the room there is, and two flexible
+        // sides that split what is left equally, so the transport stays centred
+        // as the window grows.
+        //
+        // The centre is *given* a width rather than allowed to claim one. It
+        // held `maxWidth: 560` at the highest layout priority, which meant it
+        // took 560 of any bar wide enough to offer it and left the sides to
+        // share the remainder — at the smallest window that was 30pt between
+        // them, and the format badge and the output device were squeezed to
+        // slivers rather than being dropped.
+        HStack(spacing: Self.zoneGap) {
             nowPlaying
                 .frame(height: Self.zoneHeight)
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .layoutPriority(1)
 
             VStack(spacing: 5) {
                 controls
                 SeekBar()
             }
             .frame(height: Self.zoneHeight)
-            .frame(maxWidth: 560)
-            .layoutPriority(2)
+            .frame(width: centreWidth)
 
             trailing
                 .frame(height: Self.zoneHeight)
                 .frame(maxWidth: .infinity, alignment: .trailing)
-                .layoutPriority(1)
         }
-        .padding(.horizontal, 16)
+        .padding(.horizontal, Self.inset)
         .padding(.vertical, 9)
         .glass(.regular, fallback: .regularMaterial, in: .rect(cornerRadius: Self.radius))
-        .padding(.horizontal, 16)
+        .padding(.horizontal, Self.inset)
         .padding(.bottom, 14)
+        // Measured outside the paddings, so nothing the layout below decides
+        // feeds back into the width it was decided from.
+        .onGeometryChange(for: CGFloat.self) { $0.size.width } action: { barWidth = $0 }
     }
+
+    /// What the three zones have between them, once both insets are paid.
+    private var available: CGFloat { max(0, barWidth - Self.inset * 4) }
+
+    /// Room enough to read a seek bar off, and no more than the controls need.
+    /// A share of the bar rather than a constant: the transport is the middle
+    /// of the window, and it should look like it at every width.
+    private var centreWidth: CGFloat { min(560, max(210, available * 0.40)) }
+
+    /// What each side gets. Both are the same by construction — that is what
+    /// keeps the centre centred — so one number answers for both.
+    private var sideWidth: CGFloat { max(0, (available - Self.zoneGap * 2 - centreWidth) / 2) }
+
+    /// Below this the radio toggle is its icon alone. The word is the first
+    /// thing worth giving up: the button is lit when it is on, so it says what
+    /// it is either way.
+    private var compact: Bool { sideWidth < 190 }
+
+    /// And below this the format badge goes too. It is the last thing dropped
+    /// because it is the one thing on the bar that says what the DAC is being
+    /// handed — but a badge crushed to a sliver says nothing at all.
+    private var showsFormat: Bool { sideWidth >= 145 }
+
+    /// The sleeve is the leading side's own version of the same trade. It is
+    /// the largest thing there and the least informative — the queue behind it
+    /// is nothing but sleeves — so a narrow bar spends its room on the names
+    /// instead, rather than truncating them to three letters beside a cover.
+    private var showsArtwork: Bool { sideWidth >= 150 }
 
     // MARK: - Left: what's on
 
     @ViewBuilder
     private var nowPlaying: some View {
         HStack(spacing: 11) {
-            if let sleeve = player.currentArtwork {
-                AlbumArtwork(source: sleeve, size: .thumb, cornerRadius: 8)
-                    .frame(width: 44, height: 44)
-                    .showsArtworkFullSize(
-                        source: sleeve,
-                        title: player.currentEntry?.title ?? "",
-                        subtitle: player.currentEntry.map {
-                            "\($0.artist) — \($0.album)"
+            if showsArtwork {
+                if let sleeve = player.currentArtwork {
+                    AlbumArtwork(source: sleeve, size: .thumb, cornerRadius: 8)
+                        .frame(width: 44, height: 44)
+                        .showsArtworkFullSize(
+                            source: sleeve,
+                            title: player.currentEntry?.title ?? "",
+                            subtitle: player.currentEntry.map {
+                                "\($0.artist) — \($0.album)"
+                            }
+                        )
+                } else {
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(.quaternary)
+                        .frame(width: 44, height: 44)
+                        .overlay {
+                            Image(systemName: "music.note")
+                                .foregroundStyle(.tertiary)
                         }
-                    )
-            } else {
-                RoundedRectangle(cornerRadius: 8)
-                    .fill(.quaternary)
-                    .frame(width: 44, height: 44)
-                    .overlay {
-                        Image(systemName: "music.note")
-                            .foregroundStyle(.tertiary)
-                    }
+                }
             }
 
             VStack(alignment: .leading, spacing: 2) {
@@ -114,7 +158,10 @@ struct TransportBar: View {
                         .foregroundStyle(.secondary)
                 }
             }
-            .frame(minWidth: 90, alignment: .leading)
+            // No minimum: a narrow bar should truncate the names, which is what
+            // a line of text is for, rather than hold a width that pushes the
+            // heart off the end of the zone.
+            .frame(maxWidth: .infinity, alignment: .leading)
             // Gapless means a track can change with nothing else to mark it.
             // A cross-fade catches the corner of the eye; a hard swap doesn't.
             .contentTransition(.opacity)
@@ -186,9 +233,13 @@ struct TransportBar: View {
     private var trailing: some View {
         HStack(spacing: 12) {
             // The whole point of the player: what the DAC is being handed.
-            if let format = player.currentFormat {
+            if let format = player.currentFormat, showsFormat {
                 Text(Format.quality(format))
                     .font(.caption.monospaced())
+                    // One line or none. Mid-resize the zone is briefly narrower
+                    // than the badge, and a badge that wraps to two lines is
+                    // taller than the bar it sits in.
+                    .lineLimit(1)
                     // A refused rate isn't a fault to raise an alarm over, so
                     // it reads at the same weight as the rest of the badge and
                     // explains itself only to someone who looks.
@@ -203,9 +254,15 @@ struct TransportBar: View {
                 get: { player.radioEnabled },
                 set: { player.setRadio($0) }
             )) {
-                Label("Radio", systemImage: Icon.radio)
-                    .labelStyle(.titleAndIcon)
-                    .font(.caption)
+                if compact {
+                    Label("Radio", systemImage: Icon.radio)
+                        .labelStyle(.iconOnly)
+                        .font(.caption)
+                } else {
+                    Label("Radio", systemImage: Icon.radio)
+                        .labelStyle(.titleAndIcon)
+                        .font(.caption)
+                }
             }
             .toggleStyle(.button)
             .buttonStyle(.glass)
@@ -213,6 +270,10 @@ struct TransportBar: View {
 
             DeviceMenu()
         }
+        // Natural size, always. What does not fit is dropped above rather than
+        // compressed — a badge and a menu squeezed to a few points wide is what
+        // the smallest window used to show.
+        .fixedSize(horizontal: true, vertical: false)
     }
 }
 


### PR DESCRIPTION
At the smallest window size the macOS app drew three things wrong. Two of them turned out to be the same cause.

## What this does

**The window's floor is now the sum of what the columns draw at (940 → 1320).**

`NavigationSplitView` does not refuse to go below a column's declared minimum. It lays the column out at its *ideal* width and clips whatever does not fit. With the lyrics panel open at 940 the sidebar got 137pt against a 215pt ideal and the inspector 208 against 320 — hence rows and lyrics hanging outside their own panes. The same shortage is why the panel stopped sliding: with no slack to move through, the split view clamps instead of animating.

The floor is `widest page's stage (~760) + sidebar ideal (215) + inspector ideal (320)`. One number rather than one per column count — a floor that moved when the panel opened resized the window under you, which is worse than a window that is wide.

**The transport sheds instead of squashing.** The centre zone held `maxWidth: 560` at the highest layout priority, so it claimed 560pt of any bar wide enough to offer it and left the two sides to share the remainder — about 30pt each at the smallest window. The format badge and the output device were drawn as slivers and the track name got three letters. The centre is now handed a share of the measured bar and the sides split what is left equally (which is what keeps the transport centred); a side that runs short drops things in order — the radio toggle's word, then the sleeve, then the format badge.

**The lyrics panel slides open.** `showLyrics` was `@AppStorage`, and a `UserDefaults` write publishes on its own *after* the transaction that caused it has gone — so the pane had no animation to expand with while the stage around it was still moving. It is observable state on `UIState` that writes through to defaults now, toggled inside `withAnimation`, so the change lands inside the transaction. Still one copy of the flag, still persisted across launches; all three entry points (toolbar button, View menu, ⌥⌘L) go through `toggleLyrics()`.

## How to confirm

Build and run (`just macos-run` — note `just macos-build` alone does *not* re-bundle):

1. Shrink the window to its minimum with the lyrics panel open. The sidebar's rows and footer counts should be fully inside the sidebar, and the lyrics should wrap inside their pane rather than running off the edge.
2. Look at the transport at that width. The format badge and output device should be whole or absent, never compressed; the radio toggle drops its label before anything else goes.
3. Toggle the lyrics panel (⌥⌘L). The pane and the stage should move together.
4. Widen the window right out — the format badge, radio label and sleeve should all come back.

## Known limitations

- **The 1320 floor is driven by the playlist and album pages**, whose headers demand ~760pt of stage against the queue's ~600. Making those headers compress would let the floor come back down toward ~1150 and give the panel more slack at the minimum. Not attempted here — it is a change to those pages' layout and deserves its own PR.
- **At the floor itself the panel's slide is still tighter than it is on a large window.** Frame captures at the pane's leading edge across an open: 1200pt showed no intermediate frames at all, 1320 shows the stage sliding, 2000 catches the pane genuinely half-expanded. Better, not perfect, and it is gated on the same header work above.
- **The lyrics toolbar button still looks orphaned in full screen**, floating above the pane's top edge rather than reading as part of it. I tried moving it into the window toolbar and reverted: `ToolbarSpacer` is dropped when it follows an unconditional item, so the button merged into the filter field's capsule on every page that has one. Untouched in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GSymWiy72ReFs1jiEMcqQg