### PR TITLE
perf(server): push the subscriptions instead of polling for them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 
 ### Changed
 
+- **The GraphQL subscriptions are pushed, not polled.** `nowPlaying` and `queueUpdated` looked at the engine every 200ms and 500ms and yielded when something had moved; `vizFrame` resampled the analyser at whatever rate the client asked for, sending frames twice or skipping them depending on how the two clocks lined up. All three wait on a signal now. `vizFrame` is one message per analysed frame, and its `fps` sets the rate the analyser itself runs at rather than a rate to resample it at — one analyser, so a second client asking for a different figure moves it for both.
+
+  `nowPlaying` sends an anchor, the way the native client already receives one: `positionMs` is where the playhead was when the message was sent, and a client that knows it is playing can work out the rest. It arrives on a seek, a pause, a track boundary or a stall — not on a clock — so a paused koan sends nothing at all. **A client drawing a moving position must derive it rather than waiting to be told.** The `intervalMs` arguments remain in the schema and are ignored, so existing queries still parse.
+
+- **The app waits to be told rather than looking.** Restoring a session and jumping to the queue after an enqueue both watched a value every five milliseconds until it moved. They wait on the mirror now, with the deadline as one sleep for the whole wait rather than one per look.
+
 - **The last three clocks go.** The activity rows asked the engine whether a scan or a sync was running, once a second, for the whole life of the app, to notice something that happens twice a day — the engine says so now, in the same stream as everything else. The session autosave woke every second whether or not there was anything to save; it runs while the music does and writes on the edge when it stops. And a decode thread reading a track that is still downloading looked at the byte count every ten milliseconds: it waits on the count itself now, woken by the bytes as they land and by whatever ends the transfer.
 
 - **The engine stops polling itself.** A thread woke ten times a second for as long as koan was open, rebuilt what is playing, sampled every transfer's byte count, compared three version counters and published whatever had moved. The interface was reactive — the app has read events rather than asking since v0.32 — but the events were manufactured by a clock.

--- a/apps/macos/Sources/Koan/Support/EngineMirror.swift
+++ b/apps/macos/Sources/Koan/Support/EngineMirror.swift
@@ -286,6 +286,69 @@ extension EngineMirror {
             Task { @MainActor [weak self] in self?.follow(body) }
         }
     }
+
+    /// Wait until `settled` holds, or until `deadline` passes.
+    ///
+    /// For the two places that have asked the engine for something and want the
+    /// answer before drawing — a restored queue, a queue mutation to confirm.
+    /// Both looked again every five milliseconds until it arrived; the mirror
+    /// is observable, so the arrival is a thing to be woken by. The deadline is
+    /// one sleep for the whole wait rather than one per look, and it is a
+    /// giving-up clock, not a checking one.
+    func waitUntil(
+        _ deadline: ContinuousClock.Instant,
+        _ settled: @escaping @MainActor () -> Bool
+    ) async {
+        while !settled(), ContinuousClock.now < deadline {
+            await nextChange(before: deadline)
+        }
+    }
+
+    /// Resumes on the next change to anything held here, or at `deadline`.
+    ///
+    /// Resumed from a task rather than from the change handler itself: the
+    /// handler runs *before* the mutation it is announcing, so a caller told
+    /// there and then would read the value it was waiting to see change.
+    ///
+    /// Whichever arrives first resumes; the `Once` is what makes the other one
+    /// harmless, since observation is registered for one change and a handler
+    /// that lost the race still fires.
+    private func nextChange(before deadline: ContinuousClock.Instant) async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            let once = Once()
+            withObservationTracking {
+                _ = playback
+                _ = playhead
+                _ = queue
+                _ = lock
+                _ = transfers
+                _ = figures
+                _ = libraryVersion
+                _ = tasks
+            } onChange: {
+                Task { @MainActor in
+                    if once.take() { continuation.resume() }
+                }
+            }
+            Task { @MainActor in
+                try? await Task.sleep(until: deadline, clock: .continuous)
+                if once.take() { continuation.resume() }
+            }
+        }
+    }
+}
+
+/// One-shot latch. Everything that touches it is on the main actor, so it is
+/// a Bool and a method rather than anything cleverer.
+@MainActor
+private final class Once {
+    private var spent = false
+
+    func take() -> Bool {
+        guard !spent else { return false }
+        spent = true
+        return true
+    }
 }
 
 extension TransferState {

--- a/apps/macos/Sources/Koan/Support/Navigator.swift
+++ b/apps/macos/Sources/Koan/Support/Navigator.swift
@@ -263,14 +263,8 @@ final class Navigator {
     func showQueueWhenReady(watching player: PlayerModel) {
         let before = player.queueVersion
         Task {
-            let deadline = ContinuousClock.now + .milliseconds(50)
-            while ContinuousClock.now < deadline {
-                if player.queueVersion != before {
-                    show(.queue)
-                    return
-                }
-                try? await Task.sleep(for: .milliseconds(5))
-            }
+            await player.settle(within: .milliseconds(50)) { player.queueVersion != before }
+            if player.queueVersion != before { show(.queue) }
         }
     }
 }

--- a/apps/macos/Sources/Koan/Support/PlayerModel.swift
+++ b/apps/macos/Sources/Koan/Support/PlayerModel.swift
@@ -509,10 +509,14 @@ final class PlayerModel {
     /// window shut.
     func restoreSession() async {
         guard let restored = try? await engine.restoreSession(), restored > 0 else { return }
-        let deadline = ContinuousClock.now + .milliseconds(500)
-        while mirror.queue.count < Int(restored), ContinuousClock.now < deadline {
-            try? await Task.sleep(for: .milliseconds(5))
-        }
+        await settle(within: .milliseconds(500)) { self.mirror.queue.count >= Int(restored) }
+    }
+
+    /// Wait for the engine to catch up with something already asked of it, or
+    /// give up after `limit`. Woken by the mirror rather than looking again —
+    /// see `EngineMirror.waitUntil`.
+    func settle(within limit: Duration, _ settled: @escaping @MainActor () -> Bool) async {
+        await mirror.waitUntil(.now + limit, settled)
     }
 
     // MARK: - Errors

--- a/crates/koan-core/src/signal.rs
+++ b/crates/koan-core/src/signal.rs
@@ -13,11 +13,16 @@ use std::sync::OnceLock;
 use std::time::Duration;
 
 use parking_lot::{Condvar, Mutex};
+use tokio::sync::watch;
 
 /// A generation counter that can be waited on.
 pub struct Wake {
     generation: Mutex<u64>,
     changed: Condvar,
+    /// The same signal for a caller that cannot park a thread on it. A GraphQL
+    /// subscription is a task on a runtime, and a task that blocks holds a
+    /// worker rather than sleeping.
+    published: watch::Sender<u64>,
 }
 
 impl Wake {
@@ -25,6 +30,7 @@ impl Wake {
         Self {
             generation: Mutex::new(0),
             changed: Condvar::new(),
+            published: watch::Sender::new(0),
         }
     }
 
@@ -33,6 +39,9 @@ impl Wake {
         let mut generation = self.generation.lock();
         *generation = generation.wrapping_add(1);
         self.changed.notify_all();
+        // Both kinds of waiter from one lock, so a thread and a task can never
+        // disagree about which generation they are looking at.
+        self.published.send_replace(*generation);
     }
 
     /// The generation now, to be handed back to `wait`.
@@ -50,6 +59,13 @@ impl Wake {
             self.changed.wait(&mut generation);
         }
         *generation
+    }
+
+    /// A receiver that wakes on each bump, for an async caller. Its value is
+    /// the generation, so a subscriber that slept through a burst sees one
+    /// wake and reads the versions once — the same batching a thread gets.
+    pub fn subscribe(&self) -> watch::Receiver<u64> {
+        self.published.subscribe()
     }
 
     /// The same, giving up after `timeout`. For a caller that has something

--- a/crates/koan-server/src/graphql/subscriptions.rs
+++ b/crates/koan-server/src/graphql/subscriptions.rs
@@ -1,5 +1,4 @@
 use std::sync::Arc;
-use std::time::Duration;
 
 use async_graphql::{Context, Subscription};
 use tokio_stream::Stream;
@@ -17,20 +16,27 @@ pub struct SubscriptionRoot;
 
 #[Subscription]
 impl SubscriptionRoot {
-    /// Playback state updates — pushes on state change and position at the given interval.
-    /// Default interval: 200ms (5Hz). Override with `intervalMs` for faster/slower updates.
-    /// Minimum 16ms (~60fps) — values below this are clamped to prevent CPU waste.
+    /// Playback updates, pushed when something changes.
+    ///
+    /// `positionMs` is an anchor rather than a reading. A playhead advancing at
+    /// one second per second is the one thing a client can work out for itself,
+    /// so this pushes when that stops being true — a seek, a pause, a track
+    /// boundary, a stall — and not on a clock. Derive the current position from
+    /// the last message and `state`; that is what the native client does, and
+    /// what lets a paused koan send nothing at all.
     async fn now_playing(
         &self,
         ctx: &Context<'_>,
         #[graphql(
             default = 200,
-            desc = "Push interval in milliseconds (minimum 16). Default 200 (5Hz)."
+            desc = "Ignored. Kept so existing queries still parse — this stream \
+                    pushes on change rather than on an interval."
         )]
         interval_ms: u64,
     ) -> impl Stream<Item = GqlNowPlaying> {
+        let _ = interval_ms; // Kept in the schema, not used — see above.
         let state = ctx.data_unchecked::<Arc<SharedPlayerState>>().clone();
-        let interval = Duration::from_millis(interval_ms.max(16)); // floor at ~60fps
+        let mut wake = koan_core::signal::engine_changed().subscribe();
 
         async_stream::stream! {
             let mut last_state = 255u8; // impossible value to force first emit
@@ -42,7 +48,6 @@ impl SubscriptionRoot {
                 let position_ms = state.position_ms();
                 let queue_item_id = state.track_info().map(|ti| ti.id.0.to_string());
 
-                // Emit on any change: state, position, or track.
                 let changed = playback_state != last_state
                     || position_ms != last_position
                     || queue_item_id != last_queue_item;
@@ -55,22 +60,35 @@ impl SubscriptionRoot {
                     yield GqlNowPlaying::capture(&state);
                 }
 
-                tokio::time::sleep(interval).await;
+                // Marked seen before the wait, so a change landing between the
+                // read above and this cannot be slept through.
+                wake.borrow_and_update();
+                if wake.changed().await.is_err() {
+                    return; // The engine is gone; so is this stream.
+                }
             }
         }
     }
 
-    /// Queue updates — pushes the full queue snapshot whenever the playlist
-    /// version changes, and while anything is downloading, since progress moves
-    /// without the version moving.
+    /// Queue updates — the full snapshot whenever the playlist changes, and
+    /// while anything is downloading, since progress moves without the
+    /// playlist version moving.
+    ///
+    /// Woken rather than polled: the download store takes a rate reading as the
+    /// bytes land and says so, which is the same signal a queue edit sends.
     async fn queue_updated(
         &self,
         ctx: &Context<'_>,
-        #[graphql(default = 500, desc = "Poll interval in milliseconds. Default 500.")]
+        #[graphql(
+            default = 500,
+            desc = "Ignored. Kept so existing queries still parse — this stream \
+                    pushes on change rather than on an interval."
+        )]
         interval_ms: u64,
     ) -> impl Stream<Item = GqlQueueSnapshot> {
+        let _ = interval_ms; // Kept in the schema, not used — see above.
         let state = ctx.data_unchecked::<Arc<SharedPlayerState>>().clone();
-        let interval = Duration::from_millis(interval_ms.max(50));
+        let mut wake = koan_core::signal::engine_changed().subscribe();
 
         async_stream::stream! {
             let mut last_version = u64::MAX; // force first emit
@@ -84,30 +102,54 @@ impl SubscriptionRoot {
                     yield GqlQueueSnapshot::capture(&state);
                 }
 
-                tokio::time::sleep(interval).await;
+                wake.borrow_and_update();
+                if wake.changed().await.is_err() {
+                    return;
+                }
             }
         }
     }
 
     /// Visualizer frames — spectrum, peaks, VU, beat energy, optional waveform.
-    /// Pushes at `fps` rate (default 30). Set `includeWaveform` for oscilloscope modes.
+    /// Set `includeWaveform` for oscilloscope modes.
+    ///
+    /// One message per analysed frame: `fps` sets the rate the analyser itself
+    /// runs at rather than a rate to resample it at, so no frame is sent twice
+    /// and none is skipped. The analyser stops publishing when the play head
+    /// does, so a paused koan sends nothing and this stream costs nothing.
+    ///
+    /// The rate is the analyser's, and it is one analyser: a second client
+    /// asking for a different `fps` moves it for both.
     async fn viz_frame(
         &self,
         ctx: &Context<'_>,
-        #[graphql(default = 30, desc = "Target frames per second. Default 30.")] fps: u32,
+        #[graphql(
+            default = 30,
+            desc = "Frames per second to run the analyser at. Default 30."
+        )]
+        fps: u32,
         #[graphql(default = false, desc = "Include raw waveform samples. Default false.")]
         include_waveform: bool,
     ) -> impl Stream<Item = GqlVizFrame> {
         let viz = ctx.data_opt::<Arc<VizSnapshot>>().cloned();
-        let interval = Duration::from_millis((1000 / fps.clamp(1, 120)) as u64);
 
         async_stream::stream! {
             let Some(viz) = viz else {
                 // No VizSnapshot — nothing to push.
                 return;
             };
+            viz.set_fps(fps.clamp(1, 240) as u8);
+            // Counted as a reader before the first wait: an analyser parked for
+            // want of one would otherwise never publish the frame this waits
+            // for. Every read below keeps it counted.
+            viz.touch();
+            let mut published = viz.subscribe();
 
             loop {
+                published.borrow_and_update();
+                if published.changed().await.is_err() {
+                    return;
+                }
                 let frame = viz.read();
                 yield GqlVizFrame {
                     spectrum: frame.spectrum.to_vec(),
@@ -120,9 +162,30 @@ impl SubscriptionRoot {
                         Vec::new()
                     },
                 };
-
-                tokio::time::sleep(interval).await;
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    /// The arguments stay in the schema even though the streams no longer run
+    /// on them: a query that named one still has to parse.
+    #[test]
+    fn the_interval_arguments_are_still_in_the_schema() {
+        let (state, _timeline, _viz, cmd_tx) = koan_core::player::Player::spawn();
+        let schema = crate::graphql::build_schema(
+            state,
+            cmd_tx,
+            std::path::PathBuf::from("/nonexistent/koan-test.db"),
+            None,
+        );
+        let sdl = schema.sdl();
+        let subscription = sdl
+            .split("type SubscriptionRoot")
+            .nth(1)
+            .expect("subscription root in SDL");
+        assert!(subscription.contains("intervalMs"), "{subscription}");
+        assert!(subscription.contains("fps"), "{subscription}");
     }
 }


### PR DESCRIPTION
The last polling in koan. After #393–#397 the macOS app was event-driven end to end while the GraphQL clients still got their updates from three `tokio::time::sleep` loops on the server.

## The three streams

| | Was | Now |
|---|---|---|
| `nowPlaying` | read the engine every 200ms, yield if something moved | waits on `signal::Wake` |
| `queueUpdated` | every 500ms, plus unconditionally while anything downloaded | same signal — the download store already says when a reading was taken |
| `vizFrame` | resampled `VizSnapshot` at the client's `fps` | subscribes to the analyser; one message per analysed frame |

`Wake` gains a `tokio::sync::watch` beside its condvar, sent under the same lock, so a task and a thread can never disagree about which generation they are looking at. A subscription is a task on a runtime — parking it on a condvar would hold a worker rather than sleep.

`vizFrame`'s `fps` now sets the rate the **analyser** runs at rather than a rate to resample it at, so no frame is sent twice and none is skipped. It is one analyser, so a second client asking for a different figure moves it for both — documented on the field. It calls `touch()` before its first wait, or an analyser parked for want of a reader would never publish the frame it is waiting for.

## The one contract change

`nowPlaying` sends an **anchor**, which is what the native client already receives (#394): `positionMs` is where the playhead was when the message was sent, and it arrives on a seek, a pause, a track boundary or a stall — not on a clock. A paused koan sends nothing at all.

**A client drawing a moving position must derive it** from the last message and `state` rather than waiting to be told again. The `intervalMs` arguments stay in the schema and are ignored so existing queries still parse; a test asserts they are still there.

## Also

The app's own two remaining waits — restoring a session, and jumping to the queue after an enqueue — looked at a value every 5ms until it moved. They wait on the mirror now via `EngineMirror.waitUntil`, where the deadline is one sleep for the whole wait rather than one per look.

## Verifying

- `websocat` a `nowPlaying` subscription: messages on play/pause/seek/skip, silence while paused, silence while a track simply plays on.
- `queueUpdated`: fires on a queue edit and follows a download's progress.
- `vizFrame` at `fps: 60`: sixty messages a second while playing, none when paused.
- Idle koan with a subscriber attached: `sample` the process — no timer frames.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WAbe522TUhqe7K6QD4dnS2