### PR TITLE
feat(macos): let a playlist take files dropped on it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- **A playlist takes files dropped on it.** Dropping a folder on the queue has always worked — the files are indexed where they lie, which is what gives them the rows organize needs to move them into the music tree later. Playlists took koan's own payload and nothing else, so a drive of tracks from a friend could be played but not put in a list, and the drop was refused with no sign it had been understood. The playlist page, a playlist's row in the sidebar and **New Playlist…** all take files now, through the same import: dropping on the page adds at the end, and dropping on **New Playlist…** names the list the files became.
+
 ## v0.33.2 (2026-08-29)
 
 ### Changed

--- a/apps/macos/Sources/Koan/Support/FileImport.swift
+++ b/apps/macos/Sources/Koan/Support/FileImport.swift
@@ -1,0 +1,39 @@
+import Foundation
+import KoanFFI
+
+/// Dropped files, given library rows.
+///
+/// Shared by the queue and by playlists: both want the same thing out of a
+/// drop — track ids — and both have to show something while it happens. Holds
+/// the local library, because it reads tags and writes the rows a scan writes,
+/// and a folder of a few hundred files takes long enough that a drop with no
+/// sign of life reads as a drop that missed.
+///
+/// The files are indexed where they lie rather than copied anywhere. Rows are
+/// the point: they are what let organize move the drop into the music tree
+/// afterwards, on purpose and with a preview.
+@MainActor
+enum FileImport {
+    /// The tracks the drop became, or nothing — which is reported here rather
+    /// than left to each caller to phrase differently.
+    static func trackIds(
+        for urls: [URL],
+        engine: KoanEngine,
+        activity: ActivityModel?,
+        report: (String) -> Void
+    ) async -> [Int64] {
+        let paths = urls.filter(\.isFileURL).map(\.path)
+        guard !paths.isEmpty else { return [] }
+        let summary = try? await activity?.run("Adding dropped files", uses: .localLibrary) {
+            try await engine.importFiles(paths: paths)
+        }.get()
+        guard let summary, !summary.trackIds.isEmpty else {
+            report("Nothing there koan can play.")
+            return []
+        }
+        if let first = summary.errors.first {
+            report(first)
+        }
+        return summary.trackIds
+    }
+}

--- a/apps/macos/Sources/Koan/Support/PlayerModel.swift
+++ b/apps/macos/Sources/Koan/Support/PlayerModel.swift
@@ -407,25 +407,15 @@ final class PlayerModel {
     /// move them into the music tree afterwards, on purpose and with a preview.
     /// Folders are walked, so dropping a rip queues the album.
     func importFiles(_ urls: [URL]) {
-        let paths = urls.filter(\.isFileURL).map(\.path)
-        guard !paths.isEmpty else { return }
-        let engine = self.engine
         Task {
-            // Holds the local library: it reads tags and writes rows, the same
-            // ones a scan would. A folder of a few hundred files takes long
-            // enough that a drop with no sign of life reads as a drop that
-            // missed.
-            let summary = try? await activity?.run("Adding dropped files", uses: .localLibrary) {
-                try await engine.importFiles(paths: paths)
-            }.get()
-            guard let summary, !summary.trackIds.isEmpty else {
-                lastError = "Nothing there koan can play."
-                return
-            }
-            if let first = summary.errors.first {
-                lastError = first
-            }
-            enqueue(trackIds: summary.trackIds)
+            let ids = await FileImport.trackIds(
+                for: urls,
+                engine: engine,
+                activity: activity,
+                report: { self.lastError = $0 }
+            )
+            guard !ids.isEmpty else { return }
+            enqueue(trackIds: ids)
         }
     }
 

--- a/apps/macos/Sources/Koan/Support/PlaylistsModel.swift
+++ b/apps/macos/Sources/Koan/Support/PlaylistsModel.swift
@@ -142,6 +142,37 @@ final class PlaylistsModel {
         Task { naming = await resolve(dropped) }
     }
 
+    /// Files from outside koan, added to a playlist.
+    ///
+    /// A playlist row names a track id and a file that is not in the library
+    /// has none, so the drop is indexed before anything is added — the same
+    /// import a drop on the queue does.
+    func add(files urls: [URL], to id: Int64) {
+        Task {
+            let ids = await importing(urls)
+            guard !ids.isEmpty else { return }
+            add(trackIds: ids, to: id)
+        }
+    }
+
+    /// The same, for the playlist that does not exist yet.
+    func beginNaming(files urls: [URL]) {
+        Task {
+            let ids = await importing(urls)
+            guard !ids.isEmpty else { return }
+            naming = ids
+        }
+    }
+
+    private func importing(_ urls: [URL]) async -> [Int64] {
+        await FileImport.trackIds(
+            for: urls,
+            engine: engine,
+            activity: activity,
+            report: { self.report?($0) }
+        )
+    }
+
     func rename(id: Int64, to name: String) {
         let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }

--- a/apps/macos/Sources/Koan/Views/PlaylistView.swift
+++ b/apps/macos/Sources/Koan/Views/PlaylistView.swift
@@ -86,6 +86,13 @@ struct PlaylistView: View {
             playlists.add(dropped: dropped, to: playlistId)
             return true
         }
+        // Files from outside koan — a USB drive, a folder of rips. The row
+        // targets take koan's own payload only, so a file dragged over one
+        // falls through to here and lands at the end.
+        .dropDestination(for: URL.self) { urls, _ in
+            playlists.add(files: urls, to: playlistId)
+            return true
+        }
         // Only for a library change — the rows arrived before the page did.
         .reloading(on: playlistId) {
             await playlists.prepare(id: playlistId)

--- a/apps/macos/Sources/Koan/Views/SidebarView.swift
+++ b/apps/macos/Sources/Koan/Views/SidebarView.swift
@@ -170,6 +170,12 @@ struct SidebarView: View {
                     } isTargeted: { targeted in
                         playlistDropTarget = targeted ? playlist.id : nil
                     }
+                    .dropDestination(for: URL.self) { urls, _ in
+                        playlists.add(files: urls, to: playlist.id)
+                        return true
+                    } isTargeted: { targeted in
+                        playlistDropTarget = targeted ? playlist.id : nil
+                    }
                     .listRowBackground(
                         playlistDropTarget == playlist.id
                             ? RoundedRectangle(cornerRadius: 5).fill(.tint.opacity(0.25))
@@ -209,6 +215,10 @@ struct SidebarView: View {
             .onTapGesture { playlists.naming = [] }
             .dropDestination(for: PlayableTransfer.self) { dropped, _ in
                 playlists.beginNaming(dropped: dropped)
+                return true
+            } isTargeted: { newPlaylistDropTargeted = $0 }
+            .dropDestination(for: URL.self) { urls, _ in
+                playlists.beginNaming(files: urls)
                 return true
             } isTargeted: { newPlaylistDropTargeted = $0 }
             .listRowBackground(


### PR DESCRIPTION
Dropping files from Finder — a USB drive, a folder of rips — onto a playlist did nothing. Dropping them on the **queue** has always worked: `QueueView` has a `URL` drop destination that indexes the files where they lie, which is what gives them the library rows organize needs in order to move them into the music tree afterwards.

Every playlist surface took `PlayableTransfer` and nothing else, so external files were ignored with nothing to say the drag had even been understood.

## The change

| File | Change |
|---|---|
| `FileImport.swift` *(new)* | drop → rows → track ids, shared. Holds the local library while it runs, and says "nothing there koan can play" in one place rather than once per caller |
| `PlayerModel.swift` | the queue's existing drop routes through it — same behaviour |
| `PlaylistsModel.swift` | `add(files:to:)` and `beginNaming(files:)` — index first, then add, because a playlist row names a track id and a loose file has none |
| `PlaylistView.swift` | page-level `URL` destination |
| `SidebarView.swift` | playlist rows, and **New Playlist…** |

The row targets inside a playlist page still take koan's own payload only, so a file dragged over a row falls through to the page and lands at the end rather than asking for a position it has no row for yet.

## How to confirm

With a folder of audio from outside the library — a USB drive, anything not yet indexed:

1. Drop it on an open **playlist page** → tracks land at the end.
2. Drop it on a **playlist's row in the sidebar** → same, without opening it.
3. Drop it on **New Playlist…** → the naming prompt, and the new list is the folder.
4. Drop it on the **queue** → unchanged from today. This is the regression check on the refactor.

A drop with nothing playable in it should say so once. After any of the above the tracks have library rows, so organize can preview a move for them — which is the reason indexing in place is the right half of this.

Closes #401

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FXDsV5CXPPDkWfHa8cAxsQ