### PR TITLE
fix(macos): let an album be dragged off its tile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- **An album can be dragged off its tile.** The drag was declared on the tile's container, above both the cover and the title — and each of those carries a tap gesture of its own, which claims the press before any ancestor sees it. What was left to grab was the year line and a few points of padding, so the drag almost never started: dropping a record onto a playlist read as a drop that had been refused, rather than as a drag that never began. Whether the album was downloaded or still remote never came into it, since that is not decided until long after the gesture.
+
+  The payload rides on the same views as the taps now, where the drag recogniser's own movement threshold is what separates a click from a drag — the arrangement the queue's rows have always used. Dragging by the artist name still means the artist.
+
 ## v0.33.2 (2026-08-29)
 
 ### Changed

--- a/apps/macos/Sources/Koan/Views/AlbumGridCell.swift
+++ b/apps/macos/Sources/Koan/Views/AlbumGridCell.swift
@@ -18,7 +18,7 @@ struct AlbumGridCell: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 7) {
-            PlayableArtwork(albumId: album.id)
+            PlayableArtwork(albumId: album.id, drag: .album(album))
                 .shadow(color: .black.opacity(0.28), radius: 7, y: 3)
                 .overlay(alignment: .topTrailing) {
                     if let codec = album.codec {
@@ -64,6 +64,7 @@ struct AlbumGridCell: View {
                 .contentShape(.rect)
                 .onHover { titleHovering = $0 }
                 .onTapGesture { Trace.event("tap"); nav.open(album: album.id) }
+                .draggablePlayable(.album(album))
 
             HStack(spacing: 4) {
                 if showArtist {
@@ -79,7 +80,6 @@ struct AlbumGridCell: View {
         .onHover { hovering = $0 }
         .animation(.smooth(duration: 0.18), value: hovering)
         .contextMenu { PlayableMenu(playable: .album(album)) }
-        .draggablePlayable(.album(album))
     }
 
 }

--- a/apps/macos/Sources/Koan/Views/LinkText.swift
+++ b/apps/macos/Sources/Koan/Views/LinkText.swift
@@ -75,6 +75,12 @@ struct LinkText: View {
 struct PlayableArtwork: View {
     let albumId: Int64
     var cornerRadius: CGFloat = 6
+    /// What dragging the cover carries, if anything.
+    ///
+    /// It rides on this view rather than on whatever contains it: a tap
+    /// gesture claims the press from every ancestor, so a `.draggable` above
+    /// this one never sees the movement that would start a drag.
+    var drag: Playable?
 
     @Environment(PlayerModel.self) private var player
     @Environment(Navigator.self) private var nav
@@ -106,6 +112,7 @@ struct PlayableArtwork: View {
             .animation(.easeOut(duration: 0.12), value: hovering)
             .onHover { hovering = $0 }
             .onTapGesture { play() }
+            .modifier(OptionalDrag(playable: drag))
             .help("Play album")
     }
 

--- a/apps/macos/Sources/Koan/Views/RowBehaviour.swift
+++ b/apps/macos/Sources/Koan/Views/RowBehaviour.swift
@@ -28,7 +28,7 @@ struct RowBehaviour: ViewModifier {
 /// Known limit: with a multi-selection this drags only the row you grabbed, not
 /// the selection. Dragging a whole selection means building the item providers
 /// from `selection` by hand.
-private struct OptionalDrag: ViewModifier {
+struct OptionalDrag: ViewModifier {
     let playable: Playable?
 
     func body(content: Content) -> some View {


### PR DESCRIPTION
Dragging an album tile onto a playlist did nothing. The tile declared `.draggablePlayable(.album(album))` on its outer `VStack`, but both of the things you would actually grab carry a tap gesture of their own:

- the cover — `PlayableArtwork` has `.onTapGesture { play() }`
- the title — `.onTapGesture { nav.open(album:) }`

An inner tap claims the press before an ancestor's drag recogniser sees the movement that would start a drag. What was left draggable was the year label and a few points of padding, which is nowhere anyone grabs a record.

Synced vs unsynced was a red herring: the transfer carries an id and nothing else, and resolving it to track ids happens on drop — long after the gesture that never started.

## The change

The payload rides on the same views as the taps, where `.draggable`'s movement threshold is what separates a click from a drag. That is the arrangement `RowBehaviour` already gives the queue's rows.

| File | Change |
|---|---|
| `LinkText.swift` | `PlayableArtwork` gains `drag: Playable?`, applied on the same view as its tap |
| `AlbumGridCell.swift` | Passes it, attaches the drag to the title, drops it from the `VStack` |
| `RowBehaviour.swift` | `OptionalDrag` stops being `private` so the cover reuses it |

## How to confirm

Drag an album tile — from Albums, an artist page, Favourites or search results — onto a playlist in the sidebar, onto **New Playlist…**, and onto **Queue**. Grab it by the cover and then by the title; both should lift.

Then check the gestures underneath still work: a click on the cover plays the record, a click on the title opens it. Grabbing the **artist name** should still drag the artist rather than the album — that nesting is deliberate.

## Not in scope

The album page's own header (`TrackListView.swift:124`) is a bare `AlbumArtwork` with no drag at all. That is a missing feature rather than this bug, so it is left for its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FXDsV5CXPPDkWfHa8cAxsQ